### PR TITLE
Improve inspection of invoke expression

### DIFF
--- a/src/test/inspection.ts
+++ b/src/test/inspection.ts
@@ -6,7 +6,7 @@ import * as PQP from "@microsoft/powerquery-parser";
 import { assert, expect } from "chai";
 import "mocha";
 
-import { TestUtils } from ".";
+import { TestConstants, TestUtils } from ".";
 import { Inspection, InspectionUtils, Position, SignatureProviderContext } from "../powerquery-language-services";
 import { MockDocument } from "./mockDocument";
 
@@ -32,9 +32,9 @@ function assertIsPostionInBounds(
 // Unit testing for analysis operations related to power query parser inspection results.
 describe("InspectedInvokeExpression", () => {
     describe("getContextForInspected", () => {
-        it("Date.AddDays(d|,", () => {
+        it(`${TestConstants.TestLibraryName.SquareIfNumber}(1|,`, () => {
             const [document, position]: [MockDocument, Position] = TestUtils.createMockDocumentAndPosition(
-                "Date.AddDays(d|,",
+                `${TestConstants.TestLibraryName.SquareIfNumber}(1|,`,
             );
             const inspected: Inspection.Inspection = TestUtils.assertGetInspectionCacheItem(document, position);
             const maybeContext:
@@ -43,13 +43,13 @@ describe("InspectedInvokeExpression", () => {
             assert.isDefined(maybeContext);
             const context: SignatureProviderContext = maybeContext!;
 
-            expect(context.functionName).to.equal("Date.AddDays");
+            expect(context.functionName).to.equal(TestConstants.TestLibraryName.SquareIfNumber);
             expect(context.argumentOrdinal).to.equal(0);
         });
 
-        it("Date.AddDays(d,|", () => {
+        it(`${TestConstants.TestLibraryName.SquareIfNumber}(d,|`, () => {
             const [document, position]: [MockDocument, Position] = TestUtils.createMockDocumentAndPosition(
-                "Date.AddDays(d,|",
+                `${TestConstants.TestLibraryName.SquareIfNumber}(d,|`,
             );
             const inspected: Inspection.Inspection = TestUtils.assertGetInspectionCacheItem(document, position);
             const maybeContext:
@@ -58,13 +58,13 @@ describe("InspectedInvokeExpression", () => {
             assert.isDefined(maybeContext);
             const context: SignatureProviderContext = maybeContext!;
 
-            expect(context.functionName).to.equal("Date.AddDays");
+            expect(context.functionName).to.equal(TestConstants.TestLibraryName.SquareIfNumber);
             expect(context.argumentOrdinal).to.equal(1);
         });
 
-        it("Date.AddDays(d,1|", () => {
+        it(`${TestConstants.TestLibraryName.SquareIfNumber}(d,1|`, () => {
             const [document, position]: [MockDocument, Position] = TestUtils.createMockDocumentAndPosition(
-                "Date.AddDays(d,1|",
+                `${TestConstants.TestLibraryName.SquareIfNumber}(d,1|`,
             );
             const inspected: Inspection.Inspection = TestUtils.assertGetInspectionCacheItem(document, position);
             const maybeContext:
@@ -73,7 +73,7 @@ describe("InspectedInvokeExpression", () => {
             assert.isDefined(maybeContext);
             const context: SignatureProviderContext = maybeContext!;
 
-            expect(context.functionName).to.equal("Date.AddDays");
+            expect(context.functionName).to.equal(TestConstants.TestLibraryName.SquareIfNumber);
             expect(context.argumentOrdinal).to.equal(1);
         });
 

--- a/src/test/inspection/invokeExpression.ts
+++ b/src/test/inspection/invokeExpression.ts
@@ -436,7 +436,7 @@ describe(`subset Inspection - InvokeExpression`, () => {
             expectRequiredAndOptional_givenRequired(inspected);
         });
 
-        it("WIP expects required and optional, given required and optional", () => {
+        it("expects required and optional, given required and optional", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `${TestConstants.TestLibraryName.CombineNumberAndOptionalText}(1, "secondArg"|`,
             );
@@ -487,7 +487,7 @@ describe(`subset Inspection - InvokeExpression`, () => {
             expectText_givenNumber(inspected);
         });
 
-        it("nested invocations, expects no parameters, missing parameter", () => {
+        it("WIP nested invocations, expects no parameters, missing parameter", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `Foobar(${TestConstants.TestLibraryName.CreateFooAndBarRecord}(|), Baz`,
             );

--- a/src/test/inspection/invokeExpression.ts
+++ b/src/test/inspection/invokeExpression.ts
@@ -8,13 +8,9 @@ import { expect } from "chai";
 import "mocha";
 import { Inspection } from "../../powerquery-language-services";
 
-import { TestUtils } from "..";
+import { TestConstants, TestUtils } from "..";
+import { InvokeExpressionArguments } from "../../powerquery-language-services/inspection";
 import { InspectionSettings } from "../../powerquery-language-services/inspection/settings";
-
-const Settings: PQP.Settings & InspectionSettings = {
-    ...PQP.DefaultSettings,
-    maybeExternalTypeResolver: undefined,
-};
 
 function assertInvokeExpressionOk(
     settings: InspectionSettings,
@@ -56,75 +52,452 @@ function assertParseErrInvokeExpressionOk(
     return assertInvokeExpressionOk(settings, parseErr.nodeIdMapCollection, parseErr.leafNodeIds, position);
 }
 
+function expectNoParameters_givenExtraneousParameter(inspected: Inspection.InvokeExpression | undefined): void {
+    Assert.isDefined(inspected);
+
+    expect(inspected.maybeName).to.equal(TestConstants.TestLibraryName.CreateFooAndBarRecord);
+
+    Assert.isDefined(inspected.maybeArguments);
+    const invokeArgs: InvokeExpressionArguments = inspected.maybeArguments;
+
+    expect(invokeArgs.argumentOrdinal).to.equal(0);
+    // tslint:disable-next-line: chai-vague-errors
+    expect(invokeArgs.givenArgumentTypes).to.deep.equal([PQP.Language.TypeUtils.createNumberLiteral(false, `1`)]);
+    expect(invokeArgs.givenArguments.length).to.equal(1);
+    expect(invokeArgs.numMaxExpectedArguments).to.equal(0);
+    expect(invokeArgs.numMinExpectedArguments).to.equal(0);
+    expect(invokeArgs.typeCheck.extraneous.length).to.equal(1);
+    expect(invokeArgs.typeCheck.invalid.length).to.equal(0);
+    expect(invokeArgs.typeCheck.missing.length).to.equal(0);
+    expect(invokeArgs.typeCheck.valid.length).to.equal(0);
+
+    // tslint:disable-next-line: chai-vague-errors
+    expect(invokeArgs.typeCheck.extraneous.includes(0)).to.equal(true);
+}
+
+function expectText_givenNothing(inspected: Inspection.InvokeExpression | undefined): void {
+    Assert.isDefined(inspected);
+
+    expect(inspected.maybeName).to.equal(TestConstants.TestLibraryName.DuplicateText);
+
+    Assert.isDefined(inspected.maybeArguments);
+    const invokeArgs: InvokeExpressionArguments = inspected.maybeArguments;
+
+    expect(invokeArgs.argumentOrdinal).to.equal(0);
+    // tslint:disable-next-line: chai-vague-errors
+    expect(invokeArgs.givenArgumentTypes).to.deep.equal([]);
+    expect(invokeArgs.givenArguments.length).to.equal(0);
+    expect(invokeArgs.numMaxExpectedArguments).to.equal(1);
+    expect(invokeArgs.numMinExpectedArguments).to.equal(1);
+    expect(invokeArgs.typeCheck.extraneous.length).to.equal(0);
+    expect(invokeArgs.typeCheck.invalid.length).to.equal(0);
+    expect(invokeArgs.typeCheck.missing.length).to.equal(1);
+    expect(invokeArgs.typeCheck.valid.length).to.equal(0);
+
+    expect(invokeArgs.typeCheck.missing).to.deep.equal([0]);
+}
+
+function expectText_givenText(inspected: Inspection.InvokeExpression | undefined): void {
+    Assert.isDefined(inspected);
+
+    expect(inspected.maybeName).to.equal(TestConstants.TestLibraryName.DuplicateText);
+
+    Assert.isDefined(inspected.maybeArguments);
+    const invokeArgs: InvokeExpressionArguments = inspected.maybeArguments;
+
+    expect(invokeArgs.argumentOrdinal).to.equal(0);
+    // tslint:disable-next-line: chai-vague-errors
+    expect(invokeArgs.givenArgumentTypes).to.deep.equal([PQP.Language.TypeUtils.createTextLiteral(false, `"foo"`)]);
+    expect(invokeArgs.givenArguments.length).to.equal(1);
+    expect(invokeArgs.numMaxExpectedArguments).to.equal(1);
+    expect(invokeArgs.numMinExpectedArguments).to.equal(1);
+    expect(invokeArgs.typeCheck.extraneous.length).to.equal(0);
+    expect(invokeArgs.typeCheck.invalid.length).to.equal(0);
+    expect(invokeArgs.typeCheck.missing.length).to.equal(0);
+    expect(invokeArgs.typeCheck.valid.length).to.equal(1);
+
+    expect(invokeArgs.typeCheck.valid).to.deep.equal([0]);
+}
+
+function expectNumberParameter_missingParameter(inspected: Inspection.InvokeExpression | undefined): void {
+    Assert.isDefined(inspected);
+
+    expect(inspected.maybeName).to.equal(TestConstants.TestLibraryName.SquareIfNumber);
+
+    Assert.isDefined(inspected.maybeArguments);
+    const invokeArgs: InvokeExpressionArguments = inspected.maybeArguments;
+
+    expect(invokeArgs.argumentOrdinal).to.equal(0);
+    // tslint:disable-next-line: chai-vague-errors
+    expect(invokeArgs.givenArgumentTypes).to.deep.equal([]);
+    expect(invokeArgs.givenArguments.length).to.equal(0);
+    expect(invokeArgs.numMaxExpectedArguments).to.equal(1);
+    expect(invokeArgs.numMinExpectedArguments).to.equal(1);
+    expect(invokeArgs.typeCheck.extraneous.length).to.equal(0);
+    expect(invokeArgs.typeCheck.invalid.length).to.equal(0);
+    expect(invokeArgs.typeCheck.missing.length).to.equal(1);
+    expect(invokeArgs.typeCheck.valid.length).to.equal(0);
+
+    // tslint:disable-next-line: chai-vague-errors
+    expect(invokeArgs.typeCheck.missing.includes(0)).to.equal(true);
+}
+
+function expectNoParameter_givenNoParameter(inspected: Inspection.InvokeExpression | undefined): void {
+    Assert.isDefined(inspected);
+
+    expect(inspected.maybeName).to.equal(TestConstants.TestLibraryName.CreateFooAndBarRecord);
+
+    Assert.isDefined(inspected.maybeArguments);
+    const invokeArgs: InvokeExpressionArguments = inspected.maybeArguments;
+
+    expect(invokeArgs.argumentOrdinal).to.equal(0);
+    expect(invokeArgs.givenArgumentTypes).to.deep.equal([]);
+    expect(invokeArgs.givenArguments.length).to.equal(0);
+    expect(invokeArgs.numMaxExpectedArguments).to.equal(0);
+    expect(invokeArgs.numMinExpectedArguments).to.equal(0);
+    expect(invokeArgs.typeCheck.extraneous.length).to.equal(0);
+    expect(invokeArgs.typeCheck.invalid.length).to.equal(0);
+    expect(invokeArgs.typeCheck.missing.length).to.equal(0);
+    expect(invokeArgs.typeCheck.valid.length).to.equal(0);
+}
+
+function expectRequiredAndOptional_givenRequired(inspected: Inspection.InvokeExpression | undefined): void {
+    Assert.isDefined(inspected);
+
+    expect(inspected.maybeName).to.equal(TestConstants.TestLibraryName.CombineNumberAndOptionalText);
+
+    Assert.isDefined(inspected.maybeArguments);
+    const invokeArgs: InvokeExpressionArguments = inspected.maybeArguments;
+
+    expect(invokeArgs.argumentOrdinal).to.equal(0);
+    // tslint:disable-next-line: chai-vague-errors
+    expect(invokeArgs.givenArgumentTypes).to.deep.equal([PQP.Language.TypeUtils.createNumberLiteral(false, "1")]);
+    expect(invokeArgs.givenArguments.length).to.equal(1);
+    expect(invokeArgs.numMaxExpectedArguments).to.equal(2);
+    expect(invokeArgs.numMinExpectedArguments).to.equal(1);
+    expect(invokeArgs.typeCheck.extraneous.length).to.equal(0);
+    expect(invokeArgs.typeCheck.invalid.length).to.equal(0);
+    expect(invokeArgs.typeCheck.missing.length).to.equal(0);
+    expect(invokeArgs.typeCheck.valid.length).to.equal(2);
+
+    expect(invokeArgs.typeCheck.valid).to.deep.equal([0, 1]);
+}
+
+function expectRequiredAndOptional_givenRequiredAndOptional(inspected: Inspection.InvokeExpression | undefined): void {
+    Assert.isDefined(inspected);
+
+    expect(inspected.maybeName).to.equal(TestConstants.TestLibraryName.CombineNumberAndOptionalText);
+
+    Assert.isDefined(inspected.maybeArguments);
+
+    const invokeArgs: InvokeExpressionArguments = inspected.maybeArguments;
+
+    expect(invokeArgs.argumentOrdinal).to.equal(1);
+    // tslint:disable-next-line: chai-vague-errors
+    expect(invokeArgs.givenArgumentTypes).to.deep.equal([
+        PQP.Language.TypeUtils.createNumberLiteral(false, "1"),
+        PQP.Language.TypeUtils.createTextLiteral(false, `"secondArg"`),
+    ]);
+    expect(invokeArgs.givenArguments.length).to.equal(2);
+    expect(invokeArgs.numMaxExpectedArguments).to.equal(2);
+    expect(invokeArgs.numMinExpectedArguments).to.equal(1);
+    expect(invokeArgs.typeCheck.extraneous.length).to.equal(0);
+    expect(invokeArgs.typeCheck.invalid.length).to.equal(0);
+    expect(invokeArgs.typeCheck.missing.length).to.equal(0);
+    expect(invokeArgs.typeCheck.valid.length).to.equal(2);
+
+    expect(invokeArgs.typeCheck.valid).to.deep.equal([0, 1]);
+}
+
+function expectText_givenNumber(inspected: Inspection.InvokeExpression | undefined): void {
+    const expectedArgument: PQP.Language.Type.FunctionParameter = PQP.Assert.asDefined(
+        TestConstants.DuplicateTextDefinedFunction.parameters[0],
+    );
+    const actualArgument: PQP.Language.Type.NumberLiteral = PQP.Language.TypeUtils.createNumberLiteral(false, "1");
+
+    Assert.isDefined(inspected);
+
+    expect(inspected.maybeName).to.equal(TestConstants.TestLibraryName.DuplicateText);
+
+    Assert.isDefined(inspected.maybeArguments);
+    const invokeArgs: InvokeExpressionArguments = inspected.maybeArguments;
+
+    expect(invokeArgs.argumentOrdinal).to.equal(0);
+    // tslint:disable-next-line: chai-vague-errors
+    expect(invokeArgs.givenArgumentTypes).to.deep.equal([actualArgument]);
+    expect(invokeArgs.givenArguments.length).to.equal(1);
+    expect(invokeArgs.numMaxExpectedArguments).to.equal(1);
+    expect(invokeArgs.numMinExpectedArguments).to.equal(1);
+    expect(invokeArgs.typeCheck.extraneous.length).to.equal(0);
+    expect(invokeArgs.typeCheck.invalid.length).to.equal(1);
+    expect(invokeArgs.typeCheck.missing.length).to.equal(0);
+    expect(invokeArgs.typeCheck.valid.length).to.equal(0);
+
+    const invalidArgument: PQP.Language.TypeUtils.Mismatch<
+        number,
+        PQP.Language.Type.PowerQueryType | undefined,
+        PQP.Language.Type.FunctionParameter
+    > = PQP.Assert.asDefined(
+        invokeArgs.typeCheck.invalid.find(mismatch => mismatch.key === 0),
+        "expected the 0th argument to be invalid",
+    );
+    expect(invalidArgument).to.deep.equal({
+        key: 0,
+        expected: expectedArgument,
+        actual: actualArgument,
+    });
+}
+
+function expectNestedInvocation(inspected: Inspection.InvokeExpression | undefined): void {
+    Assert.isDefined(inspected);
+
+    expect(inspected.maybeName).to.equal(TestConstants.TestLibraryName.CreateFooAndBarRecord);
+
+    Assert.isDefined(inspected.maybeArguments);
+    const invokeArgs: InvokeExpressionArguments = inspected.maybeArguments;
+
+    expect(invokeArgs.argumentOrdinal).to.equal(0);
+    // tslint:disable-next-line: chai-vague-errors
+    expect(invokeArgs.givenArgumentTypes).to.deep.equal([]);
+    expect(invokeArgs.givenArguments.length).to.equal(0);
+    expect(invokeArgs.numMaxExpectedArguments).to.equal(0);
+    expect(invokeArgs.numMinExpectedArguments).to.equal(0);
+    expect(invokeArgs.typeCheck.extraneous.length).to.equal(0);
+    expect(invokeArgs.typeCheck.invalid.length).to.equal(0);
+    expect(invokeArgs.typeCheck.missing.length).to.equal(0);
+    expect(invokeArgs.typeCheck.valid.length).to.equal(0);
+}
+
 describe(`subset Inspection - InvokeExpression`, () => {
-    it("single invoke expression, no parameters", () => {
-        const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition("Foo(|)");
-        const inspected: Inspection.InvokeExpression | undefined = assertParseOkInvokeExpressionOk(
-            Settings,
-            text,
-            position,
-        );
-        Assert.isDefined(inspected);
+    describe(`parse Ok`, () => {
+        it("expects no parameters, given no parameters", () => {
+            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                `${TestConstants.TestLibraryName.CreateFooAndBarRecord}(|)`,
+            );
+            const inspected: Inspection.InvokeExpression | undefined = assertParseOkInvokeExpressionOk(
+                TestConstants.SimpleSettings,
+                text,
+                position,
+            );
 
-        expect(inspected.maybeName).to.equal("Foo");
-        expect(inspected.maybeArguments).to.equal(undefined, "expected no arguments");
+            expectNoParameter_givenNoParameter(inspected);
+        });
+
+        it("expects no parameters, given extraneous parameter", () => {
+            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                `${TestConstants.TestLibraryName.CreateFooAndBarRecord}(1|)`,
+            );
+            const inspected: Inspection.InvokeExpression | undefined = assertParseOkInvokeExpressionOk(
+                TestConstants.SimpleSettings,
+                text,
+                position,
+            );
+            expectNoParameters_givenExtraneousParameter(inspected);
+        });
+
+        it("expect number parameter, missing parameter", () => {
+            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                `${TestConstants.TestLibraryName.SquareIfNumber}(|)`,
+            );
+            const inspected: Inspection.InvokeExpression | undefined = assertParseOkInvokeExpressionOk(
+                TestConstants.SimpleSettings,
+                text,
+                position,
+            );
+            expectNumberParameter_missingParameter(inspected);
+        });
+
+        it("expects required and optional, given required", () => {
+            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                `${TestConstants.TestLibraryName.CombineNumberAndOptionalText}(1|)`,
+            );
+            const inspected: Inspection.InvokeExpression | undefined = assertParseOkInvokeExpressionOk(
+                TestConstants.SimpleSettings,
+                text,
+                position,
+            );
+
+            expectRequiredAndOptional_givenRequired(inspected);
+        });
+
+        it("expects required and optional, given required and optional", () => {
+            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                `${TestConstants.TestLibraryName.CombineNumberAndOptionalText}(1, "secondArg"|)`,
+            );
+            const inspected: Inspection.InvokeExpression | undefined = assertParseOkInvokeExpressionOk(
+                TestConstants.SimpleSettings,
+                text,
+                position,
+            );
+
+            expectRequiredAndOptional_givenRequiredAndOptional(inspected);
+        });
+
+        it("expects text, given text", () => {
+            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                `${TestConstants.TestLibraryName.DuplicateText}("foo"|)`,
+            );
+            const inspected: Inspection.InvokeExpression | undefined = assertParseOkInvokeExpressionOk(
+                TestConstants.SimpleSettings,
+                text,
+                position,
+            );
+
+            expectText_givenText(inspected);
+        });
+
+        it("expects text, given nothing", () => {
+            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                `${TestConstants.TestLibraryName.DuplicateText}(|)`,
+            );
+            const inspected: Inspection.InvokeExpression | undefined = assertParseOkInvokeExpressionOk(
+                TestConstants.SimpleSettings,
+                text,
+                position,
+            );
+            expectText_givenNothing(inspected);
+        });
+
+        it("expects text, given number", () => {
+            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                `${TestConstants.TestLibraryName.DuplicateText}(1|)`,
+            );
+            const inspected: Inspection.InvokeExpression | undefined = assertParseOkInvokeExpressionOk(
+                TestConstants.SimpleSettings,
+                text,
+                position,
+            );
+
+            expectText_givenNumber(inspected);
+        });
+
+        it("nested invocations, expects no parameters, missing parameter", () => {
+            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                `Foobar(${TestConstants.TestLibraryName.CreateFooAndBarRecord}(|), Baz)`,
+            );
+            const inspected: Inspection.InvokeExpression | undefined = assertParseOkInvokeExpressionOk(
+                TestConstants.SimpleSettings,
+                text,
+                position,
+            );
+
+            expectNestedInvocation(inspected);
+        });
     });
 
-    it("multiple invoke expression, no parameters", () => {
-        const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition("Bar(Foo(|))");
-        const inspected: Inspection.InvokeExpression | undefined = assertParseOkInvokeExpressionOk(
-            Settings,
-            text,
-            position,
-        );
-        Assert.isDefined(inspected);
+    describe(`parse error`, () => {
+        it("expects no parameters, given no parameters", () => {
+            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                `${TestConstants.TestLibraryName.CreateFooAndBarRecord}(|`,
+            );
+            const inspected: Inspection.InvokeExpression | undefined = assertParseErrInvokeExpressionOk(
+                TestConstants.SimpleSettings,
+                text,
+                position,
+            );
 
-        expect(inspected.maybeName).to.equal("Foo");
-        expect(inspected.maybeArguments).to.equal(undefined, "expected no arguments");
-    });
+            expectNoParameter_givenNoParameter(inspected);
+        });
 
-    it("single invoke expression - Foo(a|)", () => {
-        const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition("Foo(a|)");
-        const inspected: Inspection.InvokeExpression | undefined = assertParseOkInvokeExpressionOk(
-            Settings,
-            text,
-            position,
-        );
-        Assert.isDefined(inspected);
+        it("expects no parameters, given extraneous parameter", () => {
+            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                `${TestConstants.TestLibraryName.CreateFooAndBarRecord}(1|`,
+            );
+            const inspected: Inspection.InvokeExpression | undefined = assertParseErrInvokeExpressionOk(
+                TestConstants.SimpleSettings,
+                text,
+                position,
+            );
+            expectNoParameters_givenExtraneousParameter(inspected);
+        });
 
-        expect(inspected.maybeName).to.equal("Foo");
-        expect(inspected.maybeArguments).not.equal(undefined, "expected arguments");
-        expect(inspected.maybeArguments?.numArguments).equal(1);
-        expect(inspected.maybeArguments?.argumentOrdinal).equal(0);
-    });
+        it("expect number parameter, missing parameter", () => {
+            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                `${TestConstants.TestLibraryName.SquareIfNumber}(|`,
+            );
+            const inspected: Inspection.InvokeExpression | undefined = assertParseErrInvokeExpressionOk(
+                TestConstants.SimpleSettings,
+                text,
+                position,
+            );
+            expectNumberParameter_missingParameter(inspected);
+        });
 
-    it("single invoke expression - Foo(a|,)", () => {
-        const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition("Foo(a|,)");
-        const inspected: Inspection.InvokeExpression | undefined = assertParseErrInvokeExpressionOk(
-            Settings,
-            text,
-            position,
-        );
-        Assert.isDefined(inspected);
+        it("expects required and optional, given required", () => {
+            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                `${TestConstants.TestLibraryName.CombineNumberAndOptionalText}(1|`,
+            );
+            const inspected: Inspection.InvokeExpression | undefined = assertParseErrInvokeExpressionOk(
+                TestConstants.SimpleSettings,
+                text,
+                position,
+            );
 
-        expect(inspected.maybeName).to.equal("Foo");
-        expect(inspected.maybeArguments).not.equal(undefined, "expected arguments");
-        expect(inspected.maybeArguments?.numArguments).equal(2);
-        expect(inspected.maybeArguments?.argumentOrdinal).equal(0);
-    });
+            expectRequiredAndOptional_givenRequired(inspected);
+        });
 
-    it("single invoke expression - Foo(a,|)", () => {
-        const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition("Foo(a,|)");
-        const inspected: Inspection.InvokeExpression | undefined = assertParseErrInvokeExpressionOk(
-            Settings,
-            text,
-            position,
-        );
-        Assert.isDefined(inspected);
+        it("WIP expects required and optional, given required and optional", () => {
+            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                `${TestConstants.TestLibraryName.CombineNumberAndOptionalText}(1, "secondArg"|`,
+            );
+            const inspected: Inspection.InvokeExpression | undefined = assertParseErrInvokeExpressionOk(
+                TestConstants.SimpleSettings,
+                text,
+                position,
+            );
 
-        expect(inspected.maybeName).to.equal("Foo");
-        expect(inspected.maybeArguments).not.equal(undefined, "expected arguments");
-        expect(inspected.maybeArguments?.numArguments).equal(2);
-        expect(inspected.maybeArguments?.argumentOrdinal).equal(1);
+            expectRequiredAndOptional_givenRequiredAndOptional(inspected);
+        });
+
+        it("expects text, given text", () => {
+            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                `${TestConstants.TestLibraryName.DuplicateText}("foo"|`,
+            );
+            const inspected: Inspection.InvokeExpression | undefined = assertParseErrInvokeExpressionOk(
+                TestConstants.SimpleSettings,
+                text,
+                position,
+            );
+
+            expectText_givenText(inspected);
+        });
+
+        it("expects text, given nothing", () => {
+            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                `${TestConstants.TestLibraryName.DuplicateText}(|`,
+            );
+            const inspected: Inspection.InvokeExpression | undefined = assertParseErrInvokeExpressionOk(
+                TestConstants.SimpleSettings,
+                text,
+                position,
+            );
+            expectText_givenNothing(inspected);
+        });
+
+        it("expects text, given number", () => {
+            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                `${TestConstants.TestLibraryName.DuplicateText}(1|`,
+            );
+            const inspected: Inspection.InvokeExpression | undefined = assertParseErrInvokeExpressionOk(
+                TestConstants.SimpleSettings,
+                text,
+                position,
+            );
+
+            expectText_givenNumber(inspected);
+        });
+
+        it("nested invocations, expects no parameters, missing parameter", () => {
+            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                `Foobar(${TestConstants.TestLibraryName.CreateFooAndBarRecord}(|), Baz`,
+            );
+            const inspected: Inspection.InvokeExpression | undefined = assertParseErrInvokeExpressionOk(
+                TestConstants.SimpleSettings,
+                text,
+                position,
+            );
+
+            expectNestedInvocation(inspected);
+        });
     });
 });

--- a/src/test/testConstants.ts
+++ b/src/test/testConstants.ts
@@ -25,11 +25,69 @@ export const NoOpLibrary: Library.ILibrary = {
     libraryDefinitions: new Map(),
 };
 
+export const CreateFooAndBarRecordDefinedFunction: PQP.Language.Type.DefinedFunction = PQP.Language.TypeUtils.createDefinedFunction(
+    false,
+    [],
+    PQP.Language.TypeUtils.createDefinedRecord(
+        false,
+        new Map<string, PQP.Language.Type.PowerQueryType>([
+            ["foo", PQP.Language.TypeUtils.createTextLiteral(false, `"fooString"`)],
+            ["bar", PQP.Language.TypeUtils.createTextLiteral(false, `"barString"`)],
+        ]),
+        false,
+    ),
+);
+
+export const CombineNumberAndOptionalTextDefinedFunction: PQP.Language.Type.DefinedFunction = PQP.Language.TypeUtils.createDefinedFunction(
+    false,
+    [
+        {
+            isNullable: false,
+            isOptional: false,
+            nameLiteral: "firstArg",
+            maybeType: PQP.Language.Type.TypeKind.Number,
+        },
+        {
+            isNullable: false,
+            isOptional: true,
+            nameLiteral: "secondArg",
+            maybeType: PQP.Language.Type.TypeKind.Text,
+        },
+    ],
+    PQP.Language.Type.NullInstance,
+);
+
+export const SquareIfNumberDefinedFunction: PQP.Language.Type.DefinedFunction = PQP.Language.TypeUtils.createDefinedFunction(
+    false,
+    [
+        {
+            isNullable: false,
+            isOptional: false,
+            maybeType: undefined,
+            nameLiteral: "x",
+        },
+    ],
+    PQP.Language.Type.AnyInstance,
+);
+
+export const DuplicateTextDefinedFunction: PQP.Language.Type.DefinedFunction = PQP.Language.TypeUtils.createDefinedFunction(
+    false,
+    [
+        {
+            isNullable: false,
+            isOptional: false,
+            maybeType: PQP.Language.Type.TypeKind.Text,
+            nameLiteral: "txt",
+        },
+    ],
+    PQP.Language.Type.TextInstance,
+);
+
 export const SimpleLibraryDefinitions: Library.LibraryDefinitions = new Map<string, Library.TLibraryDefinition>([
     [
         TestLibraryName.CreateFooAndBarRecord,
         LibraryUtils.createFunctionDefinition(
-            PQP.Language.Type.FunctionInstance,
+            CreateFooAndBarRecordDefinedFunction,
             `The name is ${TestLibraryName.CreateFooAndBarRecord}`,
             TestLibraryName.CreateFooAndBarRecord,
             PQP.Language.Type.RecordInstance,
@@ -46,6 +104,31 @@ export const SimpleLibraryDefinitions: Library.LibraryDefinitions = new Map<stri
         ),
     ],
     [
+        TestLibraryName.CombineNumberAndOptionalText,
+        LibraryUtils.createFunctionDefinition(
+            CombineNumberAndOptionalTextDefinedFunction,
+            `The name is ${TestLibraryName.CombineNumberAndOptionalText}`,
+            TestLibraryName.CombineNumberAndOptionalText,
+            PQP.Language.Type.NullInstance,
+            [
+                {
+                    isNullable: false,
+                    isOptional: false,
+                    label: "firstArg",
+                    maybeDocumentation: undefined,
+                    typeKind: PQP.Language.Type.TypeKind.Number,
+                },
+                {
+                    isNullable: false,
+                    isOptional: true,
+                    label: "secondArg",
+                    maybeDocumentation: undefined,
+                    typeKind: PQP.Language.Type.TypeKind.Text,
+                },
+            ],
+        ),
+    ],
+    [
         TestLibraryName.NumberOne,
         LibraryUtils.createConstantDefinition(
             PQP.Language.TypeUtils.createNumberLiteral(false, "1"),
@@ -57,21 +140,7 @@ export const SimpleLibraryDefinitions: Library.LibraryDefinitions = new Map<stri
     [
         TestLibraryName.SquareIfNumber,
         LibraryUtils.createFunctionDefinition(
-            PQP.Language.TypeUtils.createDefinedFunction(
-                false,
-                [
-                    {
-                        isNullable: false,
-                        isOptional: false,
-                        maybeType: PQP.Language.Type.TypeKind.Any,
-                        nameLiteral: "x",
-                    },
-                ],
-                PQP.Language.TypeUtils.createAnyUnion([
-                    PQP.Language.Type.NumberInstance,
-                    PQP.Language.Type.AnyInstance,
-                ]),
-            ),
+            SquareIfNumberDefinedFunction,
             `The name is ${TestLibraryName.SquareIfNumber}`,
             TestLibraryName.SquareIfNumber,
             PQP.Language.Type.AnyInstance,
@@ -81,7 +150,7 @@ export const SimpleLibraryDefinitions: Library.LibraryDefinitions = new Map<stri
                     isOptional: false,
                     label: "x",
                     maybeDocumentation:
-                        "If the argument is a number then multiply it by itself, otehrwise return argument as-is.",
+                        "If the argument is a number then multiply it by itself, otherwise return argument as-is.",
                     typeKind: PQP.Language.Type.TypeKind.Any,
                 },
             ],
@@ -122,18 +191,13 @@ export const SimpleExternalTypeResolver: Inspection.ExternalType.TExternalTypeRe
         case Inspection.ExternalType.ExternalTypeRequestKind.Value:
             switch (request.identifierLiteral) {
                 case TestLibraryName.CreateFooAndBarRecord:
-                    return PQP.Language.TypeUtils.createDefinedFunction(
-                        false,
-                        [],
-                        PQP.Language.TypeUtils.createDefinedRecord(
-                            false,
-                            new Map<string, PQP.Language.Type.PowerQueryType>([
-                                ["foo", PQP.Language.TypeUtils.createTextLiteral(false, `"fooString"`)],
-                                ["bar", PQP.Language.TypeUtils.createTextLiteral(false, `"barString"`)],
-                            ]),
-                            false,
-                        ),
-                    );
+                    return CreateFooAndBarRecordDefinedFunction;
+
+                case TestLibraryName.CombineNumberAndOptionalText:
+                    return CombineNumberAndOptionalTextDefinedFunction;
+
+                case TestLibraryName.DuplicateText:
+                    return DuplicateTextDefinedFunction;
 
                 case TestLibraryName.Number:
                     return PQP.Language.Type.NumberInstance;
@@ -142,18 +206,7 @@ export const SimpleExternalTypeResolver: Inspection.ExternalType.TExternalTypeRe
                     return PQP.Language.TypeUtils.createNumberLiteral(false, "1");
 
                 case TestLibraryName.SquareIfNumber:
-                    return PQP.Language.TypeUtils.createDefinedFunction(
-                        false,
-                        [
-                            {
-                                isNullable: false,
-                                isOptional: false,
-                                maybeType: undefined,
-                                nameLiteral: "x",
-                            },
-                        ],
-                        PQP.Language.Type.AnyInstance,
-                    );
+                    return SquareIfNumberDefinedFunction;
 
                 default:
                     return undefined;
@@ -162,6 +215,11 @@ export const SimpleExternalTypeResolver: Inspection.ExternalType.TExternalTypeRe
         default:
             throw Assert.isNever(request);
     }
+};
+
+export const SimpleSettings: PQP.Settings & Inspection.InspectionSettings = {
+    ...DefaultSettings,
+    maybeExternalTypeResolver: SimpleExternalTypeResolver,
 };
 
 export const SimpleLibrary: Library.ILibrary = {
@@ -179,7 +237,9 @@ export const SimpleLibraryAnalysisOptions: AnalysisOptions = {
 
 export const enum TestLibraryName {
     CreateFooAndBarRecord = "Test.CreateFooAndBarRecord",
-    SquareIfNumber = "Test.SquareIfNumber",
+    CombineNumberAndOptionalText = "Test.CombineNumberAndOptionalText",
+    DuplicateText = "Test.DuplicateText",
     Number = "Test.Number",
     NumberOne = "Test.NumberOne",
+    SquareIfNumber = "Test.SquareIfNumber",
 }

--- a/src/test/testUtils/testUtils.ts
+++ b/src/test/testUtils/testUtils.ts
@@ -127,11 +127,6 @@ export async function createSignatureHelp(
     return createAnalysis(text, maybeLibrary, maybeAnalysisOptions).getSignatureHelp();
 }
 
-// export function dumpNodeToTraceFile(node: PQP.Language.Ast.INode, filePath: string): void {
-//     const asJson: string = JSON.stringify(node);
-//     File.writeFileSync(filePath, asJson);
-// }
-
 function createFileAnalysis(
     fileName: string,
     position: Position,


### PR DESCRIPTION
Improves the introspection on invoke expression:

```
// old
export interface InvokeExpressionArgs {
    readonly numArguments: number;
    readonly argumentOrdinal: number;
}

// new 
export interface InvokeExpressionArguments {
    readonly numMaxExpectedArguments: number;
    readonly numMinExpectedArguments: number;
    // numArguments is replaced by this. It's the TXorNodes given as arguments.
    // Eventually it'll be used for VSCode diagnostic errors.
    readonly givenArguments: ReadonlyArray<PQP.Parser.TXorNode>;
    // The given argument above turned into types.
    // Eventually it'll be used for VSCode diagnostic errors.
    readonly givenArgumentTypes: ReadonlyArray<PQP.Language.Type.PowerQueryType>;
    // same as before
    readonly argumentOrdinal: number;
    // a type check on the given arguments against the function's parameters
    readonly typeCheck: PQP.Language.TypeUtils.CheckedInvocation;
}
```

I haven't integrate the enhancements into VSCode diagnostic errors yet. Theoretically this change introduces no behavior changes. I plan on developing and merging those changes in another branch to keep PR sizes down.