### PR TITLE
Passthrough locale value to parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -91,15 +91,15 @@
       "dev": true
     },
     "@types/mocha": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-7.0.2.tgz",
-      "integrity": "sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.0.0.tgz",
+      "integrity": "sha512-jWeYcTo3sCH/rMgsdYXDTO85GNRyTCII5dayMIu/ZO4zbEot1E3iNGaOwpLReLUHjeNQFkgeNNVYlY4dX6azQQ==",
       "dev": true
     },
     "@types/node": {
-      "version": "14.0.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.13.tgz",
-      "integrity": "sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA==",
+      "version": "14.0.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.23.tgz",
+      "integrity": "sha512-Z4U8yDAl5TFkmYsZdFPdjeMa57NOvnaf1tljHzhouaPEp7LCj2JKkejpI1ODviIAQuW4CcQmxkQ77rnLsOOoKw==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -747,9 +747,9 @@
       "dev": true
     },
     "enhanced-resolve": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.1.tgz",
-      "integrity": "sha512-98p2zE+rL7/g/DzMHMTF4zZlCgeVdJ7yr6xzEpJRYwFYrGi9ANdn5DnJURg6RpBkyk60XYDnWIv51VfIhfNGuA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz",
+      "integrity": "sha512-3e87LvavsdxyoCfGusJnrZ5G8SLPOFeHSNpZI/ATL9a5leXo2k0w6MKnbqhdBad9qTobSfB20Ld7UmgoNbAZkQ==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -1741,9 +1741,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
     "log-symbols": {
@@ -2955,9 +2955,9 @@
       "dev": true
     },
     "ts-loader": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-7.0.5.tgz",
-      "integrity": "sha512-zXypEIT6k3oTc+OZNx/cqElrsbBtYqDknf48OZos0NQ3RTt045fBIU8RRSu+suObBzYB355aIPGOe/3kj9h7Ig==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.0.1.tgz",
+      "integrity": "sha512-I9Nmly0ufJoZRMuAT9d5ijsC2B7oSPvUnOJt/GhgoATlPGYfa17VicDKPcqwUCrHpOkCxr/ybLYwbnS4cOxmvQ==",
       "dev": true,
       "requires": {
         "chalk": "^2.3.0",
@@ -3090,9 +3090,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.5.tgz",
-      "integrity": "sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.6.tgz",
+      "integrity": "sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==",
       "dev": true
     },
     "union-value": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/powerquery-language-services",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,21 +30,21 @@
     ],
     "devDependencies": {
         "@types/chai": "^4.2.11",
-        "@types/mocha": "^7.0.2",
-        "@types/node": "^14.0.13",
+        "@types/mocha": "^8.0.0",
+        "@types/node": "^14.0.23",
         "chai": "^4.2.0",
         "cpy-cli": "^3.1.1",
         "mocha": "^8.0.1",
         "mocha-junit-reporter": "^2.0.0",
         "mocha-multi-reporters": "^1.1.7",
         "prettier": "^2.0.5",
-        "ts-loader": "^7.0.5",
+        "ts-loader": "^8.0.1",
         "ts-node": "^8.10.2",
         "tslint": "^6.1.2",
         "tslint-config-prettier": "^1.18.0",
         "tslint-microsoft-contrib": "^6.2.0",
         "tslint-plugin-prettier": "^2.3.0",
-        "typescript": "^3.9.5"
+        "typescript": "^3.9.6"
     },
     "dependencies": {
         "@microsoft/powerquery-parser": "0.1.56",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.1.13",
+    "version": "0.1.14",
     "author": "Microsoft",
     "license": "MIT",
     "scripts": {

--- a/src/language-services/analysis.ts
+++ b/src/language-services/analysis.ts
@@ -201,7 +201,7 @@ abstract class AnalysisBase implements Analysis {
 
 class DocumentAnalysis extends AnalysisBase {
     constructor(private readonly document: TextDocument, position: Position, options: AnalysisOptions) {
-        super(WorkspaceCache.maybeTriedInspection(document, position), position, options);
+        super(WorkspaceCache.maybeTriedInspection(document, position, options.locale), position, options);
     }
 
     public dispose(): void {
@@ -211,7 +211,7 @@ class DocumentAnalysis extends AnalysisBase {
     }
 
     protected getLexerState(): PQP.Lexer.State {
-        return WorkspaceCache.getLexerState(this.document);
+        return WorkspaceCache.getLexerState(this.document, this.options.locale);
     }
 
     protected getText(range?: Range): string {

--- a/src/language-services/documentSymbols.ts
+++ b/src/language-services/documentSymbols.ts
@@ -10,7 +10,7 @@ import * as LanguageServiceUtils from "./languageServiceUtils";
 import * as WorkspaceCache from "./workspaceCache";
 
 export function getDocumentSymbols(document: TextDocument, options?: AnalysisOptions): DocumentSymbol[] {
-    const triedLexParse: PQP.Task.TriedLexParse = WorkspaceCache.getTriedLexParse(document);
+    const triedLexParse: PQP.Task.TriedLexParse = WorkspaceCache.getTriedLexParse(document, options?.locale);
     let result: DocumentSymbol[] = [];
 
     let contextState: PQP.ParseContext.State | undefined = undefined;

--- a/src/language-services/validation.ts
+++ b/src/language-services/validation.ts
@@ -28,7 +28,7 @@ export interface ValidationOptions extends AnalysisOptions {
 }
 
 export function validate(document: TextDocument, options?: ValidationOptions): ValidationResult {
-    const triedLexParse: PQP.Task.TriedLexParse = WorkspaceCache.getTriedLexParse(document);
+    const triedLexParse: PQP.Task.TriedLexParse = WorkspaceCache.getTriedLexParse(document, options?.locale);
     let diagnostics: Diagnostic[] = [];
 
     let contextState: PQP.ParseContext.State | undefined = undefined;

--- a/src/test/language-services/inspectionUtils.ts
+++ b/src/test/language-services/inspectionUtils.ts
@@ -13,7 +13,7 @@ import * as WorkspaceCache from "../../language-services/workspaceCache";
 import * as Utils from "./utils";
 
 function getLexAndParseOk(document: TextDocument): PQP.Task.LexParseOk {
-    const triedLexParse: PQP.Task.TriedLexParse = WorkspaceCache.getTriedLexParse(document);
+    const triedLexParse: PQP.Task.TriedLexParse = WorkspaceCache.getTriedLexParse(document, "en-US");
     if (PQP.ResultUtils.isErr(triedLexParse)) {
         throw new Error("AssertFailed: triedLexParse to be Ok");
     }

--- a/src/test/language-services/utils.ts
+++ b/src/test/language-services/utils.ts
@@ -134,6 +134,7 @@ export function expectInspectionOk(document: MockDocument, position: Position): 
     const maybeTriedInspect: PQP.Task.TriedInspection | undefined = WorkspaceCache.maybeTriedInspection(
         document,
         position,
+        undefined,
     );
     if (maybeTriedInspect === undefined) {
         throw new Error(`maybeTriedInspect is expected to be defined`);

--- a/src/test/language-services/workspaceCacheTest.ts
+++ b/src/test/language-services/workspaceCacheTest.ts
@@ -14,14 +14,14 @@ import * as Utils from "./utils";
 describe("workspaceCache", () => {
     it("getLexerState", () => {
         const document: TextDocument = Utils.documentFromText("let\n   b = 1\n   in b");
-        const state: PQP.Lexer.State = WorkspaceCache.getLexerState(document);
+        const state: PQP.Lexer.State = WorkspaceCache.getLexerState(document, undefined);
         assert.isDefined(state);
         expect(state.lines.length).to.equal(3);
     });
 
     it("getTriedLexerSnapshot", () => {
         const document: TextDocument = Utils.documentFromText("let a = 1 in a");
-        const triedSnapshot: PQP.TriedLexerSnapshot = WorkspaceCache.getTriedLexerSnapshot(document);
+        const triedSnapshot: PQP.TriedLexerSnapshot = WorkspaceCache.getTriedLexerSnapshot(document, undefined);
         assert.isDefined(triedSnapshot);
         if (PQP.ResultUtils.isOk(triedSnapshot)) {
             const snapshot: PQP.LexerSnapshot = triedSnapshot.value;
@@ -33,7 +33,7 @@ describe("workspaceCache", () => {
 
     it("getTriedLexParse", () => {
         const document: TextDocument = Utils.documentFromText("let c = 1 in c");
-        const triedLexParse: PQP.Task.TriedLexParse = WorkspaceCache.getTriedLexParse(document);
+        const triedLexParse: PQP.Task.TriedLexParse = WorkspaceCache.getTriedLexParse(document, undefined);
         assert.isDefined(triedLexParse);
         if (PQP.ResultUtils.isOk(triedLexParse)) {
             const lexParseOk: PQP.Task.LexParseOk = triedLexParse.value;
@@ -45,7 +45,7 @@ describe("workspaceCache", () => {
 
     it("getTriedLexParse with error", () => {
         const document: TextDocument = Utils.documentFromText("let c = 1, in c");
-        const triedLexParse: PQP.Task.TriedLexParse = WorkspaceCache.getTriedLexParse(document);
+        const triedLexParse: PQP.Task.TriedLexParse = WorkspaceCache.getTriedLexParse(document, undefined);
         assert.isDefined(triedLexParse);
         expect(triedLexParse.kind).to.equal(PQP.ResultKind.Err);
     });
@@ -55,6 +55,7 @@ describe("workspaceCache", () => {
         const triedInspect: PQP.Task.TriedInspection | undefined = WorkspaceCache.maybeTriedInspection(
             document,
             postion,
+            undefined,
         );
         if (triedInspect) {
             expect(triedInspect.kind).to.equal(PQP.ResultKind.Ok);
@@ -68,6 +69,7 @@ describe("workspaceCache", () => {
         const triedInspect: PQP.Task.TriedInspection | undefined = WorkspaceCache.maybeTriedInspection(
             document,
             postion,
+            undefined,
         );
         if (triedInspect) {
             expect(triedInspect.kind).to.equal(PQP.ResultKind.Ok);


### PR DESCRIPTION
Passes through locale value so that validate() can return localized errors from the parser level. 

We are still missing localization for errors that come from the language-services level (#19).