### PR TITLE
Fix AnalysisOptions export

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "author": "Microsoft",
     "license": "MIT",
     "scripts": {

--- a/src/language-services/index.ts
+++ b/src/language-services/index.ts
@@ -5,6 +5,7 @@ import { TextDocument, TextDocumentContentChangeEvent } from "vscode-languageser
 import * as WorkspaceCache from "./workspaceCache";
 
 export * from "./analysis";
+export * from "./analysisOptions";
 export * from "./commonTypes";
 export * from "./formatter";
 export * from "./providers";


### PR DESCRIPTION
I missed an export statement after refactoring the `AnalysisOptions` code. 

I created a tracking issue (#8 ) to add tests to prevent this sort of thing in the future. 
