### PR TITLE
Fix token logic when cursor is before the identifier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/powerquery-language-services",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.1.11",
+    "version": "0.1.12",
     "author": "Microsoft",
     "license": "MIT",
     "scripts": {

--- a/src/language-services/analysis.ts
+++ b/src/language-services/analysis.ts
@@ -193,9 +193,7 @@ abstract class AnalysisBase implements Analysis {
             return undefined;
         }
 
-        return AnalysisUtils.getTokenAtPosition(maybeLineTokens, this.position, (range?: Range | undefined) =>
-            this.getText(range),
-        );
+        return AnalysisUtils.getTokenAtPosition(maybeLineTokens, this.position);
     }
 }
 

--- a/src/language-services/analysis.ts
+++ b/src/language-services/analysis.ts
@@ -6,6 +6,7 @@ import type { TextDocument } from "vscode-languageserver-textdocument";
 import type { CompletionItem, Hover, Position, Range, SignatureHelp } from "vscode-languageserver-types";
 
 import { AnalysisOptions } from "./analysisOptions";
+import * as AnalysisUtils from "./analysisUtils";
 import { IDisposable } from "./commonTypes";
 import { CurrentDocumentSymbolProvider } from "./currentDocumentSymbolProvider";
 import * as InspectionUtils from "./inspectionUtils";
@@ -62,7 +63,7 @@ abstract class AnalysisBase implements Analysis {
         const maybeToken: PQP.Language.LineToken | undefined = this.maybeTokenAt();
         if (maybeToken !== undefined) {
             context = {
-                range: AnalysisBase.getTokenRangeForPosition(maybeToken, this.position),
+                range: AnalysisUtils.getTokenRangeForPosition(maybeToken, this.position),
                 text: maybeToken.data,
                 tokenKind: maybeToken.kind,
             };
@@ -111,7 +112,7 @@ abstract class AnalysisBase implements Analysis {
         const identifierToken: PQP.Language.LineToken | undefined = this.maybeIdentifierAt();
         if (identifierToken) {
             const context: HoverProviderContext = {
-                range: AnalysisBase.getTokenRangeForPosition(identifierToken, this.position),
+                range: AnalysisUtils.getTokenRangeForPosition(identifierToken, this.position),
                 identifier: identifierToken.data,
             };
 
@@ -167,19 +168,6 @@ abstract class AnalysisBase implements Analysis {
 
     protected abstract getLexerState(): PQP.Lexer.State;
     protected abstract getText(range?: Range): string;
-
-    private static getTokenRangeForPosition(token: PQP.Language.LineToken, cursorPosition: Position): Range {
-        return {
-            start: {
-                line: cursorPosition.line,
-                character: token.positionStart,
-            },
-            end: {
-                line: cursorPosition.line,
-                character: token.positionEnd,
-            },
-        };
-    }
 
     private maybeIdentifierAt(): PQP.Language.LineToken | undefined {
         const maybeToken: PQP.Language.LineToken | undefined = this.maybeTokenAt();

--- a/src/language-services/analysisUtils.ts
+++ b/src/language-services/analysisUtils.ts
@@ -5,6 +5,47 @@ import * as PQP from "@microsoft/powerquery-parser";
 
 import { Position, Range } from "./commonTypes";
 
+export function getTokenAtPosition(
+    lineTokens: ReadonlyArray<PQP.Language.LineToken>,
+    position: Position,
+    getTextCallback: (range?: Range) => string,
+): PQP.Language.LineToken | undefined {
+    for (const token of lineTokens) {
+        if (token.positionStart <= position.character && token.positionEnd >= position.character) {
+            return token;
+        }
+    }
+
+    // TODO: is this still needed with the latest parser?
+    // Token wasn't found - check for special case where current position is a trailing "." on an identifier
+    const currentRange: Range = {
+        start: {
+            line: position.line,
+            character: position.character - 1,
+        },
+        end: position,
+    };
+
+    if (getTextCallback(currentRange) === ".") {
+        for (const token of lineTokens) {
+            if (
+                token.kind === PQP.Language.LineTokenKind.Identifier &&
+                token.positionStart <= position.character - 1 &&
+                token.positionEnd >= position.character - 1
+            ) {
+                // Use this token with an adjusted position
+                return {
+                    ...token,
+                    data: `${token.data}.`,
+                    positionEnd: token.positionEnd + 1,
+                };
+            }
+        }
+    }
+
+    return undefined;
+}
+
 export function getTokenRangeForPosition(token: PQP.Language.LineToken, cursorPosition: Position): Range {
     return {
         start: {

--- a/src/language-services/analysisUtils.ts
+++ b/src/language-services/analysisUtils.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as PQP from "@microsoft/powerquery-parser";
+
+import { Position, Range } from "./commonTypes";
+
+export function getTokenRangeForPosition(token: PQP.Language.LineToken, cursorPosition: Position): Range {
+    return {
+        start: {
+            line: cursorPosition.line,
+            character: token.positionStart,
+        },
+        end: {
+            line: cursorPosition.line,
+            character: token.positionEnd,
+        },
+    };
+}

--- a/src/language-services/analysisUtils.ts
+++ b/src/language-services/analysisUtils.ts
@@ -8,38 +8,10 @@ import { Position, Range } from "./commonTypes";
 export function getTokenAtPosition(
     lineTokens: ReadonlyArray<PQP.Language.LineToken>,
     position: Position,
-    getTextCallback: (range?: Range) => string,
 ): PQP.Language.LineToken | undefined {
     for (const token of lineTokens) {
-        if (token.positionStart <= position.character && token.positionEnd >= position.character) {
+        if (token.positionStart < position.character && token.positionEnd >= position.character) {
             return token;
-        }
-    }
-
-    // TODO: is this still needed with the latest parser?
-    // Token wasn't found - check for special case where current position is a trailing "." on an identifier
-    const currentRange: Range = {
-        start: {
-            line: position.line,
-            character: position.character - 1,
-        },
-        end: position,
-    };
-
-    if (getTextCallback(currentRange) === ".") {
-        for (const token of lineTokens) {
-            if (
-                token.kind === PQP.Language.LineTokenKind.Identifier &&
-                token.positionStart <= position.character - 1 &&
-                token.positionEnd >= position.character - 1
-            ) {
-                // Use this token with an adjusted position
-                return {
-                    ...token,
-                    data: `${token.data}.`,
-                    positionEnd: token.positionEnd + 1,
-                };
-            }
         }
     }
 

--- a/src/test/language-services/analysisUtilsTests.ts
+++ b/src/test/language-services/analysisUtilsTests.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// tslint:disable: no-implicit-dependencies
+import { expect } from "chai";
+import "mocha";
+
+// import * as AnalysisUtils from "../language-services/analysisUtils";
+// import { Position, Range } from "../../language-services";
+
+describe("getTokenRangeForPosition", () => {
+    it(`getTokenRangeForPosition`, () => {
+        // TODO
+        expect(true);
+    });
+});

--- a/src/test/language-services/analysisUtilsTests.ts
+++ b/src/test/language-services/analysisUtilsTests.ts
@@ -12,9 +12,12 @@ import * as Utils from "./utils";
 import { MockDocument } from "./utils";
 
 describe("getTokenAtPosition", () => {
-    // it(`|Table.AddColumn()`, () => {
-    //     expectToken("Table|.AddColumn()", "Table.AddColumn");
-    // });
+    it(`| Table.AddColumn()`, () => {
+        expectToken("| Table.AddColumn()", undefined);
+    });
+    it(`|Table.AddColumn()`, () => {
+        expectToken("|Table.AddColumn()", undefined);
+    });
     it(`Tab|le.AddColumn()`, () => {
         expectToken("Tab|le.AddColumn()", "Table.AddColumn");
     });
@@ -30,12 +33,21 @@ describe("getTokenAtPosition", () => {
     it(`Table.AddColum|n()`, () => {
         expectToken("Table.AddColum|n()", "Table.AddColumn");
     });
-    // it(`Table.AddColumn|()`, () => {
-    //     expectToken("Table|.AddColumn()", "Table.AddColumn");
-    // });
+    it(`Table.AddColumn|()`, () => {
+        expectToken("Table.AddColumn|()", "Table.AddColumn");
+    });
+    it(`Table.|`, () => {
+        expectToken("Table.|", "Table.");
+    });
+    it(`Table|.`, () => {
+        expectToken("Table|.", "Table.");
+    });
+    it(`|Table.`, () => {
+        expectToken("|Table.", undefined);
+    });
 });
 
-function expectToken(textWithPosition: string, tokenData: string): void {
+function expectToken(textWithPosition: string, tokenData: string | undefined): void {
     const [document, position]: [MockDocument, Position] = Utils.documentAndPositionFrom(textWithPosition);
     const lexerState: PQP.Lexer.State = PQP.Lexer.stateFrom(PQP.DefaultSettings, document.getText());
     const maybeLine: PQP.Lexer.TLine | undefined = lexerState.lines[position.line];
@@ -44,11 +56,7 @@ function expectToken(textWithPosition: string, tokenData: string): void {
     }
 
     const lineTokens: ReadonlyArray<PQP.Language.LineToken> = maybeLine.tokens;
-    const token: PQP.Language.LineToken | undefined = AnalysisUtils.getTokenAtPosition(
-        lineTokens,
-        position,
-        document.getText,
-    );
+    const token: PQP.Language.LineToken | undefined = AnalysisUtils.getTokenAtPosition(lineTokens, position);
 
     expect(token?.data).to.equal(tokenData, "Unexpected token data");
 }

--- a/src/test/language-services/analysisUtilsTests.ts
+++ b/src/test/language-services/analysisUtilsTests.ts
@@ -2,15 +2,53 @@
 // Licensed under the MIT license.
 
 // tslint:disable: no-implicit-dependencies
-import { expect } from "chai";
+import * as PQP from "@microsoft/powerquery-parser";
+import { assert, expect } from "chai";
 import "mocha";
 
-// import * as AnalysisUtils from "../language-services/analysisUtils";
-// import { Position, Range } from "../../language-services";
+import { Position } from "../../language-services";
+import * as AnalysisUtils from "../../language-services/analysisUtils";
+import * as Utils from "./utils";
+import { MockDocument } from "./utils";
 
-describe("getTokenRangeForPosition", () => {
-    it(`getTokenRangeForPosition`, () => {
-        // TODO
-        expect(true);
+describe("getTokenAtPosition", () => {
+    // it(`|Table.AddColumn()`, () => {
+    //     expectToken("Table|.AddColumn()", "Table.AddColumn");
+    // });
+    it(`Tab|le.AddColumn()`, () => {
+        expectToken("Tab|le.AddColumn()", "Table.AddColumn");
     });
+    it(`Table|.AddColumn()`, () => {
+        expectToken("Table|.AddColumn()", "Table.AddColumn");
+    });
+    it(`Table.|AddColumn()`, () => {
+        expectToken("Table.|AddColumn()", "Table.AddColumn");
+    });
+    it(`Table.Add|Column()`, () => {
+        expectToken("Table.Add|Column()", "Table.AddColumn");
+    });
+    it(`Table.AddColum|n()`, () => {
+        expectToken("Table.AddColum|n()", "Table.AddColumn");
+    });
+    // it(`Table.AddColumn|()`, () => {
+    //     expectToken("Table|.AddColumn()", "Table.AddColumn");
+    // });
 });
+
+function expectToken(textWithPosition: string, tokenData: string): void {
+    const [document, position]: [MockDocument, Position] = Utils.documentAndPositionFrom(textWithPosition);
+    const lexerState: PQP.Lexer.State = PQP.Lexer.stateFrom(PQP.DefaultSettings, document.getText());
+    const maybeLine: PQP.Lexer.TLine | undefined = lexerState.lines[position.line];
+    if (!maybeLine) {
+        assert.fail("expected PQP.Lexer.TLine !== undefined");
+    }
+
+    const lineTokens: ReadonlyArray<PQP.Language.LineToken> = maybeLine.tokens;
+    const token: PQP.Language.LineToken | undefined = AnalysisUtils.getTokenAtPosition(
+        lineTokens,
+        position,
+        document.getText,
+    );
+
+    expect(token?.data).to.equal(tokenData, "Unexpected token data");
+}


### PR DESCRIPTION
Resolves long standing issue where triggering autocomplete when the cursor is before an identifier causes that identifier to be replaced.
See: https://github.com/microsoft/vscode-powerquery/issues/26

Also removed unnecessary code, and refactored some analysis helper functions to make them unit testable. 