### PR TITLE
Support Document Symbols

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/powerquery-language-services",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.1.9",
+    "version": "0.1.10",
     "author": "Microsoft",
     "license": "MIT",
     "scripts": {

--- a/src/language-services/documentSymbols.ts
+++ b/src/language-services/documentSymbols.ts
@@ -1,0 +1,118 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as PQP from "@microsoft/powerquery-parser";
+
+import { AnalysisOptions } from "./analysisOptions";
+import { DocumentSymbol, Range, SymbolKind, TextDocument } from "./commonTypes";
+import * as LanguageServiceUtils from "./languageServiceUtils";
+import * as InspectionUtils from "./inspectionUtils";
+import * as WorkspaceCache from "./workspaceCache";
+
+const DefaultLocale: string = PQP.Locale.en_US;
+
+export function getDocumentSymbols(document: TextDocument, options?: AnalysisOptions): DocumentSymbol[] {
+    const triedLexParse: PQP.Task.TriedLexParse = WorkspaceCache.getTriedLexParse(document);
+    let result: DocumentSymbol[] = [];
+
+    // TODO: Can we get symbols even when there is a syntax error?
+    if (PQP.ResultUtils.isOk(triedLexParse)) {
+        const lexParseOk: PQP.Task.LexParseOk = triedLexParse.value;
+        const ast: PQP.Language.Ast.TNode = lexParseOk.ast;
+        const nodeIdMapCollection: PQP.NodeIdMap.Collection = lexParseOk.state.contextState.nodeIdMapCollection;
+
+        const documentOutlineResult: PQP.Traverse.TriedTraverse<DocumentOutline> = tryTraverse(
+            ast,
+            nodeIdMapCollection,
+            options,
+        );
+
+        // TODO: Trace error case
+        if (PQP.ResultUtils.isOk(documentOutlineResult)) {
+            result = documentOutlineResult.value.symbols;
+        }
+    }
+
+    if (!options?.maintainWorkspaceCache) {
+        WorkspaceCache.close(document);
+    }
+
+    return result;
+}
+
+interface DocumentOutline {
+    symbols: DocumentSymbol[];
+    currentParent?: DocumentSymbol;
+}
+
+interface TraversalState extends PQP.Traverse.IState<DocumentOutline> {}
+
+function tryTraverse(
+    ast: PQP.Language.Ast.TNode,
+    nodeIdMapCollection: PQP.NodeIdMap.Collection,
+    options?: AnalysisOptions,
+): PQP.Traverse.TriedTraverse<DocumentOutline> {
+    const locale: string = options?.locale ?? DefaultLocale;
+    const localizationTemplates: PQP.ILocalizationTemplates = PQP.getLocalizationTemplates(locale);
+
+    const traversalState: TraversalState = {
+        localizationTemplates,
+        result: {
+            symbols: [],
+        },
+    };
+
+    return PQP.Traverse.tryTraverseAst(
+        traversalState,
+        nodeIdMapCollection,
+        ast,
+        PQP.Traverse.VisitNodeStrategy.DepthFirst,
+        visitNode,
+        PQP.Traverse.expectExpandAllAstChildren,
+        undefined,
+    );
+}
+
+function visitNode(state: TraversalState, node: PQP.Language.Ast.TNode): void {
+    let currentSymbol: DocumentSymbol | undefined;
+
+    switch (node.kind) {
+        case PQP.Language.Ast.NodeKind.Section:
+            currentSymbol = createDocumentSymbol(node.maybeName, node, node.maybeName?.tokenRange);
+            break;
+
+        default:
+            currentSymbol = undefined;
+    }
+
+    if (currentSymbol) {
+        if (state.result.currentParent) {
+            if (!state.result.currentParent.children) {
+                state.result.currentParent.children = [];
+            }
+
+            state.result.currentParent.children.push(currentSymbol);
+        } else {
+            // Add it to the root list of symbols
+            state.result.symbols.push(currentSymbol);
+        }
+    }
+}
+
+function createDocumentSymbol(
+    name: PQP.Language.Ast.Identifier | undefined,
+    node: PQP.Language.Ast.TNode,
+    selectionRange: PQP.Language.TokenRange | undefined,
+): DocumentSymbol | undefined {
+    if (!name) {
+        return undefined;
+    }
+
+    const range: Range = LanguageServiceUtils.tokenRangeToRange(node.tokenRange);
+    return {
+        kind: InspectionUtils.getSymbolKindFromNode(node),
+        name: name.literal,
+        range: LanguageServiceUtils.tokenRangeToRange(node.tokenRange),
+        selectionRange: selectionRange ? LanguageServiceUtils.tokenRangeToRange(selectionRange) : range,
+    };
+}

--- a/src/language-services/index.ts
+++ b/src/language-services/index.ts
@@ -7,6 +7,7 @@ import * as WorkspaceCache from "./workspaceCache";
 export * from "./analysis";
 export * from "./analysisOptions";
 export * from "./commonTypes";
+export * from "./documentSymbols";
 export * from "./formatter";
 export * from "./providers";
 export * from "./validation";

--- a/src/language-services/inspectionUtils.ts
+++ b/src/language-services/inspectionUtils.ts
@@ -75,6 +75,9 @@ export function getSymbolKindFromNode(node: PQP.Language.Ast.INode | PQP.ParseCo
         case PQP.Language.Ast.NodeKind.RecordLiteral:
             return SymbolKind.Struct;
 
+        case PQP.Language.Ast.NodeKind.Section:
+            return SymbolKind.Module;
+
         default:
             return SymbolKind.Variable;
     }

--- a/src/language-services/inspectionUtils.ts
+++ b/src/language-services/inspectionUtils.ts
@@ -95,6 +95,24 @@ export function getSymbolsForLetExpression(expressionNode: PQP.Language.Ast.LetE
     return documentSymbols;
 }
 
+export function getSymbolsForRecord(
+    recordNode: PQP.Language.Ast.RecordExpression | PQP.Language.Ast.RecordLiteral,
+): DocumentSymbol[] {
+    const documentSymbols: DocumentSymbol[] = [];
+
+    for (const element of recordNode.content.elements) {
+        documentSymbols.push({
+            kind: SymbolKind.Field,
+            deprecated: false,
+            name: element.node.key.literal,
+            range: LanguageServiceUtils.tokenRangeToRange(element.node.tokenRange),
+            selectionRange: LanguageServiceUtils.tokenRangeToRange(element.node.key.tokenRange),
+        });
+    }
+
+    return documentSymbols;
+}
+
 export function getSymbolsForSection(sectionNode: PQP.Language.Ast.Section): DocumentSymbol[] {
     const documentSymbols: DocumentSymbol[] = [];
 

--- a/src/test/language-services/documentSymbols.ts
+++ b/src/test/language-services/documentSymbols.ts
@@ -65,9 +65,9 @@ describe("getDocumentSymbols", () => {
     });
 
     // with syntax error
-    it(`shared foo; shared a = 1; b = "hello"; c = let a1`, () => {
+    it(`section foo; shared a = 1; b = "hello"; c = let a1`, () => {
         const document: Utils.MockDocument = Utils.documentFromText(
-            `shared foo; shared a = 1; b = "hello"; c = let a1`,
+            `section foo; shared a = 1; b = "hello"; c = let a1`,
         );
 
         expectSymbolsForDocument(document, [

--- a/src/test/language-services/documentSymbols.ts
+++ b/src/test/language-services/documentSymbols.ts
@@ -95,16 +95,16 @@ describe("getDocumentSymbols", () => {
             {
                 name: "HelloWorldWithDocs",
                 kind: SymbolKind.Struct,
-                // children: [{ name: "Authentication", kind: SymbolKind.Field }],
+                children: [{ name: "Authentication", kind: SymbolKind.Field }],
             },
             {
                 name: "HelloWorldWithDocs.Publish",
                 kind: SymbolKind.Struct,
-                // children: [
-                //     { name: "Beta", kind: SymbolKind.Field },
-                //     { name: "Category", kind: SymbolKind.Field },
-                //     { name: "ButtonText", kind: SymbolKind.Field },
-                // ],
+                children: [
+                    { name: "Beta", kind: SymbolKind.Field },
+                    { name: "Category", kind: SymbolKind.Field },
+                    { name: "ButtonText", kind: SymbolKind.Field },
+                ],
             },
         ]);
     });

--- a/src/test/language-services/documentSymbols.ts
+++ b/src/test/language-services/documentSymbols.ts
@@ -2,66 +2,17 @@
 // Licensed under the MIT license.
 
 // tslint:disable: no-implicit-dependencies
-import * as PQP from "@microsoft/powerquery-parser";
 import { assert, expect } from "chai";
 import "mocha";
-import { DocumentSymbol, SymbolKind, TextDocument } from "../../language-services";
+import { SymbolKind, TextDocument } from "../../language-services";
+import { ExpectedDocumentSymbol } from "./utils";
 
 import * as DocumentSymbols from "../../language-services/documentSymbols";
-import * as InspectionUtils from "../../language-services/inspectionUtils";
-import * as WorkspaceCache from "../../language-services/workspaceCache";
 import * as Utils from "./utils";
-
-function getLexAndParseOk(document: TextDocument): PQP.Task.LexParseOk {
-    const triedLexParse: PQP.Task.TriedLexParse = WorkspaceCache.getTriedLexParse(document);
-    if (PQP.ResultUtils.isErr(triedLexParse)) {
-        throw new Error("AssertFailed: triedLexParse to be Ok");
-    }
-    return triedLexParse.value;
-}
-
-interface ExpectedDocumentSymbol {
-    name: string;
-    kind: SymbolKind;
-    children?: ExpectedDocumentSymbol[];
-}
-
-function documentSymbolArrayToExpectedSymbols(documentSymbols: DocumentSymbol[]): ExpectedDocumentSymbol[] {
-    const expectedSymbols: ExpectedDocumentSymbol[] = [];
-    documentSymbols.forEach(element => {
-        let children: ExpectedDocumentSymbol[] | undefined;
-        if (element.children) {
-            children = documentSymbolArrayToExpectedSymbols(element.children);
-            expectedSymbols.push({ name: element.name, kind: element.kind, children });
-        } else {
-            expectedSymbols.push({ name: element.name, kind: element.kind });
-        }
-    });
-    return expectedSymbols;
-}
-
-// Used to test symbols at a specific level of inspection
-function expectSymbolsForNode(node: PQP.Language.Ast.TNode, expectedSymbols: ExpectedDocumentSymbol[]): void {
-    let actualSymbols: ExpectedDocumentSymbol[];
-
-    if (node.kind === PQP.Language.Ast.NodeKind.Section) {
-        const result: DocumentSymbol[] = InspectionUtils.getSymbolsForSection(node);
-        actualSymbols = documentSymbolArrayToExpectedSymbols(result);
-    } else if (node.kind === PQP.Language.Ast.NodeKind.LetExpression) {
-        const result: DocumentSymbol[] = InspectionUtils.getSymbolsForLetExpression(node);
-        actualSymbols = documentSymbolArrayToExpectedSymbols(result);
-    } else {
-        throw new Error("unsupported code path");
-    }
-
-    assert.isDefined(actualSymbols);
-
-    expect(actualSymbols).deep.equals(expectedSymbols, "Expected document symbols to match.\n");
-}
 
 // Used to check entire symbol heirarchy returned by getDocumentSymbols()
 function expectSymbolsForDocument(document: TextDocument, expectedSymbols: ExpectedDocumentSymbol[]): void {
-    const actualSymbols: ExpectedDocumentSymbol[] = documentSymbolArrayToExpectedSymbols(
+    const actualSymbols: ExpectedDocumentSymbol[] = Utils.documentSymbolArrayToExpectedSymbols(
         DocumentSymbols.getDocumentSymbols(document),
     );
 
@@ -72,72 +23,6 @@ function expectSymbolsForDocument(document: TextDocument, expectedSymbols: Expec
         "Expected document symbols to match.\n" + JSON.stringify(actualSymbols),
     );
 }
-
-describe("Document symbol base functions", () => {
-    it(`section foo; shared a = 1; b = "abc"; c = true;`, () => {
-        const document: Utils.MockDocument = Utils.documentFromText(`section foo; shared a = 1; b = "abc"; c = true;`);
-        const lexAndParseOk: PQP.Task.LexParseOk = getLexAndParseOk(document);
-
-        expect(lexAndParseOk.ast.kind).to.equal(PQP.Language.Ast.NodeKind.Section);
-
-        expectSymbolsForNode(lexAndParseOk.ast, [
-            { name: "a", kind: SymbolKind.Number },
-            { name: "b", kind: SymbolKind.String },
-            { name: "c", kind: SymbolKind.Boolean },
-        ]);
-    });
-
-    it(`section foo; a = {1,2};`, () => {
-        const document: Utils.MockDocument = Utils.documentFromText(`section foo; a = {1,2};`);
-        const lexAndParseOk: PQP.Task.LexParseOk = getLexAndParseOk(document);
-
-        expect(lexAndParseOk.ast.kind).to.equal(PQP.Language.Ast.NodeKind.Section);
-
-        expectSymbolsForNode(lexAndParseOk.ast, [{ name: "a", kind: SymbolKind.Array }]);
-    });
-
-    it(`let a = 1, b = 2, c = 3 in c`, () => {
-        const document: Utils.MockDocument = Utils.documentFromText(`let a = 1, b = 2, c = 3 in c`);
-        const lexAndParseOk: PQP.Task.LexParseOk = getLexAndParseOk(document);
-
-        expect(lexAndParseOk.ast.kind).to.equal(PQP.Language.Ast.NodeKind.LetExpression);
-
-        expectSymbolsForNode(lexAndParseOk.ast, [
-            { name: "a", kind: SymbolKind.Number },
-            { name: "b", kind: SymbolKind.Number },
-            { name: "c", kind: SymbolKind.Number },
-        ]);
-    });
-
-    it("HelloWorldWithDocs file section", () => {
-        const document: Utils.MockDocument = Utils.documentFromFile("HelloWorldWithDocs.pq");
-        const lexAndParseOk: PQP.Task.LexParseOk = getLexAndParseOk(document);
-
-        expect(lexAndParseOk.ast.kind).to.equal(PQP.Language.Ast.NodeKind.Section);
-
-        expectSymbolsForNode(lexAndParseOk.ast, [
-            { name: "HelloWorldWithDocs.Contents", kind: SymbolKind.Variable },
-            { name: "HelloWorldType", kind: SymbolKind.TypeParameter },
-            { name: "HelloWorldImpl", kind: SymbolKind.Function },
-            { name: "HelloWorldWithDocs", kind: SymbolKind.Struct },
-            { name: "HelloWorldWithDocs.Publish", kind: SymbolKind.Struct },
-        ]);
-    });
-
-    it("DirectQueryForSQL file section", () => {
-        const document: Utils.MockDocument = Utils.documentFromFile("DirectQueryForSQL.pq");
-        const lexAndParseOk: PQP.Task.LexParseOk = getLexAndParseOk(document);
-
-        expect(lexAndParseOk.ast.kind).to.equal(PQP.Language.Ast.NodeKind.Section);
-
-        expectSymbolsForNode(lexAndParseOk.ast, [
-            { name: "DirectSQL.Database", kind: SymbolKind.Function },
-            { name: "DirectSQL", kind: SymbolKind.Struct },
-            { name: "DirectSQL.UI", kind: SymbolKind.Struct },
-            { name: "DirectSQL.Icons", kind: SymbolKind.Struct },
-        ]);
-    });
-});
 
 describe("getDocumentSymbols", () => {
     it(`section foo; shared a = 1;`, () => {
@@ -185,8 +70,20 @@ describe("getDocumentSymbols", () => {
                     { name: "table", kind: SymbolKind.Variable },
                 ],
             },
-            { name: "HelloWorldWithDocs", kind: SymbolKind.Struct },
-            { name: "HelloWorldWithDocs.Publish", kind: SymbolKind.Struct },
+            {
+                name: "HelloWorldWithDocs",
+                kind: SymbolKind.Struct,
+                children: [{ name: "Authentication", kind: SymbolKind.Field }],
+            },
+            {
+                name: "HelloWorldWithDocs.Publish",
+                kind: SymbolKind.Struct,
+                children: [
+                    { name: "Beta", kind: SymbolKind.Field },
+                    { name: "Category", kind: SymbolKind.Field },
+                    { name: "ButtonText", kind: SymbolKind.Field },
+                ],
+            },
         ]);
     });
 });

--- a/src/test/language-services/documentSymbols.ts
+++ b/src/test/language-services/documentSymbols.ts
@@ -28,17 +28,13 @@ describe("getDocumentSymbols", () => {
     it(`section foo; shared a = 1;`, () => {
         const document: Utils.MockDocument = Utils.documentFromText(`section foo; shared a = 1;`);
 
-        expectSymbolsForDocument(document, [
-            { name: "foo", kind: SymbolKind.Module },
-            { name: "a", kind: SymbolKind.Number },
-        ]);
+        expectSymbolsForDocument(document, [{ name: "a", kind: SymbolKind.Number }]);
     });
 
     it(`section foo; shared query = let a = 1 in a;`, () => {
         const document: Utils.MockDocument = Utils.documentFromText(`section foo; shared query = let a = 1 in a;`);
 
         expectSymbolsForDocument(document, [
-            { name: "foo", kind: SymbolKind.Module },
             { name: "query", kind: SymbolKind.Variable, children: [{ name: "a", kind: SymbolKind.Number }] },
         ]);
     });
@@ -53,11 +49,37 @@ describe("getDocumentSymbols", () => {
         ]);
     });
 
+    it(`let a = let b = 1, c = let d = 1 in d in c in a`, () => {
+        const document: Utils.MockDocument = Utils.documentFromText(`let a = let b = 1, c = let d = 1 in d in c in a`);
+
+        expectSymbolsForDocument(document, [
+            {
+                name: "a",
+                kind: SymbolKind.Variable,
+                children: [
+                    { name: "b", kind: SymbolKind.Number },
+                    { name: "c", kind: SymbolKind.Variable, children: [{ name: "d", kind: SymbolKind.Number }] },
+                ],
+            },
+        ]);
+    });
+
+    // with syntax error
+    it(`shared foo; shared a = 1; b = "hello"; c = let a1`, () => {
+        const document: Utils.MockDocument = Utils.documentFromText(
+            `shared foo; shared a = 1; b = "hello"; c = let a1`,
+        );
+
+        expectSymbolsForDocument(document, [
+            { name: "a", kind: SymbolKind.Number },
+            { name: "b", kind: SymbolKind.String },
+        ]);
+    });
+
     it(`HelloWorldWithDocs.pq`, () => {
         const document: Utils.MockDocument = Utils.documentFromFile("HelloWorldWithDocs.pq");
 
         expectSymbolsForDocument(document, [
-            { name: "HelloWorldWithDocs", kind: SymbolKind.Module },
             // HelloWorldWithDocs.Contents comes back as a Variable because of the use of Value.ReplaceType
             { name: "HelloWorldWithDocs.Contents", kind: SymbolKind.Variable },
             { name: "HelloWorldType", kind: SymbolKind.TypeParameter },
@@ -73,16 +95,16 @@ describe("getDocumentSymbols", () => {
             {
                 name: "HelloWorldWithDocs",
                 kind: SymbolKind.Struct,
-                children: [{ name: "Authentication", kind: SymbolKind.Field }],
+                // children: [{ name: "Authentication", kind: SymbolKind.Field }],
             },
             {
                 name: "HelloWorldWithDocs.Publish",
                 kind: SymbolKind.Struct,
-                children: [
-                    { name: "Beta", kind: SymbolKind.Field },
-                    { name: "Category", kind: SymbolKind.Field },
-                    { name: "ButtonText", kind: SymbolKind.Field },
-                ],
+                // children: [
+                //     { name: "Beta", kind: SymbolKind.Field },
+                //     { name: "Category", kind: SymbolKind.Field },
+                //     { name: "ButtonText", kind: SymbolKind.Field },
+                // ],
             },
         ]);
     });

--- a/src/test/language-services/inspectionUtils.ts
+++ b/src/test/language-services/inspectionUtils.ts
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// tslint:disable: no-implicit-dependencies
+import * as PQP from "@microsoft/powerquery-parser";
+import { assert, expect } from "chai";
+import "mocha";
+import { DocumentSymbol, SymbolKind, TextDocument } from "../../language-services";
+import { ExpectedDocumentSymbol } from "./utils";
+
+import * as InspectionUtils from "../../language-services/inspectionUtils";
+import * as WorkspaceCache from "../../language-services/workspaceCache";
+import * as Utils from "./utils";
+
+function getLexAndParseOk(document: TextDocument): PQP.Task.LexParseOk {
+    const triedLexParse: PQP.Task.TriedLexParse = WorkspaceCache.getTriedLexParse(document);
+    if (PQP.ResultUtils.isErr(triedLexParse)) {
+        throw new Error("AssertFailed: triedLexParse to be Ok");
+    }
+    return triedLexParse.value;
+}
+
+// Used to test symbols at a specific level of inspection
+function expectSymbolsForNode(node: PQP.Language.Ast.TNode, expectedSymbols: ExpectedDocumentSymbol[]): void {
+    let actualSymbols: ExpectedDocumentSymbol[];
+
+    if (node.kind === PQP.Language.Ast.NodeKind.Section) {
+        const result: DocumentSymbol[] = InspectionUtils.getSymbolsForSection(node);
+        actualSymbols = Utils.documentSymbolArrayToExpectedSymbols(result);
+    } else if (node.kind === PQP.Language.Ast.NodeKind.LetExpression) {
+        const result: DocumentSymbol[] = InspectionUtils.getSymbolsForLetExpression(node);
+        actualSymbols = Utils.documentSymbolArrayToExpectedSymbols(result);
+    } else {
+        throw new Error("unsupported code path");
+    }
+
+    assert.isDefined(actualSymbols);
+
+    expect(actualSymbols).deep.equals(expectedSymbols, "Expected document symbols to match.\n");
+}
+
+describe("Document symbol base functions", () => {
+    it(`section foo; shared a = 1; b = "abc"; c = true;`, () => {
+        const document: Utils.MockDocument = Utils.documentFromText(`section foo; shared a = 1; b = "abc"; c = true;`);
+        const lexAndParseOk: PQP.Task.LexParseOk = getLexAndParseOk(document);
+
+        expect(lexAndParseOk.ast.kind).to.equal(PQP.Language.Ast.NodeKind.Section);
+
+        expectSymbolsForNode(lexAndParseOk.ast, [
+            { name: "a", kind: SymbolKind.Number },
+            { name: "b", kind: SymbolKind.String },
+            { name: "c", kind: SymbolKind.Boolean },
+        ]);
+    });
+
+    it(`section foo; a = {1,2};`, () => {
+        const document: Utils.MockDocument = Utils.documentFromText(`section foo; a = {1,2};`);
+        const lexAndParseOk: PQP.Task.LexParseOk = getLexAndParseOk(document);
+
+        expect(lexAndParseOk.ast.kind).to.equal(PQP.Language.Ast.NodeKind.Section);
+
+        expectSymbolsForNode(lexAndParseOk.ast, [{ name: "a", kind: SymbolKind.Array }]);
+    });
+
+    it(`let a = 1, b = 2, c = 3 in c`, () => {
+        const document: Utils.MockDocument = Utils.documentFromText(`let a = 1, b = 2, c = 3 in c`);
+        const lexAndParseOk: PQP.Task.LexParseOk = getLexAndParseOk(document);
+
+        expect(lexAndParseOk.ast.kind).to.equal(PQP.Language.Ast.NodeKind.LetExpression);
+
+        expectSymbolsForNode(lexAndParseOk.ast, [
+            { name: "a", kind: SymbolKind.Number },
+            { name: "b", kind: SymbolKind.Number },
+            { name: "c", kind: SymbolKind.Number },
+        ]);
+    });
+
+    it("HelloWorldWithDocs file section", () => {
+        const document: Utils.MockDocument = Utils.documentFromFile("HelloWorldWithDocs.pq");
+        const lexAndParseOk: PQP.Task.LexParseOk = getLexAndParseOk(document);
+
+        expect(lexAndParseOk.ast.kind).to.equal(PQP.Language.Ast.NodeKind.Section);
+
+        expectSymbolsForNode(lexAndParseOk.ast, [
+            { name: "HelloWorldWithDocs.Contents", kind: SymbolKind.Variable },
+            { name: "HelloWorldType", kind: SymbolKind.TypeParameter },
+            { name: "HelloWorldImpl", kind: SymbolKind.Function },
+            { name: "HelloWorldWithDocs", kind: SymbolKind.Struct },
+            { name: "HelloWorldWithDocs.Publish", kind: SymbolKind.Struct },
+        ]);
+    });
+
+    it("DirectQueryForSQL file section", () => {
+        const document: Utils.MockDocument = Utils.documentFromFile("DirectQueryForSQL.pq");
+        const lexAndParseOk: PQP.Task.LexParseOk = getLexAndParseOk(document);
+
+        expect(lexAndParseOk.ast.kind).to.equal(PQP.Language.Ast.NodeKind.Section);
+
+        expectSymbolsForNode(lexAndParseOk.ast, [
+            { name: "DirectSQL.Database", kind: SymbolKind.Function },
+            { name: "DirectSQL", kind: SymbolKind.Struct },
+            { name: "DirectSQL.UI", kind: SymbolKind.Struct },
+            { name: "DirectSQL.Icons", kind: SymbolKind.Struct },
+        ]);
+    });
+});

--- a/src/test/language-services/utils.ts
+++ b/src/test/language-services/utils.ts
@@ -23,10 +23,12 @@ import {
     Analysis,
     CompletionItemProviderContext,
     createAnalysisSession,
+    DocumentSymbol,
     HoverProviderContext,
     LibrarySymbolProvider,
     NullLibrarySymbolProvider,
     SignatureProviderContext,
+    SymbolKind,
 } from "../../language-services";
 import { AnalysisOptions } from "../../language-services/analysisOptions";
 import * as WorkspaceCache from "../../language-services/workspaceCache";
@@ -333,6 +335,26 @@ export const emptySignatureHelp: SignatureHelp = {
 export function dumpNodeToTraceFile(node: PQP.Language.Ast.INode, filePath: string): void {
     const asJson: string = JSON.stringify(node);
     File.writeFileSync(filePath, asJson);
+}
+
+export interface ExpectedDocumentSymbol {
+    name: string;
+    kind: SymbolKind;
+    children?: ExpectedDocumentSymbol[];
+}
+
+export function documentSymbolArrayToExpectedSymbols(documentSymbols: DocumentSymbol[]): ExpectedDocumentSymbol[] {
+    const expectedSymbols: ExpectedDocumentSymbol[] = [];
+    documentSymbols.forEach(element => {
+        let children: ExpectedDocumentSymbol[] | undefined;
+        if (element.children) {
+            children = documentSymbolArrayToExpectedSymbols(element.children);
+            expectedSymbols.push({ name: element.name, kind: element.kind, children });
+        } else {
+            expectedSymbols.push({ name: element.name, kind: element.kind });
+        }
+    });
+    return expectedSymbols;
 }
 
 const DefaultAnalysisOptions: AnalysisOptions = {};


### PR DESCRIPTION
Adds support for the [Document Symbols LSP](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_documentSymbol) functionality.

In VS Code, this shows up in the Outline window like this:

![image](https://user-images.githubusercontent.com/5509937/85796339-c4a4a500-b707-11ea-8a50-6865d6901cc5.png)

Supports:

- Section members
- Let expression members
- Record fields

Also sets the correct symbol type when constants/literals are used.

Further improvements could be:

- Support (partial outline) for members with syntax errors (i.e. context nodes)
- Include function signature 
- Tracing for error cases
- Lookup appropriate type info for library constants and literals
- Recognize correct type for `Value.ReplaceType` (causes functions to appear as variables)