### PR TITLE
Standardize undefined ordering

### DIFF
--- a/src/language-services/analysis.ts
+++ b/src/language-services/analysis.ts
@@ -32,7 +32,7 @@ export function createAnalysisSession(document: TextDocument, position: Position
 }
 
 class DocumentAnalysis implements Analysis {
-    private readonly maybeTriedInspection: undefined | PQP.Task.TriedInspection;
+    private readonly maybeTriedInspection: PQP.Task.TriedInspection | undefined;
     private readonly environmentSymbolProvider: SymbolProvider;
     private readonly keywordProvider: KeywordProvider;
     private readonly librarySymbolProvider: LibrarySymbolProvider;
@@ -58,7 +58,7 @@ class DocumentAnalysis implements Analysis {
     public async getCompletionItems(): Promise<CompletionItem[]> {
         let context: CompletionItemProviderContext = {};
 
-        const maybeToken: undefined | PQP.Language.LineToken = maybeTokenAt(this.document, this.position);
+        const maybeToken: PQP.Language.LineToken | undefined = maybeTokenAt(this.document, this.position);
         if (maybeToken !== undefined) {
             context = {
                 range: getTokenRangeForPosition(maybeToken, this.position),
@@ -180,8 +180,8 @@ function getTokenRangeForPosition(token: PQP.Language.LineToken, cursorPosition:
     };
 }
 
-function maybeIdentifierAt(document: TextDocument, position: Position): undefined | PQP.Language.LineToken {
-    const maybeToken: undefined | PQP.Language.LineToken = maybeTokenAt(document, position);
+function maybeIdentifierAt(document: TextDocument, position: Position): PQP.Language.LineToken | undefined {
+    const maybeToken: PQP.Language.LineToken | undefined = maybeTokenAt(document, position);
     if (maybeToken) {
         const token: PQP.Language.LineToken = maybeToken;
         if (token.kind === PQP.Language.LineTokenKind.Identifier) {
@@ -195,15 +195,15 @@ function maybeIdentifierAt(document: TextDocument, position: Position): undefine
 function maybeLineTokensAt(
     document: TextDocument,
     position: Position,
-): undefined | ReadonlyArray<PQP.Language.LineToken> {
+): ReadonlyArray<PQP.Language.LineToken> | undefined {
     const lexResult: PQP.Lexer.State = WorkspaceCache.getLexerState(document);
-    const maybeLine: undefined | PQP.Lexer.TLine = lexResult.lines[position.line];
+    const maybeLine: PQP.Lexer.TLine | undefined = lexResult.lines[position.line];
 
     return maybeLine !== undefined ? maybeLine.tokens : undefined;
 }
 
-function maybeTokenAt(document: TextDocument, position: Position): undefined | PQP.Language.LineToken {
-    const maybeLineTokens: undefined | ReadonlyArray<PQP.Language.LineToken> = maybeLineTokensAt(document, position);
+function maybeTokenAt(document: TextDocument, position: Position): PQP.Language.LineToken | undefined {
+    const maybeLineTokens: ReadonlyArray<PQP.Language.LineToken> | undefined = maybeLineTokensAt(document, position);
 
     if (maybeLineTokens === undefined) {
         return undefined;

--- a/src/language-services/currentDocumentSymbolProvider.ts
+++ b/src/language-services/currentDocumentSymbolProvider.ts
@@ -4,16 +4,16 @@
 import * as PQP from "@microsoft/powerquery-parser";
 import { CompletionItem, DocumentSymbol, Hover, SignatureHelp } from "vscode-languageserver-types";
 
+import { InspectionUtils, LanguageServiceUtils } from ".";
 import {
     CompletionItemProviderContext,
     HoverProviderContext,
     SignatureProviderContext,
     SymbolProvider,
 } from "./providers";
-import { LanguageServiceUtils, InspectionUtils } from ".";
 
 export class CurrentDocumentSymbolProvider implements SymbolProvider {
-    constructor(private readonly maybeTriedInspection: undefined | PQP.Task.TriedInspection) {}
+    constructor(private readonly maybeTriedInspection: PQP.Task.TriedInspection | undefined) {}
 
     public async getCompletionItems(_context: CompletionItemProviderContext): Promise<CompletionItem[]> {
         return LanguageServiceUtils.documentSymbolToCompletionItem(this.getDocumentSymbols());

--- a/src/language-services/inspectionUtils.ts
+++ b/src/language-services/inspectionUtils.ts
@@ -7,7 +7,7 @@ import { DocumentSymbol, Range, SymbolKind } from "vscode-languageserver-types";
 import { LanguageServiceUtils } from ".";
 import { SignatureProviderContext } from "./providers";
 
-export function maybeSignatureProviderContext(inspected: PQP.Task.InspectionOk): undefined | SignatureProviderContext {
+export function maybeSignatureProviderContext(inspected: PQP.Task.InspectionOk): SignatureProviderContext | undefined {
     return inspected.maybeInvokeExpression !== undefined
         ? getContextForInvokeExpression(inspected.maybeInvokeExpression)
         : undefined;
@@ -15,10 +15,10 @@ export function maybeSignatureProviderContext(inspected: PQP.Task.InspectionOk):
 
 export function getContextForInvokeExpression(
     maybeExpression: PQP.Inspection.InvokeExpression,
-): undefined | SignatureProviderContext {
-    const functionName: undefined | string =
+): SignatureProviderContext | undefined {
+    const functionName: string | undefined =
         maybeExpression.maybeName !== undefined ? maybeExpression.maybeName : undefined;
-    const argumentOrdinal: undefined | number =
+    const argumentOrdinal: number | undefined =
         maybeExpression.maybeArguments !== undefined ? maybeExpression.maybeArguments.argumentOrdinal : undefined;
 
     if (functionName !== undefined || argumentOrdinal !== undefined) {

--- a/src/language-services/keywordProvider.ts
+++ b/src/language-services/keywordProvider.ts
@@ -23,7 +23,7 @@ export class KeywordProvider implements CompletionItemProvider {
         PQP.Language.KeywordKind.HashTime,
     ];
 
-    constructor(private readonly maybeTriedInspection: undefined | PQP.Task.TriedInspection) {}
+    constructor(private readonly maybeTriedInspection: PQP.Task.TriedInspection | undefined) {}
 
     public async getCompletionItems(_context: CompletionItemProviderContext): Promise<CompletionItem[]> {
         if (this.maybeTriedInspection === undefined || PQP.ResultUtils.isErr(this.maybeTriedInspection)) {

--- a/src/language-services/providers.ts
+++ b/src/language-services/providers.ts
@@ -34,8 +34,8 @@ export interface SignatureHelpProvider {
 }
 
 export interface SignatureProviderContext extends ProviderContext {
-    readonly maybeArgumentOrdinal: undefined | number;
-    readonly maybeFunctionName: undefined | string;
+    readonly maybeArgumentOrdinal: number | undefined;
+    readonly maybeFunctionName: string | undefined;
 }
 
 export interface SymbolProvider extends CompletionItemProvider, HoverProvider, SignatureHelpProvider {}

--- a/src/language-services/validation.ts
+++ b/src/language-services/validation.ts
@@ -17,12 +17,12 @@ export function validate(document: TextDocument): ValidationResult {
     if (PQP.ResultUtils.isErr(triedLexParse)) {
         const lexOrParseError: PQP.LexError.TLexError | PQP.ParseError.TParseError = triedLexParse.error;
         if (lexOrParseError instanceof PQP.ParseError.ParseError) {
-            const maybeDiagnostic: undefined | Diagnostic = maybeParseErrorToDiagnostic(lexOrParseError);
+            const maybeDiagnostic: Diagnostic | undefined = maybeParseErrorToDiagnostic(lexOrParseError);
             if (maybeDiagnostic !== undefined) {
                 diagnostics = [maybeDiagnostic];
             }
         } else if (PQP.LexError.isTInnerLexError(lexOrParseError.innerError)) {
-            const maybeLexerErrorDiagnostics: undefined | Diagnostic[] = maybeLexErrorToDiagnostics(
+            const maybeLexerErrorDiagnostics: Diagnostic[] | undefined = maybeLexErrorToDiagnostics(
                 lexOrParseError.innerError,
             );
             if (maybeLexerErrorDiagnostics !== undefined) {
@@ -36,7 +36,7 @@ export function validate(document: TextDocument): ValidationResult {
     };
 }
 
-function maybeLexErrorToDiagnostics(error: PQP.LexError.TInnerLexError): undefined | Diagnostic[] {
+function maybeLexErrorToDiagnostics(error: PQP.LexError.TInnerLexError): Diagnostic[] | undefined {
     const diagnostics: Diagnostic[] = [];
     // TODO: handle other types of lexer errors
     if (error instanceof PQP.LexError.ErrorLineMapError) {
@@ -64,10 +64,10 @@ function maybeLexErrorToDiagnostics(error: PQP.LexError.TInnerLexError): undefin
     return diagnostics.length ? diagnostics : undefined;
 }
 
-function maybeParseErrorToDiagnostic(error: PQP.ParseError.ParseError): undefined | Diagnostic {
+function maybeParseErrorToDiagnostic(error: PQP.ParseError.ParseError): Diagnostic | undefined {
     const innerError: PQP.ParseError.TInnerParseError = error.innerError;
     const message: string = error.message;
-    let maybeErrorToken: undefined | PQP.Language.Token;
+    let maybeErrorToken: PQP.Language.Token | undefined;
     if (
         (innerError instanceof PQP.ParseError.ExpectedAnyTokenKindError ||
             innerError instanceof PQP.ParseError.ExpectedTokenKindError) &&
@@ -100,12 +100,12 @@ function maybeParseErrorToDiagnostic(error: PQP.ParseError.ParseError): undefine
         };
     } else {
         const parseContextState: PQP.ParseContext.State = error.state.contextState;
-        const maybeRoot: undefined | PQP.ParseContext.Node = parseContextState.root.maybeNode;
+        const maybeRoot: PQP.ParseContext.Node | undefined = parseContextState.root.maybeNode;
         if (maybeRoot === undefined) {
             return undefined;
         }
 
-        const maybeLeaf: undefined | PQP.Language.Ast.TNode = PQP.NodeIdMapUtils.maybeRightMostLeaf(
+        const maybeLeaf: PQP.Language.Ast.TNode | undefined = PQP.NodeIdMapUtils.maybeRightMostLeaf(
             error.state.contextState.nodeIdMapCollection,
             maybeRoot.id,
         );

--- a/src/language-services/workspaceCache.ts
+++ b/src/language-services/workspaceCache.ts
@@ -14,7 +14,7 @@ const triedInspectionCache: Map<string, InspectionMap> = new Map();
 // then createTriedInspection would return undefined as you can't inspect something that wasn't parsed.
 // If we used WeakMap.get(...) we wouldn't know if an undefined was returned because of a cache miss
 // or that we we couldn't do an inspection.
-type InspectionMap = WeakMap<Position, undefined | PQP.Task.TriedInspection>;
+type InspectionMap = WeakMap<Position, PQP.Task.TriedInspection | undefined>;
 
 const allCaches: Map<string, any>[] = [lexerSnapshotCache, lexerStateCache, triedLexParseCache, triedInspectionCache];
 
@@ -50,13 +50,13 @@ export function getTriedLexParse(textDocument: TextDocument): PQP.Task.TriedLexP
 export function maybeTriedInspection(
     textDocument: TextDocument,
     position: Position,
-): undefined | PQP.Task.TriedInspection {
+): PQP.Task.TriedInspection | undefined {
     const cacheKey: string = textDocument.uri;
     const maybePositionCache:
         | undefined
-        | WeakMap<Position, undefined | PQP.Task.TriedInspection> = triedInspectionCache.get(cacheKey);
+        | WeakMap<Position, PQP.Task.TriedInspection | undefined> = triedInspectionCache.get(cacheKey);
 
-    let positionCache: WeakMap<Position, undefined | PQP.Task.TriedInspection>;
+    let positionCache: WeakMap<Position, PQP.Task.TriedInspection | undefined>;
     // document has been inspected before
     if (maybePositionCache !== undefined) {
         positionCache = maybePositionCache;
@@ -68,7 +68,7 @@ export function maybeTriedInspection(
     if (positionCache.has(position)) {
         return positionCache.get(position);
     } else {
-        const value: undefined | PQP.Task.TriedInspection = createTriedInspection(textDocument, position);
+        const value: PQP.Task.TriedInspection | undefined = createTriedInspection(textDocument, position);
         positionCache.set(position, value);
         return value;
     }
@@ -80,7 +80,7 @@ function getOrCreate<T>(
     factoryFn: (textDocument: TextDocument) => T,
 ): T {
     const cacheKey: string = textDocument.uri;
-    const maybeValue: undefined | T = cache.get(cacheKey);
+    const maybeValue: T | undefined = cache.get(cacheKey);
 
     if (maybeValue === undefined) {
         const value: T = factoryFn(textDocument);
@@ -123,7 +123,7 @@ function createTriedLexParse(textDocument: TextDocument): PQP.Task.TriedLexParse
 
 // We're allowed to return undefined because if a document wasn't parsed
 // then there's no way to perform an inspection.
-function createTriedInspection(textDocument: TextDocument, position: Position): undefined | PQP.Task.TriedInspection {
+function createTriedInspection(textDocument: TextDocument, position: Position): PQP.Task.TriedInspection | undefined {
     const triedLexParse: PQP.Task.TriedLexParse = getTriedLexParse(textDocument);
     if (
         PQP.ResultUtils.isErr(triedLexParse) &&
@@ -133,7 +133,7 @@ function createTriedInspection(textDocument: TextDocument, position: Position): 
         return undefined;
     }
 
-    const maybeTriedParse: undefined | PQP.TriedParse = PQP.Task.maybeTriedParseFromTriedLexParse(triedLexParse);
+    const maybeTriedParse: PQP.TriedParse | undefined = PQP.Task.maybeTriedParseFromTriedLexParse(triedLexParse);
     if (maybeTriedParse === undefined) {
         return undefined;
     }

--- a/src/test/language-services/utils.ts
+++ b/src/test/language-services/utils.ts
@@ -90,7 +90,7 @@ export class SimpleLibraryProvider implements LibrarySymbolProvider {
         throw new Error("Method not implemented.");
     }
 
-    private getMember(value: undefined | string): undefined | string {
+    private getMember(value: string | undefined): string | undefined {
         if (value === undefined) {
             return undefined;
         }


### PR DESCRIPTION
Previously the code was a mix of T | undefined and undefined | T. It's now standardized to T | undefined.