### PR TITLE
Add native types to completion items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/powerquery-language-services",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.1.12",
+    "version": "0.1.13",
     "author": "Microsoft",
     "license": "MIT",
     "scripts": {

--- a/src/language-services/analysis.ts
+++ b/src/language-services/analysis.ts
@@ -10,7 +10,7 @@ import * as AnalysisUtils from "./analysisUtils";
 import { IDisposable } from "./commonTypes";
 import { CurrentDocumentSymbolProvider } from "./currentDocumentSymbolProvider";
 import * as InspectionUtils from "./inspectionUtils";
-import { KeywordProvider } from "./keywordProvider";
+import { LanguageConstantProvider } from "./languageConstantProvider";
 import * as LanguageServiceUtils from "./languageServiceUtils";
 import {
     CompletionItemProviderContext,
@@ -34,7 +34,7 @@ export function createAnalysisSession(document: TextDocument, position: Position
 
 abstract class AnalysisBase implements Analysis {
     protected readonly environmentSymbolProvider: SymbolProvider;
-    protected readonly keywordProvider: KeywordProvider;
+    protected readonly languageConstantProvider: LanguageConstantProvider;
     protected readonly librarySymbolProvider: LibrarySymbolProvider;
     protected readonly localSymbolProvider: SymbolProvider;
 
@@ -50,7 +50,7 @@ abstract class AnalysisBase implements Analysis {
         this.environmentSymbolProvider = this.options.environmentSymbolProvider
             ? this.options.environmentSymbolProvider
             : new NullLibrarySymbolProvider();
-        this.keywordProvider = new KeywordProvider(this.triedInspection);
+        this.languageConstantProvider = new LanguageConstantProvider(this.triedInspection);
         this.librarySymbolProvider = this.options.librarySymbolProvider
             ? this.options.librarySymbolProvider
             : new NullLibrarySymbolProvider();
@@ -81,9 +81,11 @@ abstract class AnalysisBase implements Analysis {
             .catch(() => {
                 return LanguageServiceUtils.EmptyCompletionItems;
             });
-        const getKeywords: Promise<CompletionItem[]> = this.keywordProvider.getCompletionItems(context).catch(() => {
-            return LanguageServiceUtils.EmptyCompletionItems;
-        });
+        const getLanguageConstants: Promise<CompletionItem[]> = this.languageConstantProvider
+            .getCompletionItems(context)
+            .catch(() => {
+                return LanguageServiceUtils.EmptyCompletionItems;
+            });
         const getEnvironmentCompletionItems: Promise<
             CompletionItem[]
         > = this.environmentSymbolProvider.getCompletionItems(context).catch(() => {
@@ -97,7 +99,7 @@ abstract class AnalysisBase implements Analysis {
 
         const [libraryResponse, keywordResponse, environmentResponse, localResponse] = await Promise.all([
             getLibraryCompletionItems,
-            getKeywords,
+            getLanguageConstants,
             getEnvironmentCompletionItems,
             getLocalCompletionItems,
         ]);

--- a/src/language-services/languageConstantProvider.ts
+++ b/src/language-services/languageConstantProvider.ts
@@ -6,7 +6,7 @@ import { CompletionItem, CompletionItemKind } from "vscode-languageserver-types"
 
 import { CompletionItemProvider, CompletionItemProviderContext } from "./providers";
 
-export class KeywordProvider implements CompletionItemProvider {
+export class LanguageConstantProvider implements CompletionItemProvider {
     // Power Query defines constructor functions (ex. #table()) as keywords, but we want
     // them to be treated like library functions instead.
     private static readonly ExcludedKeywords: ReadonlyArray<PQP.Language.KeywordKind> = [
@@ -32,7 +32,10 @@ export class KeywordProvider implements CompletionItemProvider {
         const inspectionOk: PQP.Task.InspectionOk = this.maybeTriedInspection.value;
 
         return inspectionOk.autocomplete
-            .filter((keyword: PQP.Language.KeywordKind) => KeywordProvider.ExcludedKeywords.indexOf(keyword) === -1)
+            .filter(
+                (keyword: PQP.Language.KeywordKind) =>
+                    LanguageConstantProvider.ExcludedKeywords.indexOf(keyword) === -1,
+            )
             .map((keyword: PQP.Language.KeywordKind) => {
                 return {
                     kind: CompletionItemKind.Keyword,

--- a/src/language-services/languageConstantProvider.ts
+++ b/src/language-services/languageConstantProvider.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 
 import * as PQP from "@microsoft/powerquery-parser";
-import { CompletionItem, CompletionItemKind } from "vscode-languageserver-types";
 
+import { CompletionItem, CompletionItemKind } from "./commonTypes";
 import { CompletionItemProvider, CompletionItemProviderContext } from "./providers";
 
 export class LanguageConstantProvider implements CompletionItemProvider {
@@ -23,9 +23,37 @@ export class LanguageConstantProvider implements CompletionItemProvider {
         PQP.Language.KeywordKind.HashTime,
     ];
 
+    private static readonly LanguageConstants: ReadonlyArray<CompletionItem> = [
+        { kind: CompletionItemKind.Keyword, label: PQP.Language.Ast.IdentifierConstantKind.Nullable },
+        { kind: CompletionItemKind.Keyword, label: PQP.Language.Ast.IdentifierConstantKind.Optional },
+        { kind: CompletionItemKind.TypeParameter, label: PQP.Language.Ast.PrimitiveTypeConstantKind.Action },
+        { kind: CompletionItemKind.TypeParameter, label: PQP.Language.Ast.PrimitiveTypeConstantKind.Any },
+        { kind: CompletionItemKind.TypeParameter, label: PQP.Language.Ast.PrimitiveTypeConstantKind.AnyNonNull },
+        { kind: CompletionItemKind.TypeParameter, label: PQP.Language.Ast.PrimitiveTypeConstantKind.Binary },
+        { kind: CompletionItemKind.TypeParameter, label: PQP.Language.Ast.PrimitiveTypeConstantKind.Date },
+        { kind: CompletionItemKind.TypeParameter, label: PQP.Language.Ast.PrimitiveTypeConstantKind.DateTime },
+        { kind: CompletionItemKind.TypeParameter, label: PQP.Language.Ast.PrimitiveTypeConstantKind.DateTimeZone },
+        { kind: CompletionItemKind.TypeParameter, label: PQP.Language.Ast.PrimitiveTypeConstantKind.Duration },
+        { kind: CompletionItemKind.TypeParameter, label: PQP.Language.Ast.PrimitiveTypeConstantKind.Function },
+        { kind: CompletionItemKind.TypeParameter, label: PQP.Language.Ast.PrimitiveTypeConstantKind.List },
+        { kind: CompletionItemKind.TypeParameter, label: PQP.Language.Ast.PrimitiveTypeConstantKind.Logical },
+        { kind: CompletionItemKind.TypeParameter, label: PQP.Language.Ast.PrimitiveTypeConstantKind.None },
+        { kind: CompletionItemKind.TypeParameter, label: PQP.Language.Ast.PrimitiveTypeConstantKind.Null },
+        { kind: CompletionItemKind.TypeParameter, label: PQP.Language.Ast.PrimitiveTypeConstantKind.Number },
+        { kind: CompletionItemKind.TypeParameter, label: PQP.Language.Ast.PrimitiveTypeConstantKind.Record },
+        { kind: CompletionItemKind.TypeParameter, label: PQP.Language.Ast.PrimitiveTypeConstantKind.Table },
+        { kind: CompletionItemKind.TypeParameter, label: PQP.Language.Ast.PrimitiveTypeConstantKind.Text },
+        { kind: CompletionItemKind.TypeParameter, label: PQP.Language.Ast.PrimitiveTypeConstantKind.Time },
+        { kind: CompletionItemKind.TypeParameter, label: PQP.Language.Ast.PrimitiveTypeConstantKind.Type },
+    ];
+
     constructor(private readonly maybeTriedInspection: PQP.Task.TriedInspection | undefined) {}
 
     public async getCompletionItems(_context: CompletionItemProviderContext): Promise<CompletionItem[]> {
+        return [...LanguageConstantProvider.LanguageConstants, ...this.getKeywords()];
+    }
+
+    private getKeywords(): CompletionItem[] {
         if (this.maybeTriedInspection === undefined || PQP.ResultUtils.isErr(this.maybeTriedInspection)) {
             return [];
         }


### PR DESCRIPTION
Adds a hard coded list of native types and identifier constants, as described in #22. In the future, these should be context sensitive like other keywords (requires parser update). 

Also renames `KeywordProvider` to `LanguageConstantProvider` to reflect that it more than just M keywords.

