### PR TITLE
Add jaro-winkler for fuzzy autocomplete matching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/powerquery-language-services",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "author": "Microsoft",
     "license": "MIT",
     "scripts": {

--- a/src/powerquery-language-services/analysis/analysis.ts
+++ b/src/powerquery-language-services/analysis/analysis.ts
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import type { CompletionItem, Hover, SignatureHelp } from "vscode-languageserver-types";
+import type { Hover, SignatureHelp } from "vscode-languageserver-types";
+import { Inspection } from "..";
 
 import { IDisposable } from "../commonTypes";
 
 export interface Analysis extends IDisposable {
-    getCompletionItems(): Promise<CompletionItem[]>;
+    getAutocompleteItems(): Promise<Inspection.AutocompleteItem[]>;
     getHover(): Promise<Hover>;
     getSignatureHelp(): Promise<SignatureHelp>;
 }

--- a/src/powerquery-language-services/analysis/analysisBase.ts
+++ b/src/powerquery-language-services/analysis/analysisBase.ts
@@ -9,7 +9,7 @@ import * as InspectionUtils from "../inspectionUtils";
 
 import { CommonTypesUtils, Inspection } from "..";
 import { EmptyHover, EmptySignatureHelp } from "../commonTypes";
-import type { AutocompleteItem } from "../inspection";
+import { AutocompleteItem, AutocompleteItemUtils } from "../inspection";
 import type { ILibrary } from "../library/library";
 import { LanguageAutocompleteItemProvider, LibrarySymbolProvider, LocalDocumentSymbolProvider } from "../providers";
 import type {
@@ -87,7 +87,7 @@ export abstract class AnalysisBase implements Analysis {
             }
         }
 
-        return partial;
+        return partial.sort(AutocompleteItemUtils.compareFn);
     }
 
     public async getHover(): Promise<Hover> {

--- a/src/powerquery-language-services/analysis/analysisBase.ts
+++ b/src/powerquery-language-services/analysis/analysisBase.ts
@@ -3,17 +3,18 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
-import type { CompletionItem, Hover, Position, Range, SignatureHelp } from "vscode-languageserver-types";
+import type { Hover, Position, Range, SignatureHelp } from "vscode-languageserver-types";
 
 import * as InspectionUtils from "../inspectionUtils";
 
 import { CommonTypesUtils, Inspection } from "..";
-import { EmptyCompletionItems, EmptyHover, EmptySignatureHelp } from "../commonTypes";
-import { ILibrary } from "../library/library";
-import { LanguageCompletionItemProvider, LibrarySymbolProvider, LocalDocumentSymbolProvider } from "../providers";
+import { EmptyHover, EmptySignatureHelp } from "../commonTypes";
+import type { AutocompleteItem } from "../inspection";
+import type { ILibrary } from "../library/library";
+import { LanguageAutocompleteItemProvider, LibrarySymbolProvider, LocalDocumentSymbolProvider } from "../providers";
 import type {
-    CompletionItemProvider,
-    CompletionItemProviderContext,
+    AutocompleteItemProvider,
+    AutocompleteItemProviderContext,
     HoverProvider,
     HoverProviderContext,
     ISymbolProvider,
@@ -21,11 +22,11 @@ import type {
     SignatureProviderContext,
 } from "../providers/commonTypes";
 import { WorkspaceCache, WorkspaceCacheUtils } from "../workspaceCache";
-import { Analysis } from "./analysis";
-import { AnalysisOptions } from "./analysisOptions";
+import type { Analysis } from "./analysis";
+import type { AnalysisOptions } from "./analysisOptions";
 
 export abstract class AnalysisBase implements Analysis {
-    protected languageCompletionItemProvider: CompletionItemProvider;
+    protected languageAutocompleteItemProvider: AutocompleteItemProvider;
     protected librarySymbolProvider: ISymbolProvider;
     protected localDocumentSymbolProvider: ISymbolProvider;
 
@@ -35,10 +36,10 @@ export abstract class AnalysisBase implements Analysis {
         library: ILibrary,
         protected options: AnalysisOptions,
     ) {
-        this.languageCompletionItemProvider =
-            options.createLanguageCompletionItemProviderFn !== undefined
-                ? options.createLanguageCompletionItemProviderFn()
-                : new LanguageCompletionItemProvider(maybeInspectionCacheItem);
+        this.languageAutocompleteItemProvider =
+            options.createLanguageAutocompleteItemProviderFn !== undefined
+                ? options.createLanguageAutocompleteItemProviderFn()
+                : new LanguageAutocompleteItemProvider(maybeInspectionCacheItem);
 
         this.librarySymbolProvider =
             options.createLibrarySymbolProviderFn !== undefined
@@ -51,8 +52,8 @@ export abstract class AnalysisBase implements Analysis {
                 : new LocalDocumentSymbolProvider(library, maybeInspectionCacheItem);
     }
 
-    public async getCompletionItems(): Promise<CompletionItem[]> {
-        let context: CompletionItemProviderContext = {};
+    public async getAutocompleteItems(): Promise<AutocompleteItem[]> {
+        let context: AutocompleteItemProviderContext = {};
 
         const maybeToken:
             | PQP.Language.Ast.Identifier
@@ -69,18 +70,18 @@ export abstract class AnalysisBase implements Analysis {
         // TODO: intellisense improvements
         // - honor expected data type
         // - only include current query name after @
-        const [languageCompletionItemProvider, libraryResponse, localDocumentResponse] = await Promise.all(
-            AnalysisBase.createCompletionItemCalls(context, [
-                this.languageCompletionItemProvider,
+        const [languageResponse, libraryResponse, localDocumentResponse] = await Promise.all(
+            AnalysisBase.createAutocompleteItemCalls(context, [
+                this.languageAutocompleteItemProvider,
                 this.librarySymbolProvider,
                 this.localDocumentSymbolProvider,
             ]),
         );
 
-        const partial: CompletionItem[] = [];
-        for (const collection of [localDocumentResponse, languageCompletionItemProvider, libraryResponse]) {
+        const partial: AutocompleteItem[] = [];
+        for (const collection of [localDocumentResponse, languageResponse, libraryResponse]) {
             for (const item of collection) {
-                if (partial.find((partialItem: CompletionItem) => partialItem.label === item.label) === undefined) {
+                if (partial.find((partialItem: AutocompleteItem) => partialItem.label === item.label) === undefined) {
                     partial.push(item);
                 }
             }
@@ -163,14 +164,14 @@ export abstract class AnalysisBase implements Analysis {
         return defaultReturnValue;
     }
 
-    private static createCompletionItemCalls(
-        context: CompletionItemProviderContext,
-        providers: ReadonlyArray<CompletionItemProvider>,
-    ): ReadonlyArray<Promise<ReadonlyArray<CompletionItem>>> {
+    private static createAutocompleteItemCalls(
+        context: AutocompleteItemProviderContext,
+        providers: ReadonlyArray<AutocompleteItemProvider>,
+    ): ReadonlyArray<Promise<ReadonlyArray<AutocompleteItem>>> {
         // TODO: add tracing to the catch case
         return providers.map(provider =>
-            provider.getCompletionItems(context).catch(() => {
-                return EmptyCompletionItems;
+            provider.getAutocompleteItems(context).catch(() => {
+                return [];
             }),
         );
     }

--- a/src/powerquery-language-services/analysis/analysisOptions.ts
+++ b/src/powerquery-language-services/analysis/analysisOptions.ts
@@ -2,11 +2,11 @@
 // Licensed under the MIT license.
 
 import { ILibrary } from "../library/library";
-import { CompletionItemProvider, ISymbolProvider } from "../providers/commonTypes";
+import { AutocompleteItemProvider, ISymbolProvider } from "../providers/commonTypes";
 import { WorkspaceCache } from "../workspaceCache";
 
 export interface AnalysisOptions {
-    readonly createLanguageCompletionItemProviderFn?: () => CompletionItemProvider;
+    readonly createLanguageAutocompleteItemProviderFn?: () => AutocompleteItemProvider;
     readonly createLibrarySymbolProviderFn?: (library: ILibrary) => ISymbolProvider;
     readonly createLocalDocumentSymbolProviderFn?: (
         library: ILibrary,

--- a/src/powerquery-language-services/commonTypes.ts
+++ b/src/powerquery-language-services/commonTypes.ts
@@ -33,8 +33,6 @@ export interface IDisposable {
     dispose(): void;
 }
 
-export const EmptyCompletionItems: ReadonlyArray<CompletionItem> = [];
-
 export const EmptyHover: Hover = {
     range: undefined,
     contents: [],

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteFieldAccess.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteFieldAccess.ts
@@ -283,7 +283,7 @@ function createAutocompleteItems(
         inspectedFieldAccess.maybeIdentifierUnderPosition?.literal;
 
     for (const [label, powerQueryType] of fieldEntries) {
-        if (fieldAccessNames.includes(label)) {
+        if (fieldAccessNames.includes(label) && label !== maybeIdentifierUnderPositionLiteral) {
             continue;
         }
 

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteItem/autocompleteItem.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteItem/autocompleteItem.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as PQP from "@microsoft/powerquery-parser";
+
+export interface AutocompleteItem {
+    readonly key: string;
+    readonly jaroWinklerScore: number;
+    readonly powerQueryType: PQP.Language.Type.PowerQueryType;
+}

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteItem/autocompleteItem.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteItem/autocompleteItem.ts
@@ -3,8 +3,9 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
-export interface AutocompleteItem {
-    readonly key: string;
+import { CompletionItem } from "vscode-languageserver-types";
+
+export interface AutocompleteItem extends CompletionItem {
     readonly jaroWinklerScore: number;
     readonly powerQueryType: PQP.Language.Type.PowerQueryType;
 }

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteItem/autocompleteItemUtils.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteItem/autocompleteItemUtils.ts
@@ -2,31 +2,68 @@
 // Licensed under the MIT license.
 
 import * as PQP from "@microsoft/powerquery-parser";
+import { CompletionItemKind } from "vscode-languageserver-types";
 import { calculateJaroWinkler } from "../../jaroWinkler";
 import { AutocompleteItem } from "./autocompleteItem";
 
-export function create(
-    key: string,
-    jaroWinklerScore: number,
-    powerQueryType: PQP.Language.Type.PowerQueryType,
-): AutocompleteItem {
+// export function create(
+//     label: string,
+//     jaroWinklerScore: number,
+//     powerQueryType: PQP.Language.Type.PowerQueryType,
+// ): AutocompleteItem {
+//     return {
+//         label,
+//         jaroWinklerScore,
+//         powerQueryType,
+//     };
+// }
+
+// export function createFromJaroWinkler(
+//     key: string,
+//     other: string,
+//     powerQueryType: PQP.Language.Type.PowerQueryType,
+// ): AutocompleteItem {
+//     return create(key, calculateJaroWinkler(key, other), powerQueryType);
+// }
+
+export function createFromKeywordKind(label: PQP.Language.Keyword.KeywordKind, maybeOther?: string): AutocompleteItem {
+    const jaroWinklerScore: number = maybeOther !== undefined ? calculateJaroWinkler(label, maybeOther) : 1;
+
     return {
-        key,
         jaroWinklerScore,
-        powerQueryType,
+        kind: CompletionItemKind.Keyword,
+        label,
+        powerQueryType: PQP.Language.Type.NotApplicableInstance,
     };
 }
 
-export function createFromJaroWinkler(
-    key: string,
-    other: string,
-    powerQueryType: PQP.Language.Type.PowerQueryType,
+export function createFromLanguageConstantKind(
+    label: PQP.Language.Constant.LanguageConstantKind,
+    maybeOther?: string,
 ): AutocompleteItem {
-    return create(key, calculateJaroWinkler(key, other), powerQueryType);
+    const jaroWinklerScore: number = maybeOther !== undefined ? calculateJaroWinkler(label, maybeOther) : 1;
+
+    return {
+        jaroWinklerScore,
+        kind: CompletionItemKind.Keyword,
+        label,
+        powerQueryType: PQP.Language.Type.NotApplicableInstance,
+    };
 }
 
-export function createFromKeywordKind(key: PQP.Language.Keyword.KeywordKind, maybeOther?: string): AutocompleteItem {
-    return maybeOther
-        ? createFromJaroWinkler(key, maybeOther, PQP.Language.Type.NotApplicableInstance)
-        : create(key, 1, PQP.Language.Type.NotApplicableInstance);
+export function createFromPrimitiveTypeConstantKind(
+    label: PQP.Language.Constant.PrimitiveTypeConstantKind,
+    maybeOther?: string,
+): AutocompleteItem {
+    const jaroWinklerScore: number = maybeOther !== undefined ? calculateJaroWinkler(label, maybeOther) : 1;
+
+    return {
+        jaroWinklerScore,
+        kind: CompletionItemKind.Reference,
+        label,
+        powerQueryType: PQP.Language.TypeUtils.createPrimitiveType(
+            false,
+            PQP.Language.TypeUtils.typeKindFromPrimitiveTypeConstantKind(label),
+        ),
+    };
 }

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteItem/autocompleteItemUtils.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteItem/autocompleteItemUtils.ts
@@ -59,7 +59,7 @@ export function createFromPrimitiveTypeConstantKind(
 
     return {
         jaroWinklerScore,
-        kind: CompletionItemKind.Reference,
+        kind: CompletionItemKind.Keyword,
         label,
         powerQueryType: PQP.Language.TypeUtils.createPrimitiveType(
             false,

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteItem/autocompleteItemUtils.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteItem/autocompleteItemUtils.ts
@@ -60,29 +60,11 @@ export function createFromLibraryDefinition(
 ): Inspection.AutocompleteItem {
     const jaroWinklerScore: number = maybeOther !== undefined ? calculateJaroWinkler(label, maybeOther) : 1;
 
-    let completionItemKind: CompletionItemKind;
-    switch (libraryDefinition.kind) {
-        case Library.LibraryDefinitionKind.Constant:
-            completionItemKind = CompletionItemKind.Value;
-            break;
-
-        case Library.LibraryDefinitionKind.Function:
-            completionItemKind = CompletionItemKind.Function;
-            break;
-
-        case Library.LibraryDefinitionKind.Type:
-            completionItemKind = CompletionItemKind.TypeParameter;
-            break;
-
-        default:
-            throw PQP.Assert.isNever(libraryDefinition);
-    }
-
     return {
         jaroWinklerScore,
-        kind: completionItemKind,
+        kind: libraryDefinition.completionItemKind,
         label,
-        powerQueryType: libraryDefinition.asType,
+        powerQueryType: libraryDefinition.asPowerQueryType,
     };
 }
 

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteItem/autocompleteItemUtils.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteItem/autocompleteItemUtils.ts
@@ -8,26 +8,6 @@ import { Library } from "../../../library";
 import { calculateJaroWinkler } from "../../jaroWinkler";
 import { AutocompleteItem } from "./autocompleteItem";
 
-// export function create(
-//     label: string,
-//     jaroWinklerScore: number,
-//     powerQueryType: PQP.Language.Type.PowerQueryType,
-// ): AutocompleteItem {
-//     return {
-//         label,
-//         jaroWinklerScore,
-//         powerQueryType,
-//     };
-// }
-
-// export function createFromJaroWinkler(
-//     key: string,
-//     other: string,
-//     powerQueryType: PQP.Language.Type.PowerQueryType,
-// ): AutocompleteItem {
-//     return create(key, calculateJaroWinkler(key, other), powerQueryType);
-// }
-
 export function createFromKeywordKind(label: PQP.Language.Keyword.KeywordKind, maybeOther?: string): AutocompleteItem {
     const jaroWinklerScore: number = maybeOther !== undefined ? calculateJaroWinkler(label, maybeOther) : 1;
 

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteItem/autocompleteItemUtils.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteItem/autocompleteItemUtils.ts
@@ -2,11 +2,13 @@
 // Licensed under the MIT license.
 
 import * as PQP from "@microsoft/powerquery-parser";
+
 import { CompletionItemKind } from "vscode-languageserver-types";
+
 import { Inspection } from "../../..";
 import { Library } from "../../../library";
 import { calculateJaroWinkler } from "../../jaroWinkler";
-import { AutocompleteItem } from "./autocompleteItem";
+import type { AutocompleteItem } from "./autocompleteItem";
 
 export function createFromFieldAccess(
     label: string,

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteItem/autocompleteItemUtils.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteItem/autocompleteItemUtils.ts
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as PQP from "@microsoft/powerquery-parser";
+import { calculateJaroWinkler } from "../../jaroWinkler";
+import { AutocompleteItem } from "./autocompleteItem";
+
+export function create(
+    key: string,
+    jaroWinklerScore: number,
+    powerQueryType: PQP.Language.Type.PowerQueryType,
+): AutocompleteItem {
+    return {
+        key,
+        jaroWinklerScore,
+        powerQueryType,
+    };
+}
+
+export function createFromJaroWinkler(
+    key: string,
+    other: string,
+    powerQueryType: PQP.Language.Type.PowerQueryType,
+): AutocompleteItem {
+    return create(key, calculateJaroWinkler(key, other), powerQueryType);
+}
+
+export function createFromKeywordKind(key: PQP.Language.Keyword.KeywordKind, maybeOther?: string): AutocompleteItem {
+    return maybeOther
+        ? createFromJaroWinkler(key, maybeOther, PQP.Language.Type.NotApplicableInstance)
+        : create(key, 1, PQP.Language.Type.NotApplicableInstance);
+}

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteItem/index.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteItem/index.ts
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export * from "./autocompleteItem";
+export * as AutocompleteItemUtils from "./autocompleteItemUtils";

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeyword.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeyword.ts
@@ -25,6 +25,9 @@ export function tryAutocompleteKeyword(
 ): TriedAutocompleteKeyword {
     if (!ActiveNodeUtils.isPositionInBounds(maybeActiveNode)) {
         return PQP.ResultUtils.createOk([
+            ...PQP.Language.Keyword.ExpressionKeywordKinds.map((keywordKind: PQP.Language.Keyword.KeywordKind) =>
+                AutocompleteItemUtils.createFromKeywordKind(keywordKind),
+            ),
             AutocompleteItemUtils.createFromKeywordKind(PQP.Language.Keyword.KeywordKind.Section),
         ]);
     }

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeyword.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeyword.ts
@@ -5,6 +5,7 @@ import * as PQP from "@microsoft/powerquery-parser";
 
 import { ActiveNode, ActiveNodeLeafKind, ActiveNodeUtils, TMaybeActiveNode } from "../../activeNode";
 import { PositionUtils } from "../../position";
+import { AutocompleteItem, AutocompleteItemUtils } from "../autocompleteItem";
 import { TrailingToken, TriedAutocompleteKeyword } from "../commonTypes";
 import { autocompleteKeywordDefault } from "./autocompleteKeywordDefault";
 import { autocompleteKeywordErrorHandlingExpression } from "./autocompleteKeywordErrorHandlingExpression";
@@ -13,7 +14,7 @@ import { autocompleteKeywordLetExpression } from "./autocompleteKeywordLetExpres
 import { autocompleteKeywordListExpression } from "./autocompleteKeywordListExpression";
 import { autocompleteKeywordSectionMember } from "./autocompleteKeywordSectionMember";
 import { autocompleteKeywordTrailingText } from "./autocompleteKeywordTrailingText";
-import { ExpressionAutocomplete, InspectAutocompleteKeywordState } from "./commonTypes";
+import { InspectAutocompleteKeywordState } from "./commonTypes";
 
 export function tryAutocompleteKeyword(
     settings: PQP.CommonSettings,
@@ -23,7 +24,9 @@ export function tryAutocompleteKeyword(
     maybeTrailingToken: TrailingToken | undefined,
 ): TriedAutocompleteKeyword {
     if (!ActiveNodeUtils.isPositionInBounds(maybeActiveNode)) {
-        return PQP.ResultUtils.createOk([...ExpressionAutocomplete, PQP.Language.Keyword.KeywordKind.Section]);
+        return PQP.ResultUtils.createOk([
+            AutocompleteItemUtils.createFromKeywordKind(PQP.Language.Keyword.KeywordKind.Section),
+        ]);
     }
 
     return PQP.ResultUtils.ensureResult(settings.locale, () => {
@@ -36,9 +39,10 @@ export function autocompleteKeyword(
     leafNodeIds: ReadonlyArray<number>,
     activeNode: ActiveNode,
     maybeTrailingToken: TrailingToken | undefined,
-): ReadonlyArray<PQP.Language.Keyword.KeywordKind> {
+): ReadonlyArray<AutocompleteItem> {
     const ancestryLeaf: PQP.Parser.TXorNode = ActiveNodeUtils.assertGetLeaf(activeNode);
     let maybePositionName: string | undefined;
+
     if (PositionUtils.isInXor(nodeIdMapCollection, activeNode.position, ancestryLeaf, false, true)) {
         if (activeNode.maybeIdentifierUnderPosition !== undefined) {
             maybePositionName = activeNode.maybeIdentifierUnderPosition.literal;
@@ -55,7 +59,7 @@ export function autocompleteKeyword(
     }
 
     if (activeNode.ancestry.length < 2) {
-        return filterRecommendations(handleConjunctions(activeNode, [], maybeTrailingToken), maybePositionName);
+        return createAutocompleteItems(handleConjunctions(activeNode, [], maybeTrailingToken), maybePositionName);
     }
 
     const state: InspectAutocompleteKeywordState = {
@@ -68,15 +72,12 @@ export function autocompleteKeyword(
         ancestryIndex: 0,
     };
 
-    const maybeEarlyExitInspected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> | undefined = maybeEdgeCase(
-        state,
-        maybeTrailingToken,
-    );
-    if (maybeEarlyExitInspected !== undefined) {
-        return maybeEarlyExitInspected;
+    const maybeEdgeCase: ReadonlyArray<AutocompleteItem> | undefined = getMaybeEdgeCase(state, maybeTrailingToken);
+    if (maybeEdgeCase !== undefined) {
+        return maybeEdgeCase;
     }
 
-    return filterRecommendations(
+    return createAutocompleteItems(
         handleConjunctions(state.activeNode, traverseAncestors(state), maybeTrailingToken),
         maybePositionName,
     );
@@ -137,13 +138,13 @@ function traverseAncestors(state: InspectAutocompleteKeywordState): ReadonlyArra
     return [];
 }
 
-function maybeEdgeCase(
+function getMaybeEdgeCase(
     state: InspectAutocompleteKeywordState,
     maybeTrailingToken: TrailingToken | undefined,
-): ReadonlyArray<PQP.Language.Keyword.KeywordKind> | undefined {
+): ReadonlyArray<AutocompleteItem> | undefined {
     const activeNode: ActiveNode = state.activeNode;
     const ancestry: ReadonlyArray<PQP.Parser.TXorNode> = activeNode.ancestry;
-    let maybeInspected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> | undefined;
+    let maybeInspected: ReadonlyArray<AutocompleteItem> | undefined;
 
     // The user is typing in a new file, which the parser defaults to searching for an identifier.
     // `l|` -> `let`
@@ -155,19 +156,20 @@ function maybeEdgeCase(
         ancestry[1].node.kind === PQP.Language.Ast.NodeKind.IdentifierExpression
     ) {
         const identifier: string = ancestry[0].node.literal;
-        maybeInspected = PQP.Language.Keyword.StartOfDocumentKeywords.filter(
-            (keywordKind: PQP.Language.Keyword.KeywordKind) => keywordKind.startsWith(identifier),
+        maybeInspected = PQP.Language.Keyword.StartOfDocumentKeywords.map(
+            (keywordKind: PQP.Language.Keyword.KeywordKind) =>
+                AutocompleteItemUtils.createFromKeywordKind(keywordKind, identifier),
         );
     }
 
-    // `(_ |) => _` -> `(_ as) => _`
+    // `(x |) => x+1` -> `(x as|) => x+1`
     else if (
         ancestry[0].kind === PQP.Parser.XorNodeKind.Ast &&
         ancestry[0].node.kind === PQP.Language.Ast.NodeKind.Identifier &&
         ancestry[1].node.kind === PQP.Language.Ast.NodeKind.Parameter &&
         PositionUtils.isAfterAst(activeNode.position, ancestry[0].node, true)
     ) {
-        maybeInspected = [PQP.Language.Keyword.KeywordKind.As];
+        maybeInspected = [AutocompleteItemUtils.createFromKeywordKind(PQP.Language.Keyword.KeywordKind.As)];
     }
 
     // `(foo a|) => foo` -> `(foo as) => foo
@@ -178,22 +180,19 @@ function maybeEdgeCase(
         ancestry[1].node.kind === PQP.Language.Ast.NodeKind.ParameterList &&
         ancestry[2].node.kind === PQP.Language.Ast.NodeKind.FunctionExpression
     ) {
-        maybeInspected = [PQP.Language.Keyword.KeywordKind.As];
+        maybeInspected = [AutocompleteItemUtils.createFromKeywordKind(PQP.Language.Keyword.KeywordKind.As)];
     }
 
     return maybeInspected;
 }
 
-function filterRecommendations(
-    inspected: ReadonlyArray<PQP.Language.Keyword.KeywordKind>,
+function createAutocompleteItems(
+    keywordKinds: ReadonlyArray<PQP.Language.Keyword.KeywordKind>,
     maybePositionName: string | undefined,
-): ReadonlyArray<PQP.Language.Keyword.KeywordKind> {
-    if (maybePositionName === undefined) {
-        return inspected;
-    }
-
-    const positionName: string = maybePositionName;
-    return inspected.filter((kind: PQP.Language.Keyword.KeywordKind) => kind.startsWith(positionName));
+): ReadonlyArray<AutocompleteItem> {
+    return keywordKinds.map((kind: PQP.Language.Keyword.KeywordKind) =>
+        AutocompleteItemUtils.createFromKeywordKind(kind, maybePositionName),
+    );
 }
 
 function handleConjunctions(

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordErrorHandlingExpression.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordErrorHandlingExpression.ts
@@ -5,7 +5,7 @@ import * as PQP from "@microsoft/powerquery-parser";
 
 import { Position, PositionUtils } from "../../position";
 import { TrailingToken } from "../commonTypes";
-import { ExpressionAutocomplete, InspectAutocompleteKeywordState } from "./commonTypes";
+import { InspectAutocompleteKeywordState } from "./commonTypes";
 
 export function autocompleteKeywordErrorHandlingExpression(
     state: InspectAutocompleteKeywordState,
@@ -50,7 +50,7 @@ export function autocompleteKeywordErrorHandlingExpression(
         } else if (child.kind === PQP.Parser.XorNodeKind.Ast && PositionUtils.isAfterAst(position, child.node, true)) {
             return [PQP.Language.Keyword.KeywordKind.Otherwise];
         } else {
-            return ExpressionAutocomplete;
+            return PQP.Language.Keyword.ExpressionKeywordKinds;
         }
     } else {
         return undefined;

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordListExpression.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordListExpression.ts
@@ -7,7 +7,7 @@ import { Assert } from "@microsoft/powerquery-parser";
 
 import { ActiveNode } from "../../activeNode";
 import { PositionUtils } from "../../position";
-import { ExpressionAutocomplete, InspectAutocompleteKeywordState } from "./commonTypes";
+import { InspectAutocompleteKeywordState } from "./commonTypes";
 
 export function autocompleteKeywordListExpression(
     state: InspectAutocompleteKeywordState,
@@ -47,7 +47,7 @@ export function autocompleteKeywordListExpression(
         itemNode.kind === PQP.Parser.XorNodeKind.Context ||
         PositionUtils.isBeforeXor(activeNode.position, itemNode, false)
     ) {
-        return ExpressionAutocomplete;
+        return PQP.Language.Keyword.ExpressionKeywordKinds;
     } else {
         return undefined;
     }

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/common.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/common.ts
@@ -3,9 +3,10 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
-import { Assert } from "@microsoft/powerquery-parser";
+import { Assert, CommonError } from "@microsoft/powerquery-parser";
 
 import { ActiveNode } from "../../activeNode";
+import { AutocompleteItem } from "../autocompleteItem";
 import { autocompleteKeyword } from "./autocompleteKeyword";
 import { InspectAutocompleteKeywordState } from "./commonTypes";
 
@@ -31,12 +32,21 @@ export function autocompleteKeywordRightMostLeaf(
         ...state.activeNode,
         ancestry: shiftedAncestry,
     };
-    const inspected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = autocompleteKeyword(
+
+    const inspected: ReadonlyArray<AutocompleteItem> = autocompleteKeyword(
         state.nodeIdMapCollection,
         state.leafNodeIds,
         shiftedActiveNode,
         state.maybeTrailingToken,
     );
 
-    return inspected;
+    return inspected.map((autocompleteItem: AutocompleteItem) => {
+        if (!PQP.Language.KeywordUtils.isKeyword(autocompleteItem.label)) {
+            throw new CommonError.InvariantError(
+                `expected ${autocompleteKeyword.name} to return only with KeywordKind values for AutocompleteItem.label`,
+            );
+        }
+
+        return autocompleteItem.label;
+    });
 }

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/commonTypes.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/commonTypes.ts
@@ -15,6 +15,3 @@ export interface InspectAutocompleteKeywordState {
     child: PQP.Parser.TXorNode;
     ancestryIndex: number;
 }
-
-export const ExpressionAutocomplete: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-    PQP.Language.Keyword.ExpressionKeywordKinds;

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteLanguageConstant.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteLanguageConstant.ts
@@ -5,7 +5,8 @@ import * as PQP from "@microsoft/powerquery-parser";
 
 import { ActiveNode, ActiveNodeUtils, TMaybeActiveNode } from "../activeNode";
 import { Position, PositionUtils } from "../position";
-import { AutocompleteLanguageConstant, TriedAutocompleteLanguageConstant } from "./commonTypes";
+import { AutocompleteItem, AutocompleteItemUtils } from "./autocompleteItem";
+import { TriedAutocompleteLanguageConstant } from "./commonTypes";
 
 export function tryAutocompleteLanguageConstant(
     settings: PQP.CommonSettings,
@@ -16,16 +17,20 @@ export function tryAutocompleteLanguageConstant(
     });
 }
 
-function autocompleteLanguageConstant(maybeActiveNode: TMaybeActiveNode): AutocompleteLanguageConstant | undefined {
+function autocompleteLanguageConstant(maybeActiveNode: TMaybeActiveNode): AutocompleteItem | undefined {
     if (!ActiveNodeUtils.isPositionInBounds(maybeActiveNode)) {
         return undefined;
     }
     const activeNode: ActiveNode = maybeActiveNode;
 
     if (isNullableAllowed(activeNode)) {
-        return PQP.Language.Constant.LanguageConstantKind.Nullable;
+        return AutocompleteItemUtils.createFromLanguageConstantKind(
+            PQP.Language.Constant.LanguageConstantKind.Nullable,
+        );
     } else if (isOptionalAllowed(activeNode)) {
-        return PQP.Language.Constant.LanguageConstantKind.Optional;
+        return AutocompleteItemUtils.createFromLanguageConstantKind(
+            PQP.Language.Constant.LanguageConstantKind.Optional,
+        );
     } else {
         return undefined;
     }

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteUtils.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteUtils.ts
@@ -2,8 +2,9 @@
 // Licensed under the MIT license.
 
 import * as PQP from "@microsoft/powerquery-parser";
+import { AutocompleteItem } from "./autocompleteItem";
 
-import { Autocomplete, AutocompleteItem } from "./commonTypes";
+import { Autocomplete } from "./commonTypes";
 
 export function keys(autocomplete: Autocomplete): ReadonlyArray<string> {
     let result: string[] = [];
@@ -11,17 +12,21 @@ export function keys(autocomplete: Autocomplete): ReadonlyArray<string> {
     if (PQP.ResultUtils.isOk(autocomplete.triedFieldAccess) && autocomplete.triedFieldAccess.value !== undefined) {
         result = result.concat(
             autocomplete.triedFieldAccess.value.autocompleteItems.map(
-                (autocompleteItem: AutocompleteItem) => autocompleteItem.key,
+                (autocompleteItem: AutocompleteItem) => autocompleteItem.label,
             ),
         );
     }
 
     if (PQP.ResultUtils.isOk(autocomplete.triedKeyword)) {
-        result = result.concat(autocomplete.triedKeyword.value);
+        result = result.concat(
+            autocomplete.triedKeyword.value.map((autocompleteItem: AutocompleteItem) => autocompleteItem.label),
+        );
     }
 
     if (PQP.ResultUtils.isOk(autocomplete.triedPrimitiveType) && autocomplete.triedPrimitiveType.value !== undefined) {
-        result = result.concat(autocomplete.triedPrimitiveType.value);
+        result = result.concat(
+            autocomplete.triedPrimitiveType.value.map((autocompleteItem: AutocompleteItem) => autocompleteItem.label),
+        );
     }
 
     return result;

--- a/src/powerquery-language-services/inspection/autocomplete/commonTypes.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/commonTypes.ts
@@ -13,8 +13,6 @@ export type TriedAutocompleteLanguageConstant = PQP.Result<AutocompleteItem | un
 
 export type TriedAutocompletePrimitiveType = PQP.Result<ReadonlyArray<AutocompleteItem>, PQP.CommonError.CommonError>;
 
-export type AutocompleteKeyword = ReadonlyArray<PQP.Language.Keyword.KeywordKind>;
-
 export interface Autocomplete {
     readonly triedFieldAccess: TriedAutocompleteFieldAccess;
     readonly triedKeyword: TriedAutocompleteKeyword;

--- a/src/powerquery-language-services/inspection/autocomplete/commonTypes.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/commonTypes.ts
@@ -9,18 +9,11 @@ export type TriedAutocompleteFieldAccess = PQP.Result<AutocompleteFieldAccess | 
 
 export type TriedAutocompleteKeyword = PQP.Result<ReadonlyArray<AutocompleteItem>, PQP.CommonError.CommonError>;
 
-export type TriedAutocompleteLanguageConstant = PQP.Result<
-    AutocompleteLanguageConstant | undefined,
-    PQP.CommonError.CommonError
->;
+export type TriedAutocompleteLanguageConstant = PQP.Result<AutocompleteItem | undefined, PQP.CommonError.CommonError>;
 
-export type TriedAutocompletePrimitiveType = PQP.Result<AutocompletePrimitiveType, PQP.CommonError.CommonError>;
+export type TriedAutocompletePrimitiveType = PQP.Result<ReadonlyArray<AutocompleteItem>, PQP.CommonError.CommonError>;
 
 export type AutocompleteKeyword = ReadonlyArray<PQP.Language.Keyword.KeywordKind>;
-
-export type AutocompleteLanguageConstant = PQP.Language.Constant.LanguageConstantKind;
-
-export type AutocompletePrimitiveType = ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind>;
 
 export interface Autocomplete {
     readonly triedFieldAccess: TriedAutocompleteFieldAccess;

--- a/src/powerquery-language-services/inspection/autocomplete/commonTypes.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/commonTypes.ts
@@ -3,9 +3,11 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { AutocompleteItem } from "./autocompleteItem";
+
 export type TriedAutocompleteFieldAccess = PQP.Result<AutocompleteFieldAccess | undefined, PQP.CommonError.CommonError>;
 
-export type TriedAutocompleteKeyword = PQP.Result<AutocompleteKeyword, PQP.CommonError.CommonError>;
+export type TriedAutocompleteKeyword = PQP.Result<ReadonlyArray<AutocompleteItem>, PQP.CommonError.CommonError>;
 
 export type TriedAutocompleteLanguageConstant = PQP.Result<
     AutocompleteLanguageConstant | undefined,
@@ -25,11 +27,6 @@ export interface Autocomplete {
     readonly triedKeyword: TriedAutocompleteKeyword;
     readonly triedLanguageConstant: TriedAutocompleteLanguageConstant;
     readonly triedPrimitiveType: TriedAutocompletePrimitiveType;
-}
-
-export interface AutocompleteItem {
-    readonly key: string;
-    readonly type: PQP.Language.Type.PowerQueryType;
 }
 
 export interface AutocompleteFieldAccess {

--- a/src/powerquery-language-services/inspection/autocomplete/commonTypes.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/commonTypes.ts
@@ -29,7 +29,7 @@ export interface AutocompleteFieldAccess {
 
 export interface InspectedFieldAccess {
     readonly isAutocompleteAllowed: boolean;
-    readonly maybeIdentifierUnderPosition: string | undefined;
+    readonly maybeIdentifierUnderPosition: PQP.Language.Ast.GeneralizedIdentifier | undefined;
     readonly fieldNames: ReadonlyArray<string>;
 }
 

--- a/src/powerquery-language-services/inspection/autocomplete/index.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/index.ts
@@ -4,6 +4,7 @@
 import * as AutocompleteUtils from "./autocompleteUtils";
 
 export { AutocompleteUtils };
+export * from "./autocompleteItem";
 export * from "./autocompleteKeyword";
 export * from "./commonTypes";
 export * from "./task";

--- a/src/powerquery-language-services/inspection/index.ts
+++ b/src/powerquery-language-services/inspection/index.ts
@@ -6,6 +6,7 @@ export * from "./autocomplete";
 export * from "./commonTypes";
 export * from "./externalType";
 export * from "./invokeExpression";
+export * from "./jaroWinkler";
 export * from "./position";
 export * from "./settings";
 export * from "./scope";

--- a/src/powerquery-language-services/inspection/jaroWinkler.ts
+++ b/src/powerquery-language-services/inspection/jaroWinkler.ts
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// https://en.wikipedia.org/wiki/Jaro%E2%80%93Winkler_distance
+
+// The standard magic numbers for Winkler adjustments.
+const WinklerAdjustment: number = 0.1;
+const WinklerMaxCharacterAdjustment: number = 4;
+const WinklerScoreThreshold: number = 0.7;
+
+export function calculateJaro(left: string, right: string): number {
+    const [shorter, longer]: [string, string] = getNormalized(left, right);
+    return calculateJaroForNormalized(shorter, longer);
+}
+
+export function calculateJaroWinkler(left: string, right: string): number {
+    const [shorter, longer]: [string, string] = getNormalized(left, right);
+    let jaroScore: number = calculateJaroForNormalized(shorter, longer);
+
+    if (jaroScore <= WinklerScoreThreshold) {
+        return jaroScore;
+    }
+
+    // Adjust score for the number of leading characters that match.
+    // Capped at an upper bound of N leading characters, where N is most commonly `4`.
+    const upperBound: number = Math.max(WinklerMaxCharacterAdjustment, shorter.length);
+    let startingCharIndex: number = 0;
+    while (shorter[startingCharIndex] === longer[startingCharIndex] && startingCharIndex < upperBound) {
+        startingCharIndex += 1;
+    }
+
+    if (startingCharIndex) {
+        jaroScore += startingCharIndex * WinklerAdjustment * (1 - jaroScore);
+    }
+
+    return jaroScore;
+}
+
+function calculateJaroForNormalized(shorter: string, longer: string): number {
+    const shorterLength: number = shorter.length;
+    const longerLength: number = longer.length;
+    // When trying to find similar characters limit the search to a window based on longer's length.
+    const matchingWindowSize: number = Math.floor(longerLength / 2) - 1;
+
+    // tslint:disable-next-line: prefer-array-literal
+    const shorterMatches: boolean[] = new Array(shorterLength);
+    // tslint:disable-next-line: prefer-array-literal
+    const longerMatches: boolean[] = new Array(longerLength);
+    let numMatches: number = 0;
+
+    for (let longerIndex: number = 0; longerIndex < longerLength; longerIndex += 1) {
+        const longerChar: string = longer[longerIndex];
+
+        const matchingWindowStart: number = Math.max(0, longerIndex - matchingWindowSize);
+        const matchingWindowEnd: number = Math.min(longerIndex + matchingWindowSize + 1, shorterLength);
+
+        for (let shorterIndex: number = matchingWindowStart; shorterIndex < matchingWindowEnd; shorterIndex += 1) {
+            const shorterChar: string = shorter[shorterIndex];
+
+            if (longerChar === shorterChar && !shorterMatches[shorterIndex]) {
+                shorterMatches[shorterIndex] = true;
+                longerMatches[longerIndex] = true;
+                numMatches += 1;
+                break;
+            }
+        }
+    }
+
+    if (!numMatches) {
+        return 0;
+    }
+
+    // Next we calculate the number of transpositions needed to convert `left` into `right` (or vice-versa).
+
+    // `k` is part of an optimization.
+    // It's used to keep a persistent index as we iterate over longerLength,
+    // which will prevent double matching or a double for-loop.
+    let k: number = 0;
+    let numTranspositionsNeeded: number = 0;
+    for (let longerIndex: number = 0; longerIndex < longerLength; longerIndex += 1) {
+        if (!longerMatches[longerIndex]) {
+            continue;
+        }
+
+        while (!shorterMatches[k]) {
+            k += 1;
+        }
+
+        if (longer[longerIndex] !== shorter[k]) {
+            numTranspositionsNeeded += 1;
+        }
+
+        k += 1;
+    }
+
+    const m_over_s1: number = numMatches / longerLength;
+    const m_over_s2: number = numMatches / shorterLength;
+    const mMinusT_over_m: number = (numMatches - numTranspositionsNeeded) / numMatches;
+
+    return (m_over_s1 + m_over_s2 + mMinusT_over_m) / 3;
+}
+
+function getNormalized(left: string, right: string): [string, string] {
+    left = left.toLowerCase();
+    right = right.toLowerCase();
+
+    return left.length < right.length ? [left, right] : [right, left];
+}

--- a/src/powerquery-language-services/inspection/jaroWinkler.ts
+++ b/src/powerquery-language-services/inspection/jaroWinkler.ts
@@ -36,27 +36,6 @@ export function calculateJaroWinkler(left: string, right: string): number {
     return jaroScore;
 }
 
-export function calculateManyJaroWinkler(
-    constant: string,
-    toMatch: ReadonlyArray<string>,
-    sortByScore: boolean,
-): ReadonlyArray<string> {
-    let jaroWinklerScores: [number, string][] = toMatch.map<[number, string]>((text: string) => [
-        calculateJaroWinkler(constant, text),
-        text,
-    ]);
-
-    if (sortByScore) {
-        // Sort by jaro-winkler score, descending
-        jaroWinklerScores = jaroWinklerScores.sort(
-            ([leftScore, _leftText]: [number, string], [rightScore, _rightText]: [number, string]) =>
-                rightScore - leftScore,
-        );
-    }
-
-    return jaroWinklerScores.map(([_, text]) => text);
-}
-
 function calculateJaroForNormalized(shorter: string, longer: string): number {
     const shorterLength: number = shorter.length;
     const longerLength: number = longer.length;

--- a/src/powerquery-language-services/inspection/jaroWinkler.ts
+++ b/src/powerquery-language-services/inspection/jaroWinkler.ts
@@ -36,6 +36,27 @@ export function calculateJaroWinkler(left: string, right: string): number {
     return jaroScore;
 }
 
+export function calculateManyJaroWinkler(
+    constant: string,
+    toMatch: ReadonlyArray<string>,
+    sortByScore: boolean,
+): ReadonlyArray<string> {
+    let jaroWinklerScores: [number, string][] = toMatch.map<[number, string]>((text: string) => [
+        calculateJaroWinkler(constant, text),
+        text,
+    ]);
+
+    if (sortByScore) {
+        // Sort by jaro-winkler score, descending
+        jaroWinklerScores = jaroWinklerScores.sort(
+            ([leftScore, _leftText]: [number, string], [rightScore, _rightText]: [number, string]) =>
+                rightScore - leftScore,
+        );
+    }
+
+    return jaroWinklerScores.map(([_, text]) => text);
+}
+
 function calculateJaroForNormalized(shorter: string, longer: string): number {
     const shorterLength: number = shorter.length;
     const longerLength: number = longer.length;

--- a/src/powerquery-language-services/inspectionUtils.ts
+++ b/src/powerquery-language-services/inspectionUtils.ts
@@ -97,20 +97,20 @@ export function getCompletionItems(
     const text: string | null | undefined = context.text;
     const completionItems: CompletionItem[] = [];
     for (const autocompleteItem of triedAutocompleteFieldAccess.value.autocompleteItems) {
-        if (!text || autocompleteItem.key.startsWith(text)) {
+        if (!text || autocompleteItem.label.startsWith(text)) {
             let textEdit: TextEdit | undefined;
             if (!context.range) {
                 textEdit = undefined;
             } else {
                 textEdit = {
                     range: context.range,
-                    newText: autocompleteItem.key,
+                    newText: autocompleteItem.label,
                 };
             }
 
             completionItems.push({
                 kind: CompletionItemKind.Field,
-                label: autocompleteItem.key,
+                label: autocompleteItem.label,
                 textEdit,
             });
         }

--- a/src/powerquery-language-services/inspectionUtils.ts
+++ b/src/powerquery-language-services/inspectionUtils.ts
@@ -3,20 +3,13 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
-import {
-    CompletionItem,
-    CompletionItemKind,
-    DocumentSymbol,
-    SignatureHelp,
-    SymbolKind,
-    TextEdit,
-} from "vscode-languageserver-types";
+import { DocumentSymbol, SignatureHelp, SymbolKind } from "vscode-languageserver-types";
 
 import * as LanguageServiceUtils from "./languageServiceUtils";
 
 import { Inspection } from ".";
 import { AutocompleteItemUtils } from "./inspection/autocomplete";
-import { CompletionItemProviderContext, SignatureProviderContext } from "./providers/commonTypes";
+import { AutocompleteItemProviderContext, SignatureProviderContext } from "./providers/commonTypes";
 
 export function getMaybeContextForSignatureProvider(
     inspected: Inspection.Inspection,
@@ -82,41 +75,6 @@ export function getMaybeType(
     return PQP.ResultUtils.isOk(inspection.triedScopeType)
         ? inspection.triedScopeType.value.get(identifier)
         : undefined;
-}
-
-export function getCompletionItems(
-    context: CompletionItemProviderContext,
-    inspection: Inspection.Inspection,
-): ReadonlyArray<CompletionItem> {
-    const triedAutocompleteFieldAccess: Inspection.TriedAutocompleteFieldAccess =
-        inspection.autocomplete.triedFieldAccess;
-    if (PQP.ResultUtils.isError(triedAutocompleteFieldAccess) || !triedAutocompleteFieldAccess.value) {
-        return [];
-    }
-
-    const text: string | null | undefined = context.text;
-    const completionItems: CompletionItem[] = [];
-    for (const autocompleteItem of triedAutocompleteFieldAccess.value.autocompleteItems) {
-        if (!text || autocompleteItem.label.startsWith(text)) {
-            let textEdit: TextEdit | undefined;
-            if (!context.range) {
-                textEdit = undefined;
-            } else {
-                textEdit = {
-                    range: context.range,
-                    newText: autocompleteItem.label,
-                };
-            }
-
-            completionItems.push({
-                kind: CompletionItemKind.Field,
-                label: autocompleteItem.label,
-                textEdit,
-            });
-        }
-    }
-
-    return completionItems;
 }
 
 export function getScopeItemKindText(scopeItemKind: Inspection.ScopeItemKind): string {
@@ -247,7 +205,7 @@ export function getSymbolForIdentifierPairedExpression(
 }
 
 export function getAutocompleteItemsFromScope(
-    context: CompletionItemProviderContext,
+    context: AutocompleteItemProviderContext,
     inspection: Inspection.Inspection,
 ): ReadonlyArray<Inspection.AutocompleteItem> {
     if (PQP.ResultUtils.isError(inspection.triedNodeScope)) {

--- a/src/powerquery-language-services/languageServiceUtils.ts
+++ b/src/powerquery-language-services/languageServiceUtils.ts
@@ -3,15 +3,7 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
-import {
-    CompletionItem,
-    CompletionItemKind,
-    DocumentSymbol,
-    Position,
-    Range,
-    SymbolKind,
-    TextEdit,
-} from "vscode-languageserver-types";
+import { CompletionItemKind, Position, Range, SymbolKind } from "vscode-languageserver-types";
 
 import { AnalysisOptions } from "./analysis/analysisOptions";
 
@@ -19,59 +11,45 @@ export function getLocale(analysisOptions: AnalysisOptions | undefined): string 
     return analysisOptions?.locale ?? DefaultLocale;
 }
 
-export function documentSymbolToCompletionItem(
-    documentSymbols: ReadonlyArray<DocumentSymbol>,
-    maybeTextEditRange: Range | undefined,
-): ReadonlyArray<CompletionItem> {
-    return documentSymbols.map((symbol: DocumentSymbol) => {
-        let textEdit: TextEdit | undefined;
-        if (maybeTextEditRange === undefined) {
-            textEdit = undefined;
-        } else {
-            textEdit = {
-                newText: symbol.name,
-                range: maybeTextEditRange,
-            };
-        }
-
-        return {
-            deprecated: symbol.deprecated,
-            detail: symbol.detail,
-            label: symbol.name,
-            kind: symbolKindToCompletionItemKind(symbol.kind),
-            textEdit,
-        };
-    });
-}
-
 export function symbolKindToCompletionItemKind(symbolKind: SymbolKind): CompletionItemKind | undefined {
     switch (symbolKind) {
-        case SymbolKind.Module:
-            return CompletionItemKind.Module;
-        case SymbolKind.Field:
-            return CompletionItemKind.Field;
-        case SymbolKind.Constructor:
-            return CompletionItemKind.Constructor;
-        case SymbolKind.Enum:
-            return CompletionItemKind.Enum;
-        case SymbolKind.EnumMember:
-            return CompletionItemKind.EnumMember;
-        case SymbolKind.Function:
-            return CompletionItemKind.Function;
-        case SymbolKind.Variable:
-            return CompletionItemKind.Variable;
-        case SymbolKind.Constant:
-            return CompletionItemKind.Constant;
         case SymbolKind.Array:
         case SymbolKind.Boolean:
         case SymbolKind.Number:
         case SymbolKind.Null:
         case SymbolKind.String:
             return CompletionItemKind.Value;
+
+        case SymbolKind.Module:
+            return CompletionItemKind.Module;
+
+        case SymbolKind.Field:
+            return CompletionItemKind.Field;
+
+        case SymbolKind.Constructor:
+            return CompletionItemKind.Constructor;
+
+        case SymbolKind.Enum:
+            return CompletionItemKind.Enum;
+
+        case SymbolKind.EnumMember:
+            return CompletionItemKind.EnumMember;
+
+        case SymbolKind.Function:
+            return CompletionItemKind.Function;
+
+        case SymbolKind.Variable:
+            return CompletionItemKind.Variable;
+
+        case SymbolKind.Constant:
+            return CompletionItemKind.Constant;
+
         case SymbolKind.Struct:
             return CompletionItemKind.Struct;
+
         case SymbolKind.TypeParameter:
             return CompletionItemKind.TypeParameter;
+
         default:
             return undefined;
     }

--- a/src/powerquery-language-services/library/library.ts
+++ b/src/powerquery-language-services/library/library.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import * as PQP from "@microsoft/powerquery-parser";
+import { CompletionItemKind } from "vscode-languageserver-types";
 import { ExternalType } from "../inspection";
 
 export type LibraryDefinitions = ReadonlyMap<string, TLibraryDefinition>;
@@ -20,11 +21,11 @@ export interface ILibrary {
 }
 
 export interface ILibraryDefinition {
-    readonly asType: PQP.Language.Type.PowerQueryType;
+    readonly asPowerQueryType: PQP.Language.Type.PowerQueryType;
+    readonly completionItemKind: CompletionItemKind;
     readonly description: string;
     readonly kind: LibraryDefinitionKind;
     readonly label: string;
-    readonly primitiveType: PQP.Language.Type.TPrimitiveType;
 }
 
 export interface LibraryConstant extends ILibraryDefinition {

--- a/src/powerquery-language-services/library/libraryUtils.ts
+++ b/src/powerquery-language-services/library/libraryUtils.ts
@@ -3,7 +3,7 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
-import { ParameterInformation, SignatureInformation } from "vscode-languageserver-types";
+import { CompletionItemKind, ParameterInformation, SignatureInformation } from "vscode-languageserver-types";
 import {
     LibraryConstant,
     LibraryDefinitionKind,
@@ -51,33 +51,33 @@ export function assertIsType(maybeDefinition: TLibraryDefinition | undefined): a
 }
 
 export function createConstantDefinition(
-    asType: PQP.Language.Type.PowerQueryType,
-    description: string,
     label: string,
-    primitiveType: PQP.Language.Type.TPrimitiveType,
+    description: string,
+    asType: PQP.Language.Type.PowerQueryType,
+    completionItemKind: CompletionItemKind,
 ): LibraryConstant {
     return {
         kind: LibraryDefinitionKind.Constant,
-        asType,
+        asPowerQueryType: asType,
+        completionItemKind,
         description,
         label,
-        primitiveType,
     };
 }
 
 export function createFunctionDefinition(
-    asType: PQP.Language.Type.PowerQueryType,
-    description: string,
     label: string,
-    primitiveType: PQP.Language.Type.TPrimitiveType,
+    description: string,
+    asType: PQP.Language.Type.PowerQueryType,
+    completionItemKind: CompletionItemKind,
     parameters: ReadonlyArray<LibraryParameter>,
 ): LibraryFunction {
     return {
         kind: LibraryDefinitionKind.Function,
-        asType,
+        asPowerQueryType: asType,
+        completionItemKind,
         description,
         label,
-        primitiveType,
         parameters,
     };
 }

--- a/src/powerquery-language-services/providers/commonTypes.ts
+++ b/src/powerquery-language-services/providers/commonTypes.ts
@@ -7,11 +7,11 @@ import type { Hover, Range, SignatureHelp } from "vscode-languageserver-types";
 import type { AutocompleteItem } from "../inspection/autocomplete/autocompleteItem";
 import type { ILibrary } from "../library/library";
 
-export interface CompletionItemProvider {
-    getAutocompleteItems(context: CompletionItemProviderContext): Promise<ReadonlyArray<AutocompleteItem>>;
+export interface AutocompleteItemProvider {
+    getAutocompleteItems(context: AutocompleteItemProviderContext): Promise<ReadonlyArray<AutocompleteItem>>;
 }
 
-export interface CompletionItemProviderContext extends ProviderContext {
+export interface AutocompleteItemProviderContext extends ProviderContext {
     readonly text?: string;
     readonly tokenKind?: string;
 }
@@ -39,4 +39,4 @@ export interface SignatureProviderContext extends ProviderContext {
     readonly functionType: PQP.Language.Type.PowerQueryType;
 }
 
-export interface ISymbolProvider extends CompletionItemProvider, HoverProvider, SignatureHelpProvider, ILibrary {}
+export interface ISymbolProvider extends AutocompleteItemProvider, HoverProvider, SignatureHelpProvider, ILibrary {}

--- a/src/powerquery-language-services/providers/commonTypes.ts
+++ b/src/powerquery-language-services/providers/commonTypes.ts
@@ -2,11 +2,12 @@
 // Licensed under the MIT license.
 
 import * as PQP from "@microsoft/powerquery-parser";
-import type { CompletionItem, Hover, Range, SignatureHelp } from "vscode-languageserver-types";
-import { ILibrary } from "../library/library";
+import type { Hover, Range, SignatureHelp } from "vscode-languageserver-types";
+import type { AutocompleteItem } from "../inspection/autocomplete/autocompleteItem";
+import type { ILibrary } from "../library/library";
 
 export interface CompletionItemProvider {
-    getCompletionItems(context: CompletionItemProviderContext): Promise<ReadonlyArray<CompletionItem>>;
+    getAutocompleteItems(context: CompletionItemProviderContext): Promise<ReadonlyArray<AutocompleteItem>>;
 }
 
 export interface CompletionItemProviderContext extends ProviderContext {

--- a/src/powerquery-language-services/providers/commonTypes.ts
+++ b/src/powerquery-language-services/providers/commonTypes.ts
@@ -3,6 +3,7 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 import type { Hover, Range, SignatureHelp } from "vscode-languageserver-types";
+
 import type { AutocompleteItem } from "../inspection/autocomplete/autocompleteItem";
 import type { ILibrary } from "../library/library";
 

--- a/src/powerquery-language-services/providers/index.ts
+++ b/src/powerquery-language-services/providers/index.ts
@@ -4,6 +4,6 @@
 export * from "./commonTypes";
 
 export { LibrarySymbolProvider } from "./librarySymbolProvider";
-export { LanguageCompletionItemProvider } from "./languageCompletionItemProvider";
+export { LanguageAutocompleteItemProvider } from "./languageCompletionItemProvider";
 export { LocalDocumentSymbolProvider } from "./localDocumentSymbolProvider";
 export { NullSymbolProvider } from "./nullSymbolProvider";

--- a/src/powerquery-language-services/providers/languageCompletionItemProvider.ts
+++ b/src/powerquery-language-services/providers/languageCompletionItemProvider.ts
@@ -6,9 +6,9 @@ import * as PQP from "@microsoft/powerquery-parser";
 import { Inspection } from "..";
 import { AutocompleteItem } from "../inspection/autocomplete/autocompleteItem";
 import { WorkspaceCache, WorkspaceCacheUtils } from "../workspaceCache";
-import { CompletionItemProvider, CompletionItemProviderContext } from "./commonTypes";
+import { AutocompleteItemProvider, AutocompleteItemProviderContext } from "./commonTypes";
 
-export class LanguageCompletionItemProvider implements CompletionItemProvider {
+export class LanguageAutocompleteItemProvider implements AutocompleteItemProvider {
     // Power Query defines constructor functions (ex. #table()) as keywords, but we want
     // them to be treated like library functions instead.
     private static readonly ExcludedKeywords: ReadonlyArray<string> = [
@@ -28,7 +28,7 @@ export class LanguageCompletionItemProvider implements CompletionItemProvider {
     constructor(private readonly maybeTriedInspection: WorkspaceCache.InspectionCacheItem) {}
 
     public async getAutocompleteItems(
-        _context: CompletionItemProviderContext,
+        _context: AutocompleteItemProviderContext,
     ): Promise<ReadonlyArray<AutocompleteItem>> {
         if (!WorkspaceCacheUtils.isInspectionTask(this.maybeTriedInspection)) {
             return [];
@@ -52,7 +52,7 @@ export class LanguageCompletionItemProvider implements CompletionItemProvider {
 
         return triedKeywordAutocomplete.value.filter(
             (autocompleteItem: AutocompleteItem) =>
-                LanguageCompletionItemProvider.ExcludedKeywords.includes(autocompleteItem.label) === false,
+                LanguageAutocompleteItemProvider.ExcludedKeywords.includes(autocompleteItem.label) === false,
         );
     }
 

--- a/src/powerquery-language-services/providers/librarySymbolProvider.ts
+++ b/src/powerquery-language-services/providers/librarySymbolProvider.ts
@@ -9,7 +9,7 @@ import { Inspection } from "..";
 import { AutocompleteItemUtils } from "../inspection";
 import { Library, LibraryUtils } from "../library";
 import {
-    CompletionItemProviderContext,
+    AutocompleteItemProviderContext,
     HoverProviderContext,
     ISymbolProvider,
     SignatureProviderContext,
@@ -27,7 +27,7 @@ export class LibrarySymbolProvider implements ISymbolProvider {
     }
 
     public async getAutocompleteItems(
-        context: CompletionItemProviderContext,
+        context: AutocompleteItemProviderContext,
     ): Promise<ReadonlyArray<Inspection.AutocompleteItem>> {
         if (!context.text || !context.range) {
             return [];

--- a/src/powerquery-language-services/providers/librarySymbolProvider.ts
+++ b/src/powerquery-language-services/providers/librarySymbolProvider.ts
@@ -58,7 +58,7 @@ export class LibrarySymbolProvider implements ISymbolProvider {
         const definition: Library.TLibraryDefinition = maybeDefinition;
 
         const definitionText: string = LibrarySymbolProvider.getDefinitionKindText(definition.kind);
-        const definitionTypeText: string = PQP.Language.TypeUtils.nameOf(definition.asType);
+        const definitionTypeText: string = PQP.Language.TypeUtils.nameOf(definition.asPowerQueryType);
 
         return {
             contents: {

--- a/src/powerquery-language-services/providers/localDocumentSymbolProvider.ts
+++ b/src/powerquery-language-services/providers/localDocumentSymbolProvider.ts
@@ -10,7 +10,7 @@ import * as InspectionUtils from "../inspectionUtils";
 import { Inspection, Library } from "..";
 import { WorkspaceCache, WorkspaceCacheUtils } from "../workspaceCache";
 import {
-    CompletionItemProviderContext,
+    AutocompleteItemProviderContext,
     HoverProviderContext,
     ISymbolProvider,
     SignatureProviderContext,
@@ -26,7 +26,7 @@ export class LocalDocumentSymbolProvider implements ISymbolProvider {
     }
 
     public async getAutocompleteItems(
-        context: CompletionItemProviderContext,
+        context: AutocompleteItemProviderContext,
     ): Promise<ReadonlyArray<Inspection.AutocompleteItem>> {
         const maybeInspection: Inspection.Inspection | undefined = this.getMaybeInspection();
         if (maybeInspection === undefined) {

--- a/src/powerquery-language-services/providers/nullSymbolProvider.ts
+++ b/src/powerquery-language-services/providers/nullSymbolProvider.ts
@@ -5,7 +5,7 @@ import { Inspection, Library } from "..";
 import { Hover, SignatureHelp } from "../commonTypes";
 import { AutocompleteItem } from "../inspection/autocomplete";
 import {
-    CompletionItemProviderContext,
+    AutocompleteItemProviderContext,
     HoverProviderContext,
     ISymbolProvider,
     SignatureProviderContext,
@@ -27,7 +27,7 @@ export class NullSymbolProvider implements ISymbolProvider {
     }
 
     public async getAutocompleteItems(
-        _context: CompletionItemProviderContext,
+        _context: AutocompleteItemProviderContext,
     ): Promise<ReadonlyArray<AutocompleteItem>> {
         return [];
     }

--- a/src/powerquery-language-services/providers/nullSymbolProvider.ts
+++ b/src/powerquery-language-services/providers/nullSymbolProvider.ts
@@ -3,7 +3,7 @@
 
 import { Inspection, Library } from "..";
 import { Hover, SignatureHelp } from "../commonTypes";
-import { AutocompleteItem } from "../inspection/autocomplete/autocompleteItem";
+import { AutocompleteItem } from "../inspection/autocomplete";
 import {
     CompletionItemProviderContext,
     HoverProviderContext,

--- a/src/powerquery-language-services/providers/nullSymbolProvider.ts
+++ b/src/powerquery-language-services/providers/nullSymbolProvider.ts
@@ -2,7 +2,8 @@
 // Licensed under the MIT license.
 
 import { Inspection, Library } from "..";
-import { CompletionItem, Hover, SignatureHelp } from "../commonTypes";
+import { Hover, SignatureHelp } from "../commonTypes";
+import { AutocompleteItem } from "../inspection/autocomplete/autocompleteItem";
 import {
     CompletionItemProviderContext,
     HoverProviderContext,
@@ -25,7 +26,9 @@ export class NullSymbolProvider implements ISymbolProvider {
         return NullSymbolProvider.instance;
     }
 
-    public async getCompletionItems(_context: CompletionItemProviderContext): Promise<ReadonlyArray<CompletionItem>> {
+    public async getAutocompleteItems(
+        _context: CompletionItemProviderContext,
+    ): Promise<ReadonlyArray<AutocompleteItem>> {
         return [];
     }
 

--- a/src/test/analysis.ts
+++ b/src/test/analysis.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 // tslint:disable: no-implicit-dependencies
-
 import { Assert } from "@microsoft/powerquery-parser";
 import { expect } from "chai";
 import "mocha";
@@ -16,9 +15,13 @@ describe("Analysis", () => {
         it(`prefer local over library`, async () => {
             const autocompleteItems: ReadonlyArray<AutocompleteItem> = await TestUtils.createAutocompleteItems(`
         let ${TestConstants.TestLibraryName.SquareIfNumber} = true in ${TestConstants.TestLibraryName.SquareIfNumber}|`);
+            const autocompleteItem: AutocompleteItem = Assert.asDefined(
+                autocompleteItems.find(
+                    (item: AutocompleteItem) => item.label === TestConstants.TestLibraryName.SquareIfNumber,
+                ),
+            );
 
-            expect(autocompleteItems.length).to.equal(1);
-            const autocompleteItem: AutocompleteItem = Assert.asDefined(autocompleteItems[0]);
+            expect(autocompleteItem.jaroWinklerScore).to.equal(1);
             expect(autocompleteItem.label === TestConstants.TestLibraryName.SquareIfNumber);
             expect(autocompleteItem.documentation).to.equal(undefined, "local definition should have no documentation");
         });

--- a/src/test/analysis.ts
+++ b/src/test/analysis.ts
@@ -8,18 +8,19 @@ import { expect } from "chai";
 import "mocha";
 
 import { TestConstants, TestUtils } from ".";
-import { CompletionItem, Hover, SignatureHelp } from "../powerquery-language-services";
+import { Hover, SignatureHelp } from "../powerquery-language-services";
+import type { AutocompleteItem } from "../powerquery-language-services/inspection";
 
 describe("Analysis", () => {
-    describe(`getCompletionItems;`, () => {
+    describe(`getAutocompleteItems;`, () => {
         it(`prefer local over library`, async () => {
-            const completionItems: ReadonlyArray<CompletionItem> = await TestUtils.createCompletionItems(`
+            const autocompleteItems: ReadonlyArray<AutocompleteItem> = await TestUtils.createAutocompleteItems(`
         let ${TestConstants.TestLibraryName.SquareIfNumber} = true in ${TestConstants.TestLibraryName.SquareIfNumber}|`);
 
-            expect(completionItems.length).to.equal(1);
-            const completionItem: CompletionItem = Assert.asDefined(completionItems[0]);
-            expect(completionItem.label === TestConstants.TestLibraryName.SquareIfNumber);
-            expect(completionItem.documentation).to.equal(undefined, "local definition should have no documentation");
+            expect(autocompleteItems.length).to.equal(1);
+            const autocompleteItem: AutocompleteItem = Assert.asDefined(autocompleteItems[0]);
+            expect(autocompleteItem.label === TestConstants.TestLibraryName.SquareIfNumber);
+            expect(autocompleteItem.documentation).to.equal(undefined, "local definition should have no documentation");
         });
     });
 

--- a/src/test/inspection/autocomplete/autocompleteFieldAccess.ts
+++ b/src/test/inspection/autocomplete/autocompleteFieldAccess.ts
@@ -4,28 +4,20 @@
 import * as PQP from "@microsoft/powerquery-parser";
 
 import { Assert } from "@microsoft/powerquery-parser";
-import { expect } from "chai";
 import "mocha";
 
 import { TestConstants, TestUtils } from "../..";
 import { Inspection } from "../../../powerquery-language-services";
-import {
-    AbridgedAutocompleteItem,
-    createAbridgedAutocompleteItems,
-    createTweakedAbridgedAutocompleteItems,
-} from "./common";
 
 function assertGetFieldAccessAutocomplete<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
     settings: PQP.LexSettings & PQP.ParseSettings<S> & Inspection.InspectionSettings,
     text: string,
     position: Inspection.Position,
-): ReadonlyArray<AbridgedAutocompleteItem> {
+): ReadonlyArray<Inspection.AutocompleteItem> {
     const actual: Inspection.Autocomplete = TestUtils.assertGetAutocomplete(settings, text, position);
     Assert.isOk(actual.triedFieldAccess);
 
-    return actual.triedFieldAccess.value
-        ? createAbridgedAutocompleteItems(actual.triedFieldAccess.value.autocompleteItems)
-        : [];
+    return actual.triedFieldAccess.value ? actual.triedFieldAccess.value.autocompleteItems : [];
 }
 
 describe(`Inspection - Autocomplete - FieldSelection`, () => {
@@ -35,71 +27,65 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
                 const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][x|]`,
                 );
-                const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-                const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const expected: ReadonlyArray<string> = [];
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultSettings,
                     text,
                     position,
                 );
-                expect(actual).to.deep.equal(expected);
+                TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
             it(`[cat = 1, car = 2][c|]`, () => {
                 const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][c|]`,
                 );
-                const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                    "cat",
-                    "car",
-                ]);
-                const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const expected: ReadonlyArray<string> = ["cat", "car"];
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultSettings,
                     text,
                     position,
                 );
-                expect(actual).to.deep.equal(expected);
+                TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
             it(`[cat = 1, car = 2][| c]`, () => {
                 const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][| c]`,
                 );
-                const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-                const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const expected: ReadonlyArray<string> = [];
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultSettings,
                     text,
                     position,
                 );
-                expect(actual).to.deep.equal(expected);
+                TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
             it(`[cat = 1, car = 2][c |]`, () => {
                 const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][c |]`,
                 );
-                const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-                const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const expected: ReadonlyArray<string> = [];
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultSettings,
                     text,
                     position,
                 );
-                expect(actual).to.deep.equal(expected);
+                TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
             it(`section x; value = [foo = 1, bar = 2, foobar = 3]; valueAccess = value[f|];`, () => {
                 const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                     `section x; value = [foo = 1, bar = 2, foobar = 3]; valueAccess = value[f|];`,
                 );
-                const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                    "foo",
-                    "foobar",
-                ]);
-                const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const expected: ReadonlyArray<string> = ["foo", "foobar"];
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultSettings,
                     text,
                     position,
                 );
-                expect(actual).to.deep.equal(expected);
+                TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
         });
 
@@ -108,104 +94,91 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
                 const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][|]`,
                 );
-                const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                    "cat",
-                    "car",
-                ]);
-                const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const expected: ReadonlyArray<string> = ["cat", "car"];
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultSettings,
                     text,
                     position,
                 );
-                expect(actual).to.deep.equal(expected);
+                TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
             it(`[cat = 1, car = 2]|[`, () => {
                 const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2]|[`,
                 );
-                const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-                const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const expected: ReadonlyArray<string> = [];
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultSettings,
                     text,
                     position,
                 );
-                expect(actual).to.deep.equal(expected);
+                TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
             it(`[cat = 1, car = 2][|`, () => {
                 const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][|`,
                 );
-                const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                    "cat",
-                    "car",
-                ]);
-                const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const expected: ReadonlyArray<string> = ["cat", "car"];
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultSettings,
                     text,
                     position,
                 );
-                expect(actual).to.deep.equal(expected);
+                TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
             it(`[cat = 1, car = 2][x|`, () => {
                 const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][x|`,
                 );
-                const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-                const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const expected: ReadonlyArray<string> = [];
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultSettings,
                     text,
                     position,
                 );
-                expect(actual).to.deep.equal(expected);
+                TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
             it(`[cat = 1, car = 2][c|`, () => {
                 const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][c|`,
                 );
-                const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                    "cat",
-                    "car",
-                ]);
-                const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const expected: ReadonlyArray<string> = ["cat", "car"];
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultSettings,
                     text,
                     position,
                 );
-                expect(actual).to.deep.equal(expected);
+                TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
             it(`[cat = 1, car = 2][c |`, () => {
                 const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][c |`,
                 );
-                const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-                const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const expected: ReadonlyArray<string> = [];
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultSettings,
                     text,
                     position,
                 );
-                expect(actual).to.deep.equal(expected);
+                TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
             it(`section x; value = [foo = 1, bar = 2, foobar = 3]; valueAccess = value[|`, () => {
                 const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                     `section x; value = [foo = 1, bar = 2, foobar = 3]; valueAccess = value[|`,
                 );
-                const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                    "foo",
-                    "bar",
-                    "foobar",
-                ]);
-                const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const expected: ReadonlyArray<string> = ["foo", "bar", "foobar"];
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultSettings,
                     text,
                     position,
                 );
-                expect(actual).to.deep.equal(expected);
+                TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
         });
     });
@@ -216,86 +189,79 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
                 const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [x|] ]`,
                 );
-                const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-                const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const expected: ReadonlyArray<string> = [];
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultSettings,
                     text,
                     position,
                 );
-                expect(actual).to.deep.equal(expected);
+                TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
             it(`[cat = 1, car = 2][ [c|] ]`, () => {
                 const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [c|] ]`,
                 );
-                const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                    "cat",
-                    "car",
-                ]);
-                const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const expected: ReadonlyArray<string> = ["cat", "car"];
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultSettings,
                     text,
                     position,
                 );
-                expect(actual).to.deep.equal(expected);
+                TestUtils.assertAutocompleteItemLabels(expected, actual);
+                TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
             it(`[cat = 1, car = 2][ [c |] ]`, () => {
                 const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [c |] ]`,
                 );
-                const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-                const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const expected: ReadonlyArray<string> = [];
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultSettings,
                     text,
                     position,
                 );
-                expect(actual).to.deep.equal(expected);
+                TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
             it(`[cat = 1, car = 2][ [x], [c|] ]`, () => {
                 const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [x], [c|] ]`,
                 );
-                const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                    "cat",
-                    "car",
-                ]);
-                const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const expected: ReadonlyArray<string> = ["cat", "car"];
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultSettings,
                     text,
                     position,
                 );
-                expect(actual).to.deep.equal(expected);
+                TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
             it(`[cat = 1, car = 2][ [cat], [c|] ]`, () => {
                 const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [cat], [c|] ]`,
                 );
-                const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                    "car",
-                ]);
-                const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const expected: ReadonlyArray<string> = ["car"];
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultSettings,
                     text,
                     position,
                 );
-                expect(actual).to.deep.equal(expected);
+                TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
             it(`[cat = 1, car = 2][ [cat], [car], [c|] ]`, () => {
                 const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [cat], [car], [c|] ]`,
                 );
-                const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-                const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const expected: ReadonlyArray<string> = [];
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultSettings,
                     text,
                     position,
                 );
-                expect(actual).to.deep.equal(expected);
+                TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
         });
 
@@ -304,199 +270,182 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
                 const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [|`,
                 );
-                const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                    "cat",
-                    "car",
-                ]);
-                const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const expected: ReadonlyArray<string> = ["cat", "car"];
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultSettings,
                     text,
                     position,
                 );
-                expect(actual).to.deep.equal(expected);
+                TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
             it(`[cat = 1, car = 2][ [ |`, () => {
                 const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [ |`,
                 );
-                const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                    "cat",
-                    "car",
-                ]);
-                const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const expected: ReadonlyArray<string> = ["cat", "car"];
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultSettings,
                     text,
                     position,
                 );
-                expect(actual).to.deep.equal(expected);
+                TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
             it(`[cat = 1, car = 2][ [ c|`, () => {
                 const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [ c|`,
                 );
-                const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                    "cat",
-                    "car",
-                ]);
-                const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const expected: ReadonlyArray<string> = ["cat", "car"];
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultSettings,
                     text,
                     position,
                 );
-                expect(actual).to.deep.equal(expected);
+                TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
             it(`[cat = 1, car = 2][ [ cat|`, () => {
                 const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [ cat|`,
                 );
-                const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                    "cat",
-                ]);
-                const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const expected: ReadonlyArray<string> = ["cat"];
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultSettings,
                     text,
                     position,
                 );
-                expect(actual).to.deep.equal(expected);
+                TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
             it(`[cat = 1, car = 2][ [ cat |`, () => {
                 const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [ cat |`,
                 );
-                const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-                const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const expected: ReadonlyArray<string> = [];
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultSettings,
                     text,
                     position,
                 );
-                expect(actual).to.deep.equal(expected);
+                TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
             it(`[cat = 1, car = 2][ [ cat ]|`, () => {
                 const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [ cat ]|`,
                 );
-                const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-                const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const expected: ReadonlyArray<string> = [];
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultSettings,
                     text,
                     position,
                 );
-                expect(actual).to.deep.equal(expected);
+                TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
             it(`[cat = 1, car = 2][ [ cat ] |`, () => {
                 const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [ cat ] |`,
                 );
-                const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-                const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const expected: ReadonlyArray<string> = [];
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultSettings,
                     text,
                     position,
                 );
-                expect(actual).to.deep.equal(expected);
+                TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
             it(`[cat = 1, car = 2][ [ cat ]|`, () => {
                 const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [ cat ]|`,
                 );
-                const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-                const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const expected: ReadonlyArray<string> = [];
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultSettings,
                     text,
                     position,
                 );
-                expect(actual).to.deep.equal(expected);
+                TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
             it(`[cat = 1, car = 2][ [ cat ]|`, () => {
                 const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [ cat ]|`,
                 );
-                const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-                const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const expected: ReadonlyArray<string> = [];
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultSettings,
                     text,
                     position,
                 );
-                expect(actual).to.deep.equal(expected);
+                TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
             it(`[cat = 1, car = 2][ [ cat ], |`, () => {
                 const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [ cat ], |`,
                 );
-                const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-                const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const expected: ReadonlyArray<string> = [];
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultSettings,
                     text,
                     position,
                 );
-                expect(actual).to.deep.equal(expected);
+                TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
             it(`[cat = 1, car = 2][ [ cat ], [|`, () => {
                 const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [ cat ], [|`,
                 );
-                const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                    "car",
-                ]);
-                const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const expected: ReadonlyArray<string> = ["car"];
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultSettings,
                     text,
                     position,
                 );
-                expect(actual).to.deep.equal(expected);
+                TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
             it(`[cat = 1, car = 2][ [ cat ], [|<>`, () => {
                 const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [ cat ], [|<>`,
                 );
-                const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                    "car",
-                ]);
-                const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const expected: ReadonlyArray<string> = ["car"];
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultSettings,
                     text,
                     position,
                 );
-                expect(actual).to.deep.equal(expected);
+                TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
             it(`[cat = 1, car = 2][ [ cat ], [| <>`, () => {
                 const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [ cat ], [| <>`,
                 );
-                const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                    "car",
-                ]);
-                const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const expected: ReadonlyArray<string> = ["car"];
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultSettings,
                     text,
                     position,
                 );
-                expect(actual).to.deep.equal(expected);
+                TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
             it(`[cat = 1, car = 2][ [ cat ], [<>|`, () => {
                 const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [ cat ], [<>|`,
                 );
-                const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-                const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const expected: ReadonlyArray<string> = [];
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultSettings,
                     text,
                     position,
                 );
-                expect(actual).to.deep.equal(expected);
+                TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
         });
     });
@@ -506,64 +455,52 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `let fn = () => [cat = 1, car = 2] in fn()[|`,
             );
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                "cat",
-                "car",
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+            const expected: ReadonlyArray<string> = ["cat", "car"];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                 TestConstants.DefaultSettings,
                 text,
                 position,
             );
-            expect(actual).to.deep.equal(expected);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`let foo = () => [cat = 1, car = 2], bar = foo in bar()[|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `let foo = () => [cat = 1, car = 2], bar = foo in bar()[|`,
             );
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                "cat",
-                "car",
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+            const expected: ReadonlyArray<string> = ["cat", "car"];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                 TestConstants.DefaultSettings,
                 text,
                 position,
             );
-            expect(actual).to.deep.equal(expected);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`let foo = () => [cat = 1, car = 2], bar = () => foo in bar()()[|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `let foo = () => [cat = 1, car = 2], bar = () => foo in bar()()[|`,
             );
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                "cat",
-                "car",
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+            const expected: ReadonlyArray<string> = ["cat", "car"];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                 TestConstants.DefaultSettings,
                 text,
                 position,
             );
-            expect(actual).to.deep.equal(expected);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`let foo = () => if true then [cat = 1] else [car = 2] in foo()[|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `let foo = () => if true then [cat = 1] else [car = 2] in foo()[|`,
             );
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                "cat",
-                "car",
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+            const expected: ReadonlyArray<string> = ["cat", "car"];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                 TestConstants.DefaultSettings,
                 text,
                 position,
             );
-            expect(actual).to.deep.equal(expected);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 
@@ -572,16 +509,13 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `[#"regularIdentifier" = 1, #"generalized identifier" = 2][|`,
             );
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                `regularIdentifier`,
-                `#"generalized identifier"`,
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetFieldAccessAutocomplete(
+            const expected: ReadonlyArray<string> = [`regularIdentifier`, `#"generalized identifier"`];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
                 TestConstants.DefaultSettings,
                 text,
                 position,
             );
-            expect(actual).to.deep.equal(expected);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 });

--- a/src/test/inspection/autocomplete/autocompleteKeyword.ts
+++ b/src/test/inspection/autocomplete/autocompleteKeyword.ts
@@ -9,285 +9,313 @@ import "mocha";
 
 import { TestConstants, TestUtils } from "../..";
 import { Inspection } from "../../../powerquery-language-services";
+import {
+    AbridgedAutocompleteItem,
+    createAbridgedAutocompleteItems,
+    createTweakedAbridgedAutocompleteItems,
+} from "./common";
 
-function assertGetParseOkAutocompleteOkKeyword(
+function assertGetKeywordAutocomplete(
     text: string,
     position: Inspection.Position,
-): Inspection.AutocompleteKeyword {
+): ReadonlyArray<AbridgedAutocompleteItem> {
     const actual: Inspection.Autocomplete = TestUtils.assertGetAutocomplete(
         TestConstants.DefaultSettings,
         text,
         position,
     );
     Assert.isOk(actual.triedKeyword);
-    return actual.triedKeyword.value;
+    return createAbridgedAutocompleteItems(actual.triedKeyword.value);
 }
 
-function assertGetParseErrAutocompleteOkKeyword(
-    text: string,
-    position: Inspection.Position,
-): Inspection.AutocompleteKeyword {
-    const actual: Inspection.Autocomplete = TestUtils.assertGetAutocomplete(
-        TestConstants.DefaultSettings,
-        text,
-        position,
-    );
-    Assert.isOk(actual.triedKeyword);
-    return actual.triedKeyword.value;
-}
+const AbridgedExpressionAutocompleteItems: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems(
+    PQP.Language.Keyword.ExpressionKeywordKinds,
+);
 
 describe(`Inspection - Autocomplete - Keyword`, () => {
     it("|", () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`|`);
-        const expected: Inspection.AutocompleteKeyword = [
+        const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
             ...PQP.Language.Keyword.ExpressionKeywordKinds,
             PQP.Language.Keyword.KeywordKind.Section,
-        ];
-        const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-        expect(actual).to.have.members(expected);
+        ]);
+        const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+        expect(actual).to.deep.equal(expected);
     });
 
     describe("partial keyword", () => {
         it("a|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`a|`);
-            const expected: Inspection.AutocompleteKeyword = [];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseOkAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it("x a|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`x a|`);
-            const expected: Inspection.AutocompleteKeyword = [
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
                 PQP.Language.Keyword.KeywordKind.And,
                 PQP.Language.Keyword.KeywordKind.As,
-            ];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            ]);
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it("e|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`e|`);
-            const expected: Inspection.AutocompleteKeyword = [
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
                 PQP.Language.Keyword.KeywordKind.Each,
                 PQP.Language.Keyword.KeywordKind.Error,
-            ];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseOkAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            ]);
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it("if x then x e|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `if x then x e|`,
             );
-            const expected: Inspection.AutocompleteKeyword = [PQP.Language.Keyword.KeywordKind.Else];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+                PQP.Language.Keyword.KeywordKind.Else,
+            ]);
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it("i|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`i|`);
-            const expected: Inspection.AutocompleteKeyword = [PQP.Language.Keyword.KeywordKind.If];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseOkAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+                PQP.Language.Keyword.KeywordKind.If,
+            ]);
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it("l|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`l|`);
-            const expected: Inspection.AutocompleteKeyword = [PQP.Language.Keyword.KeywordKind.Let];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseOkAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+                PQP.Language.Keyword.KeywordKind.Let,
+            ]);
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it("m|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`m|`);
-            const expected: Inspection.AutocompleteKeyword = [];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseOkAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it("x m|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`x m|`);
-            const expected: Inspection.AutocompleteKeyword = [PQP.Language.Keyword.KeywordKind.Meta];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+                PQP.Language.Keyword.KeywordKind.Meta,
+            ]);
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it("n|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`n|`);
-            const expected: Inspection.AutocompleteKeyword = [PQP.Language.Keyword.KeywordKind.Not];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseOkAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+                PQP.Language.Keyword.KeywordKind.Not,
+            ]);
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it("true o|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`true o|`);
-            const expected: Inspection.AutocompleteKeyword = [PQP.Language.Keyword.KeywordKind.Or];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+                PQP.Language.Keyword.KeywordKind.Or,
+            ]);
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it("try true o|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`try true o|`);
-            const expected: Inspection.AutocompleteKeyword = [
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
                 PQP.Language.Keyword.KeywordKind.Or,
                 PQP.Language.Keyword.KeywordKind.Otherwise,
-            ];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            ]);
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it("try true o |", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`try true o |`);
-            const expected: Inspection.AutocompleteKeyword = [];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it("try true ot|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`try true ot|`);
-            const expected: Inspection.AutocompleteKeyword = [PQP.Language.Keyword.KeywordKind.Otherwise];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+                PQP.Language.Keyword.KeywordKind.Otherwise,
+            ]);
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it("try true oth|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `try true oth|`,
             );
-            const expected: Inspection.AutocompleteKeyword = [PQP.Language.Keyword.KeywordKind.Otherwise];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+                PQP.Language.Keyword.KeywordKind.Otherwise,
+            ]);
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it("s|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`s|`);
-            const expected: Inspection.AutocompleteKeyword = [PQP.Language.Keyword.KeywordKind.Section];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseOkAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems(
+                [PQP.Language.Keyword.KeywordKind.Section],
+                new Map([[PQP.Language.Keyword.KeywordKind.Section, 0.7428571428571429]]),
+            );
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it("[] |", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`[] |`);
-            const expected: Inspection.AutocompleteKeyword = [PQP.Language.Keyword.KeywordKind.Section];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseOkAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+                PQP.Language.Keyword.KeywordKind.Section,
+            ]);
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it("[] |s", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`[] |s`);
-            const expected: Inspection.AutocompleteKeyword = [];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it("[] s|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`[] s|`);
-            const expected: Inspection.AutocompleteKeyword = [PQP.Language.Keyword.KeywordKind.Section];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+                PQP.Language.Keyword.KeywordKind.Section,
+            ]);
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it("[] s |", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`[] s |`);
-            const expected: Inspection.AutocompleteKeyword = [];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it("section; s|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`section; s|`);
-            const expected: Inspection.AutocompleteKeyword = [PQP.Language.Keyword.KeywordKind.Shared];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems(
+                [PQP.Language.Keyword.KeywordKind.Shared],
+                new Map([[PQP.Language.Keyword.KeywordKind.Shared, 0.7500000000000001]]),
+            );
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it("section; shared x|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `section; shared x|`,
             );
-            const expected: Inspection.AutocompleteKeyword = [];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it("section; [] s|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `section; [] s|`,
             );
-            const expected: Inspection.AutocompleteKeyword = [PQP.Language.Keyword.KeywordKind.Shared];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+                PQP.Language.Keyword.KeywordKind.Shared,
+            ]);
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it("if true t|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if true t|`);
-            const expected: Inspection.AutocompleteKeyword = [PQP.Language.Keyword.KeywordKind.Then];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+                PQP.Language.Keyword.KeywordKind.Then,
+            ]);
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it("t|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`t|`);
-            const expected: Inspection.AutocompleteKeyword = [
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
                 PQP.Language.Keyword.KeywordKind.True,
                 PQP.Language.Keyword.KeywordKind.Try,
                 PQP.Language.Keyword.KeywordKind.Type,
-            ];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseOkAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            ]);
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
     });
 
     describe(`${PQP.Language.Ast.NodeKind.ErrorHandlingExpression}`, () => {
         it(`try |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`try |`);
-            const expected: Inspection.AutocompleteKeyword = PQP.Language.Keyword.ExpressionKeywordKinds;
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`try true|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`try true|`);
-            const expected: Inspection.AutocompleteKeyword = [PQP.Language.Keyword.KeywordKind.True];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseOkAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+                PQP.Language.Keyword.KeywordKind.True,
+            ]);
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`try true |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`try true |`);
-            const expected: Inspection.AutocompleteKeyword = [
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
                 PQP.Language.Keyword.KeywordKind.And,
                 PQP.Language.Keyword.KeywordKind.As,
                 PQP.Language.Keyword.KeywordKind.Is,
                 PQP.Language.Keyword.KeywordKind.Meta,
                 PQP.Language.Keyword.KeywordKind.Or,
                 PQP.Language.Keyword.KeywordKind.Otherwise,
-            ];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseOkAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            ]);
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
     });
 
     describe(`${PQP.Language.Ast.NodeKind.ErrorRaisingExpression}`, () => {
         it(`if |error`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if |error`);
-            const expected: Inspection.AutocompleteKeyword = PQP.Language.Keyword.ExpressionKeywordKinds;
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`if error|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if error|`);
-            const expected: Inspection.AutocompleteKeyword = [];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`error |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`error |`);
-            const expected: Inspection.AutocompleteKeyword = PQP.Language.Keyword.ExpressionKeywordKinds;
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
     });
 
@@ -296,207 +324,221 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `let x = (_ |) => a in x`,
             );
-            const expected: Inspection.AutocompleteKeyword = [PQP.Language.Keyword.KeywordKind.As];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseOkAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+                PQP.Language.Keyword.KeywordKind.As,
+            ]);
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`let x = (_ a|) => a in`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `let x = (_ a|) => a in`,
             );
-            const expected: Inspection.AutocompleteKeyword = [PQP.Language.Keyword.KeywordKind.As];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+                PQP.Language.Keyword.KeywordKind.As,
+            ]);
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
     });
 
     describe(`${PQP.Language.Ast.NodeKind.IfExpression}`, () => {
         it(`if|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if|`);
-            const expected: Inspection.AutocompleteKeyword = [];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(` if |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if |`);
-            const expected: Inspection.AutocompleteKeyword = PQP.Language.Keyword.ExpressionKeywordKinds;
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`if 1|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if 1|`);
-            const expected: Inspection.AutocompleteKeyword = [];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`if |if`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if |if`);
-            const expected: Inspection.AutocompleteKeyword = PQP.Language.Keyword.ExpressionKeywordKinds;
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`if i|f`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if i|f`);
-            const expected: Inspection.AutocompleteKeyword = [PQP.Language.Keyword.KeywordKind.If];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+                PQP.Language.Keyword.KeywordKind.If,
+            ]);
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`if if | `, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if if |`);
-            const expected: Inspection.AutocompleteKeyword = PQP.Language.Keyword.ExpressionKeywordKinds;
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`if 1 |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if 1 |`);
-            const expected: Inspection.AutocompleteKeyword = [PQP.Language.Keyword.KeywordKind.Then];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+                PQP.Language.Keyword.KeywordKind.Then,
+            ]);
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`if 1 t|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if 1 t|`);
-            const expected: Inspection.AutocompleteKeyword = [PQP.Language.Keyword.KeywordKind.Then];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+                PQP.Language.Keyword.KeywordKind.Then,
+            ]);
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`if 1 then |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if 1 then |`);
-            const expected: Inspection.AutocompleteKeyword = PQP.Language.Keyword.ExpressionKeywordKinds;
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`if 1 then 1|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if 1 then 1|`);
-            const expected: Inspection.AutocompleteKeyword = [];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`if 1 then 1 e|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `if 1 then 1 e|`,
             );
-            const expected: Inspection.AutocompleteKeyword = [PQP.Language.Keyword.KeywordKind.Else];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+                PQP.Language.Keyword.KeywordKind.Else,
+            ]);
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`if 1 then 1 else|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `if 1 then 1 else|`,
             );
-            const expected: Inspection.AutocompleteKeyword = [];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`if 1 th|en 1 else`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `if 1 th|en 1 else`,
             );
-            const expected: Inspection.AutocompleteKeyword = [PQP.Language.Keyword.KeywordKind.Then];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+                PQP.Language.Keyword.KeywordKind.Then,
+            ]);
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`if 1 then 1 else |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `if 1 then 1 else |`,
             );
-            const expected: Inspection.AutocompleteKeyword = PQP.Language.Keyword.ExpressionKeywordKinds;
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
     });
 
     describe(`${PQP.Language.Ast.NodeKind.InvokeExpression}`, () => {
         it(`foo(|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`foo(|`);
-            const expected: Inspection.AutocompleteKeyword = PQP.Language.Keyword.ExpressionKeywordKinds;
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`foo(a|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`foo(a|`);
-            const expected: Inspection.AutocompleteKeyword = [];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`foo(a|,`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`foo(a|,`);
-            const expected: Inspection.AutocompleteKeyword = [];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`foo(a,|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`foo(a,|`);
-            const expected: Inspection.AutocompleteKeyword = PQP.Language.Keyword.ExpressionKeywordKinds;
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
     });
 
     describe(`${PQP.Language.Ast.NodeKind.ListExpression}`, () => {
         it(`{|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`{|`);
-            const expected: Inspection.AutocompleteKeyword = PQP.Language.Keyword.ExpressionKeywordKinds;
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`{1|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`{1|`);
-            const expected: Inspection.AutocompleteKeyword = [];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`{1|,`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`{1|,`);
-            const expected: Inspection.AutocompleteKeyword = [];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`{1,|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`{1,|`);
-            const expected: Inspection.AutocompleteKeyword = PQP.Language.Keyword.ExpressionKeywordKinds;
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`{1,|2`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`{1,|2`);
-            const expected: Inspection.AutocompleteKeyword = PQP.Language.Keyword.ExpressionKeywordKinds;
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`{1,|2,`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`{1,|2,`);
-            const expected: Inspection.AutocompleteKeyword = PQP.Language.Keyword.ExpressionKeywordKinds;
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`{1..|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`{1..|`);
-            const expected: Inspection.AutocompleteKeyword = PQP.Language.Keyword.ExpressionKeywordKinds;
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
     });
 
@@ -505,225 +547,227 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `try true otherwise| false`,
             );
-            const expected: Inspection.AutocompleteKeyword = [];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseOkAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`try true otherwise |false`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `try true otherwise |false`,
             );
-            const expected: Inspection.AutocompleteKeyword = PQP.Language.Keyword.ExpressionKeywordKinds;
-            const actual: Inspection.AutocompleteKeyword = assertGetParseOkAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`try true oth|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `try true oth|`,
             );
-            const expected: Inspection.AutocompleteKeyword = [PQP.Language.Keyword.KeywordKind.Otherwise];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+                PQP.Language.Keyword.KeywordKind.Otherwise,
+            ]);
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`try true otherwise |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `try true otherwise |`,
             );
-            const expected: Inspection.AutocompleteKeyword = PQP.Language.Keyword.ExpressionKeywordKinds;
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
     });
 
     describe(`${PQP.Language.Ast.NodeKind.ParenthesizedExpression}`, () => {
         it(`+(|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+(|`);
-            const expected: Inspection.AutocompleteKeyword = PQP.Language.Keyword.ExpressionKeywordKinds;
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
     });
 
     describe(`${PQP.Language.Ast.NodeKind.RecordExpression}`, () => {
         it(`+[|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[|`);
-            const expected: Inspection.AutocompleteKeyword = [];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`+[a=|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[a=|`);
-            const expected: Inspection.AutocompleteKeyword = PQP.Language.Keyword.ExpressionKeywordKinds;
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`+[a=1|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[a=1|`);
-            const expected: Inspection.AutocompleteKeyword = [];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`+[a|=1`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[a|=1`);
-            const expected: Inspection.AutocompleteKeyword = [];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`+[a=1|]`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[a=1|]`);
-            const expected: Inspection.AutocompleteKeyword = [];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseOkAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`+[a=|1]`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[a=| 1]`);
-            const expected: Inspection.AutocompleteKeyword = PQP.Language.Keyword.ExpressionKeywordKinds;
-            const actual: Inspection.AutocompleteKeyword = assertGetParseOkAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`+[a=1|,`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[a=1|`);
-            const expected: Inspection.AutocompleteKeyword = [];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`+[a=1,|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[a=1,|`);
-            const expected: Inspection.AutocompleteKeyword = [];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`+[a=1|,b`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[a=1|,b`);
-            const expected: Inspection.AutocompleteKeyword = [];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`+[a=1|,b=`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[a=1|,b=`);
-            const expected: Inspection.AutocompleteKeyword = [];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`+[a=|1,b=`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[a=|1,b=`);
-            const expected: Inspection.AutocompleteKeyword = PQP.Language.Keyword.ExpressionKeywordKinds;
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`+[a=1,b=2|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[a=1,b=2|`);
-            const expected: Inspection.AutocompleteKeyword = [];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`+[a=1,b=2 |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[a=1,b=2 |`);
-            const expected: Inspection.AutocompleteKeyword = [];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
     });
 
     describe(`AutocompleteExpression`, () => {
         it(`error |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`error |`);
-            const expected: Inspection.AutocompleteKeyword = PQP.Language.Keyword.ExpressionKeywordKinds;
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`let x = |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`let x = |`);
-            const expected: Inspection.AutocompleteKeyword = PQP.Language.Keyword.ExpressionKeywordKinds;
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`() => |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`() => |`);
-            const expected: Inspection.AutocompleteKeyword = PQP.Language.Keyword.ExpressionKeywordKinds;
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`if |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if |`);
-            const expected: Inspection.AutocompleteKeyword = PQP.Language.Keyword.ExpressionKeywordKinds;
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`if true then |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `if true then |`,
             );
-            const expected: Inspection.AutocompleteKeyword = PQP.Language.Keyword.ExpressionKeywordKinds;
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`if true then true else |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `if true then true else |`,
             );
-            const expected: Inspection.AutocompleteKeyword = PQP.Language.Keyword.ExpressionKeywordKinds;
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`foo(|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`foo(|`);
-            const expected: Inspection.AutocompleteKeyword = PQP.Language.Keyword.ExpressionKeywordKinds;
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`let x = 1 in |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `let x = 1 in |`,
             );
-            const expected: Inspection.AutocompleteKeyword = PQP.Language.Keyword.ExpressionKeywordKinds;
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`+{|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+{|`);
-            const expected: Inspection.AutocompleteKeyword = PQP.Language.Keyword.ExpressionKeywordKinds;
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`try true otherwise |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `try true otherwise |`,
             );
-            const expected: Inspection.AutocompleteKeyword = PQP.Language.Keyword.ExpressionKeywordKinds;
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`+(|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+(|`);
-            const expected: Inspection.AutocompleteKeyword = PQP.Language.Keyword.ExpressionKeywordKinds;
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
     });
 
@@ -732,171 +776,179 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `section; [] |`,
             );
-            const expected: Inspection.AutocompleteKeyword = [PQP.Language.Keyword.KeywordKind.Shared];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+                PQP.Language.Keyword.KeywordKind.Shared,
+            ]);
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`section; [] x |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `section; [] x |`,
             );
-            const expected: Inspection.AutocompleteKeyword = [];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`section; x = |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `section; x = |`,
             );
-            const expected: Inspection.AutocompleteKeyword = PQP.Language.Keyword.ExpressionKeywordKinds;
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`section; x = 1 |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `section; x = 1 |`,
             );
-            const expected: Inspection.AutocompleteKeyword = [
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
                 PQP.Language.Keyword.KeywordKind.And,
                 PQP.Language.Keyword.KeywordKind.As,
                 PQP.Language.Keyword.KeywordKind.Is,
                 PQP.Language.Keyword.KeywordKind.Meta,
                 PQP.Language.Keyword.KeywordKind.Or,
-            ];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            ]);
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`section; x = 1 i|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `section; x = 1 i|`,
             );
-            const expected: Inspection.AutocompleteKeyword = [PQP.Language.Keyword.KeywordKind.Is];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+                PQP.Language.Keyword.KeywordKind.Is,
+            ]);
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`section foo; a = () => true; b = "string"; c = 1; d = |;`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `section foo; a = () => true; b = "string"; c = 1; d = |;`,
             );
-            const expected: Inspection.AutocompleteKeyword = PQP.Language.Keyword.ExpressionKeywordKinds;
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
     });
 
     describe(`${PQP.Language.Ast.NodeKind.LetExpression}`, () => {
         it(`let a = |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`let a = |`);
-            const expected: Inspection.AutocompleteKeyword = PQP.Language.Keyword.ExpressionKeywordKinds;
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`let a = 1|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`let a = 1|`);
-            const expected: Inspection.AutocompleteKeyword = [];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`let a = 1 |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`let a = 1 |`);
-            const expected: Inspection.AutocompleteKeyword = [
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
                 PQP.Language.Keyword.KeywordKind.And,
                 PQP.Language.Keyword.KeywordKind.As,
-                PQP.Language.Keyword.KeywordKind.In,
                 PQP.Language.Keyword.KeywordKind.Is,
                 PQP.Language.Keyword.KeywordKind.Meta,
                 PQP.Language.Keyword.KeywordKind.Or,
-            ];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+                PQP.Language.Keyword.KeywordKind.In,
+            ]);
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`let a = 1 | foobar`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `let a = 1 | foobar`,
             );
-            const expected: Inspection.AutocompleteKeyword = [
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
                 PQP.Language.Keyword.KeywordKind.And,
                 PQP.Language.Keyword.KeywordKind.As,
-                PQP.Language.Keyword.KeywordKind.In,
                 PQP.Language.Keyword.KeywordKind.Is,
                 PQP.Language.Keyword.KeywordKind.Meta,
                 PQP.Language.Keyword.KeywordKind.Or,
-            ];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+                PQP.Language.Keyword.KeywordKind.In,
+            ]);
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`let a = 1 i|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`let a = 1 i|`);
-            const expected: Inspection.AutocompleteKeyword = [
-                PQP.Language.Keyword.KeywordKind.In,
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
                 PQP.Language.Keyword.KeywordKind.Is,
-            ];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+                PQP.Language.Keyword.KeywordKind.In,
+            ]);
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`let a = 1 o|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`let a = 1 o|`);
-            const expected: Inspection.AutocompleteKeyword = [PQP.Language.Keyword.KeywordKind.Or];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+                PQP.Language.Keyword.KeywordKind.Or,
+            ]);
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`let a = 1 m|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`let a = 1 m|`);
-            const expected: Inspection.AutocompleteKeyword = [PQP.Language.Keyword.KeywordKind.Meta];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+                PQP.Language.Keyword.KeywordKind.Meta,
+            ]);
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`let a = 1, |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`let a = 1, |`);
-            const expected: Inspection.AutocompleteKeyword = [];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`let a = let b = |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `let a = let b = |`,
             );
-            const expected: Inspection.AutocompleteKeyword = PQP.Language.Keyword.ExpressionKeywordKinds;
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`let a = let b = 1 |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `let a = let b = 1 |`,
             );
-            const expected: Inspection.AutocompleteKeyword = [
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
                 PQP.Language.Keyword.KeywordKind.And,
                 PQP.Language.Keyword.KeywordKind.As,
-                PQP.Language.Keyword.KeywordKind.In,
                 PQP.Language.Keyword.KeywordKind.Is,
                 PQP.Language.Keyword.KeywordKind.Meta,
                 PQP.Language.Keyword.KeywordKind.Or,
-            ];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+                PQP.Language.Keyword.KeywordKind.In,
+            ]);
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
 
         it(`let a = let b = 1, |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `let a = let b = 1, |`,
             );
-            const expected: Inspection.AutocompleteKeyword = [];
-            const actual: Inspection.AutocompleteKeyword = assertGetParseErrAutocompleteOkKeyword(text, position);
-            expect(actual).to.have.members(expected);
+            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
+            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            expect(actual).to.deep.equal(expected);
         });
     });
 });

--- a/src/test/inspection/autocomplete/autocompleteKeyword.ts
+++ b/src/test/inspection/autocomplete/autocompleteKeyword.ts
@@ -4,318 +4,289 @@
 import * as PQP from "@microsoft/powerquery-parser";
 
 import { Assert } from "@microsoft/powerquery-parser";
-import { expect } from "chai";
 import "mocha";
 
 import { TestConstants, TestUtils } from "../..";
 import { Inspection } from "../../../powerquery-language-services";
-import {
-    AbridgedAutocompleteItem,
-    createAbridgedAutocompleteItems,
-    createTweakedAbridgedAutocompleteItems,
-} from "./common";
 
 function assertGetKeywordAutocomplete(
     text: string,
     position: Inspection.Position,
-): ReadonlyArray<AbridgedAutocompleteItem> {
+): ReadonlyArray<Inspection.AutocompleteItem> {
     const actual: Inspection.Autocomplete = TestUtils.assertGetAutocomplete(
         TestConstants.DefaultSettings,
         text,
         position,
     );
     Assert.isOk(actual.triedKeyword);
-    return createAbridgedAutocompleteItems(actual.triedKeyword.value);
+    return actual.triedKeyword.value;
 }
-
-const AbridgedExpressionAutocompleteItems: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems(
-    PQP.Language.Keyword.ExpressionKeywordKinds,
-);
 
 describe(`Inspection - Autocomplete - Keyword`, () => {
     it("|", () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`|`);
-        const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+        const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
             ...PQP.Language.Keyword.ExpressionKeywordKinds,
             PQP.Language.Keyword.KeywordKind.Section,
-        ]);
-        const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-        expect(actual).to.deep.equal(expected);
+        ];
+        const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+        TestUtils.assertAutocompleteItemLabels(expected, actual);
     });
 
     describe("partial keyword", () => {
         it("a|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`a|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("x a|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`x a|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
                 PQP.Language.Keyword.KeywordKind.And,
                 PQP.Language.Keyword.KeywordKind.As,
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            ];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("e|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`e|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
                 PQP.Language.Keyword.KeywordKind.Each,
                 PQP.Language.Keyword.KeywordKind.Error,
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            ];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("if x then x e|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `if x then x e|`,
             );
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                PQP.Language.Keyword.KeywordKind.Else,
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Else];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("i|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`i|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                PQP.Language.Keyword.KeywordKind.If,
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.If];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("l|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`l|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                PQP.Language.Keyword.KeywordKind.Let,
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Let];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("m|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`m|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("x m|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`x m|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                PQP.Language.Keyword.KeywordKind.Meta,
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Meta];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("n|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`n|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                PQP.Language.Keyword.KeywordKind.Not,
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Not];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("true o|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`true o|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                PQP.Language.Keyword.KeywordKind.Or,
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Or];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("try true o|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`try true o|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
                 PQP.Language.Keyword.KeywordKind.Or,
                 PQP.Language.Keyword.KeywordKind.Otherwise,
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            ];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("try true o |", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`try true o |`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("try true ot|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`try true ot|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
                 PQP.Language.Keyword.KeywordKind.Otherwise,
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            ];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("try true oth|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `try true oth|`,
             );
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
                 PQP.Language.Keyword.KeywordKind.Otherwise,
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            ];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("s|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`s|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems(
-                [PQP.Language.Keyword.KeywordKind.Section],
-                new Map([[PQP.Language.Keyword.KeywordKind.Section, 0.7428571428571429]]),
-            );
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
+                PQP.Language.Keyword.KeywordKind.Section,
+            ];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("[] |", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`[] |`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
                 PQP.Language.Keyword.KeywordKind.Section,
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            ];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("[] |s", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`[] |s`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("[] s|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`[] s|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
                 PQP.Language.Keyword.KeywordKind.Section,
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            ];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("[] s |", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`[] s |`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("section; s|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`section; s|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems(
-                [PQP.Language.Keyword.KeywordKind.Shared],
-                new Map([[PQP.Language.Keyword.KeywordKind.Shared, 0.7500000000000001]]),
-            );
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Shared];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("section; shared x|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `section; shared x|`,
             );
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("section; [] s|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `section; [] s|`,
             );
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                PQP.Language.Keyword.KeywordKind.Shared,
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Shared];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("if true t|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if true t|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                PQP.Language.Keyword.KeywordKind.Then,
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Then];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("t|", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`t|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
                 PQP.Language.Keyword.KeywordKind.True,
                 PQP.Language.Keyword.KeywordKind.Try,
                 PQP.Language.Keyword.KeywordKind.Type,
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            ];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 
     describe(`${PQP.Language.Ast.NodeKind.ErrorHandlingExpression}`, () => {
         it(`try |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`try |`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
+                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`try true|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`try true|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                PQP.Language.Keyword.KeywordKind.True,
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.True];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`try true |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`try true |`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
                 PQP.Language.Keyword.KeywordKind.And,
                 PQP.Language.Keyword.KeywordKind.As,
                 PQP.Language.Keyword.KeywordKind.Is,
                 PQP.Language.Keyword.KeywordKind.Meta,
                 PQP.Language.Keyword.KeywordKind.Or,
                 PQP.Language.Keyword.KeywordKind.Otherwise,
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            ];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 
     describe(`${PQP.Language.Ast.NodeKind.ErrorRaisingExpression}`, () => {
         it(`if |error`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if |error`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
+                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if error|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if error|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`error |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`error |`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
+                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 
@@ -324,221 +295,219 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `let x = (_ |) => a in x`,
             );
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                PQP.Language.Keyword.KeywordKind.As,
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.As];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`let x = (_ a|) => a in`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `let x = (_ a|) => a in`,
             );
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                PQP.Language.Keyword.KeywordKind.As,
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.As];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 
     describe(`${PQP.Language.Ast.NodeKind.IfExpression}`, () => {
         it(`if|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(` if |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if |`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
+                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if 1|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if 1|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if |if`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if |if`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
+                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if i|f`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if i|f`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                PQP.Language.Keyword.KeywordKind.If,
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.If];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if if | `, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if if |`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
+                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if 1 |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if 1 |`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                PQP.Language.Keyword.KeywordKind.Then,
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Then];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if 1 t|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if 1 t|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                PQP.Language.Keyword.KeywordKind.Then,
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Then];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if 1 then |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if 1 then |`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
+                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if 1 then 1|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if 1 then 1|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if 1 then 1 e|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `if 1 then 1 e|`,
             );
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                PQP.Language.Keyword.KeywordKind.Else,
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Else];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if 1 then 1 else|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `if 1 then 1 else|`,
             );
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if 1 th|en 1 else`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `if 1 th|en 1 else`,
             );
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                PQP.Language.Keyword.KeywordKind.Then,
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Then];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if 1 then 1 else |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `if 1 then 1 else |`,
             );
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
+                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 
     describe(`${PQP.Language.Ast.NodeKind.InvokeExpression}`, () => {
         it(`foo(|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`foo(|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
+                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`foo(a|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`foo(a|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`foo(a|,`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`foo(a|,`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`foo(a,|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`foo(a,|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
+                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 
     describe(`${PQP.Language.Ast.NodeKind.ListExpression}`, () => {
         it(`{|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`{|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
+                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`{1|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`{1|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`{1|,`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`{1|,`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`{1,|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`{1,|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
+                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`{1,|2`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`{1,|2`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
+                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`{1,|2,`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`{1,|2,`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
+                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`{1..|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`{1..|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
+                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 
@@ -547,227 +516,244 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `try true otherwise| false`,
             );
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`try true otherwise |false`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `try true otherwise |false`,
             );
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
+                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`try true oth|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `try true oth|`,
             );
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
                 PQP.Language.Keyword.KeywordKind.Otherwise,
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            ];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`try true otherwise |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `try true otherwise |`,
             );
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
+                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 
     describe(`${PQP.Language.Ast.NodeKind.ParenthesizedExpression}`, () => {
         it(`+(|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+(|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
+                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 
     describe(`${PQP.Language.Ast.NodeKind.RecordExpression}`, () => {
         it(`+[|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+[a=|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[a=|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
+                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+[a=1|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[a=1|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+[a|=1`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[a|=1`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+[a=1|]`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[a=1|]`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+[a=|1]`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[a=| 1]`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
+                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+[a=1|,`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[a=1|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+[a=1,|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[a=1,|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+[a=1|,b`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[a=1|,b`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+[a=1|,b=`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[a=1|,b=`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+[a=|1,b=`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[a=|1,b=`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
+                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+[a=1,b=2|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[a=1,b=2|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+[a=1,b=2 |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[a=1,b=2 |`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 
     describe(`AutocompleteExpression`, () => {
         it(`error |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`error |`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
+                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`let x = |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`let x = |`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
+                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`() => |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`() => |`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
+                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if |`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
+                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if true then |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `if true then |`,
             );
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
+                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if true then true else |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `if true then true else |`,
             );
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
+                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`foo(|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`foo(|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
+                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`let x = 1 in |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `let x = 1 in |`,
             );
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
+                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+{|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+{|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
+                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`try true otherwise |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `try true otherwise |`,
             );
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
+                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+(|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+(|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
+                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 
@@ -776,179 +762,175 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `section; [] |`,
             );
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                PQP.Language.Keyword.KeywordKind.Shared,
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Shared];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`section; [] x |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `section; [] x |`,
             );
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`section; x = |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `section; x = |`,
             );
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
+                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`section; x = 1 |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `section; x = 1 |`,
             );
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
                 PQP.Language.Keyword.KeywordKind.And,
                 PQP.Language.Keyword.KeywordKind.As,
                 PQP.Language.Keyword.KeywordKind.Is,
                 PQP.Language.Keyword.KeywordKind.Meta,
                 PQP.Language.Keyword.KeywordKind.Or,
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            ];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`section; x = 1 i|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `section; x = 1 i|`,
             );
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                PQP.Language.Keyword.KeywordKind.Is,
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Is];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`section foo; a = () => true; b = "string"; c = 1; d = |;`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `section foo; a = () => true; b = "string"; c = 1; d = |;`,
             );
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
+                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 
     describe(`${PQP.Language.Ast.NodeKind.LetExpression}`, () => {
         it(`let a = |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`let a = |`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
+                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`let a = 1|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`let a = 1|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`let a = 1 |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`let a = 1 |`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
                 PQP.Language.Keyword.KeywordKind.And,
                 PQP.Language.Keyword.KeywordKind.As,
                 PQP.Language.Keyword.KeywordKind.Is,
                 PQP.Language.Keyword.KeywordKind.Meta,
                 PQP.Language.Keyword.KeywordKind.Or,
                 PQP.Language.Keyword.KeywordKind.In,
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            ];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`let a = 1 | foobar`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `let a = 1 | foobar`,
             );
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
                 PQP.Language.Keyword.KeywordKind.And,
                 PQP.Language.Keyword.KeywordKind.As,
                 PQP.Language.Keyword.KeywordKind.Is,
                 PQP.Language.Keyword.KeywordKind.Meta,
                 PQP.Language.Keyword.KeywordKind.Or,
                 PQP.Language.Keyword.KeywordKind.In,
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            ];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`let a = 1 i|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`let a = 1 i|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
                 PQP.Language.Keyword.KeywordKind.Is,
                 PQP.Language.Keyword.KeywordKind.In,
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            ];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`let a = 1 o|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`let a = 1 o|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                PQP.Language.Keyword.KeywordKind.Or,
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Or];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`let a = 1 m|`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`let a = 1 m|`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
-                PQP.Language.Keyword.KeywordKind.Meta,
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Meta];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`let a = 1, |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`let a = 1, |`);
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`let a = let b = |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `let a = let b = |`,
             );
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedExpressionAutocompleteItems;
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
+                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`let a = let b = 1 |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `let a = let b = 1 |`,
             );
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = createTweakedAbridgedAutocompleteItems([
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
                 PQP.Language.Keyword.KeywordKind.And,
                 PQP.Language.Keyword.KeywordKind.As,
                 PQP.Language.Keyword.KeywordKind.Is,
                 PQP.Language.Keyword.KeywordKind.Meta,
                 PQP.Language.Keyword.KeywordKind.Or,
                 PQP.Language.Keyword.KeywordKind.In,
-            ]);
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            ];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`let a = let b = 1, |`, () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `let a = let b = 1, |`,
             );
-            const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-            const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetKeywordAutocomplete(text, position);
-            expect(actual).to.deep.equal(expected);
+            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 });

--- a/src/test/inspection/autocomplete/autocompleteLanguageConstant.ts
+++ b/src/test/inspection/autocomplete/autocompleteLanguageConstant.ts
@@ -9,87 +9,103 @@ import "mocha";
 
 import { TestConstants, TestUtils } from "../..";
 import { Inspection } from "../../../powerquery-language-services";
+import { AbridgedAutocompleteItem, createAbridgedAutocompleteItem } from "./common";
 
-function assertGetParseErrAutocompleteOkLanguageConstant<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
+function assertGetLanguageConstantAutocomplete<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
     settings: PQP.LexSettings & PQP.ParseSettings<S> & Inspection.InspectionSettings,
     text: string,
     position: Inspection.Position,
-): Inspection.AutocompleteLanguageConstant | undefined {
+): AbridgedAutocompleteItem | undefined {
     const actual: Inspection.Autocomplete = TestUtils.assertGetAutocomplete(settings, text, position);
     Assert.isOk(actual.triedLanguageConstant);
-    return actual.triedLanguageConstant.value;
+
+    return actual.triedLanguageConstant.value
+        ? createAbridgedAutocompleteItem(actual.triedLanguageConstant.value)
+        : undefined;
 }
 
 describe(`Inspection - Autocomplete - Language constants`, () => {
     it(`a as |`, () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`a as |`);
-        const actual:
-            | Inspection.AutocompleteLanguageConstant
-            | undefined = assertGetParseErrAutocompleteOkLanguageConstant(
+        const expected: AbridgedAutocompleteItem | undefined = {
+            jaroWinklerScore: 1,
+            label: PQP.Language.Constant.LanguageConstantKind.Nullable,
+        };
+        const actual: AbridgedAutocompleteItem | undefined = assertGetLanguageConstantAutocomplete(
             TestConstants.DefaultSettings,
             text,
             position,
         );
-        expect(actual).to.equal(PQP.Language.Constant.LanguageConstantKind.Nullable);
+        expect(actual).to.deep.equal(expected);
     });
 
     it(`a as n|`, () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`a as n|`);
-        const actual:
-            | Inspection.AutocompleteLanguageConstant
-            | undefined = assertGetParseErrAutocompleteOkLanguageConstant(
+        const expected: AbridgedAutocompleteItem | undefined = {
+            jaroWinklerScore: 1,
+            label: PQP.Language.Constant.LanguageConstantKind.Nullable,
+        };
+        const actual: AbridgedAutocompleteItem | undefined = assertGetLanguageConstantAutocomplete(
             TestConstants.DefaultSettings,
             text,
             position,
         );
-        expect(actual).to.equal(PQP.Language.Constant.LanguageConstantKind.Nullable);
+        expect(actual).to.deep.equal(expected);
     });
 
     it(`(a as |`, () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`(a as |`);
-        const actual:
-            | Inspection.AutocompleteLanguageConstant
-            | undefined = assertGetParseErrAutocompleteOkLanguageConstant(
+        const expected: AbridgedAutocompleteItem | undefined = {
+            jaroWinklerScore: 1,
+            label: PQP.Language.Constant.LanguageConstantKind.Nullable,
+        };
+        const actual: AbridgedAutocompleteItem | undefined = assertGetLanguageConstantAutocomplete(
             TestConstants.DefaultSettings,
             text,
             position,
         );
-        expect(actual).to.equal(PQP.Language.Constant.LanguageConstantKind.Nullable);
+        expect(actual).to.deep.equal(expected);
     });
 
     it(`(a as n|`, () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`(a as n|`);
-        const actual:
-            | Inspection.AutocompleteLanguageConstant
-            | undefined = assertGetParseErrAutocompleteOkLanguageConstant(
+        const expected: AbridgedAutocompleteItem | undefined = {
+            jaroWinklerScore: 1,
+            label: PQP.Language.Constant.LanguageConstantKind.Nullable,
+        };
+        const actual: AbridgedAutocompleteItem | undefined = assertGetLanguageConstantAutocomplete(
             TestConstants.DefaultSettings,
             text,
             position,
         );
-        expect(actual).to.equal(PQP.Language.Constant.LanguageConstantKind.Nullable);
+        expect(actual).to.deep.equal(expected);
     });
 
     it(`(x, |`, () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`(x, |`);
-        const actual:
-            | Inspection.AutocompleteLanguageConstant
-            | undefined = assertGetParseErrAutocompleteOkLanguageConstant(
+        const expected: AbridgedAutocompleteItem | undefined = {
+            jaroWinklerScore: 1,
+            label: PQP.Language.Constant.LanguageConstantKind.Optional,
+        };
+        const actual: AbridgedAutocompleteItem | undefined = assertGetLanguageConstantAutocomplete(
             TestConstants.DefaultSettings,
             text,
             position,
         );
-        expect(actual).to.equal(PQP.Language.Constant.LanguageConstantKind.Optional);
+        expect(actual).to.deep.equal(expected);
     });
 
     it(`(x, op|`, () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`(x, op|`);
-        const actual:
-            | Inspection.AutocompleteLanguageConstant
-            | undefined = assertGetParseErrAutocompleteOkLanguageConstant(
+        const expected: AbridgedAutocompleteItem | undefined = {
+            jaroWinklerScore: 1,
+            label: PQP.Language.Constant.LanguageConstantKind.Optional,
+        };
+        const actual: AbridgedAutocompleteItem | undefined = assertGetLanguageConstantAutocomplete(
             TestConstants.DefaultSettings,
             text,
             position,
         );
-        expect(actual).to.equal(PQP.Language.Constant.LanguageConstantKind.Optional);
+        expect(actual).to.deep.equal(expected);
     });
 });

--- a/src/test/inspection/autocomplete/autocompletePrimitiveType.ts
+++ b/src/test/inspection/autocomplete/autocompletePrimitiveType.ts
@@ -7,35 +7,35 @@ import { Assert } from "@microsoft/powerquery-parser";
 import { expect } from "chai";
 import "mocha";
 
-import { TestUtils, TestConstants } from "../..";
+import { TestConstants, TestUtils } from "../..";
 import { Inspection } from "../../../powerquery-language-services";
 import { InspectionSettings } from "../../../powerquery-language-services/inspection";
+import { AbridgedAutocompleteItem, createAbridgedAutocompleteItems } from "./common";
 
-function assertGetParseOkAutocompleteOkPrimitiveType<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
+const AbridgedPrimitiveTypeAutocompleteItems: ReadonlyArray<AbridgedAutocompleteItem> = PQP.Language.Constant.PrimitiveTypeConstantKinds.map(
+    (kind: PQP.Language.Constant.PrimitiveTypeConstantKind) => {
+        return {
+            label: kind,
+            jaroWinklerScore: 1,
+        };
+    },
+);
+
+function assertGetPrimitiveTypeAutocompleteOk<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
     settings: PQP.LexSettings & PQP.ParseSettings<S> & InspectionSettings,
     text: string,
     position: Inspection.Position,
-): Inspection.AutocompletePrimitiveType {
+): ReadonlyArray<AbridgedAutocompleteItem> {
     const actual: Inspection.Autocomplete = TestUtils.assertGetAutocomplete(settings, text, position);
     Assert.isOk(actual.triedPrimitiveType);
-    return actual.triedPrimitiveType.value;
-}
-
-function assertGetParseErrAutocompleteOkPrimitiveType<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    settings: PQP.LexSettings & PQP.ParseSettings<S> & InspectionSettings,
-    text: string,
-    position: Inspection.Position,
-): Inspection.AutocompletePrimitiveType {
-    const actual: Inspection.Autocomplete = TestUtils.assertGetAutocomplete(settings, text, position);
-    Assert.isOk(actual.triedPrimitiveType);
-    return actual.triedPrimitiveType.value;
+    return createAbridgedAutocompleteItems(actual.triedPrimitiveType.value);
 }
 
 describe(`Inspection - Autocomplete - PrimitiveType`, () => {
     it("type|", () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`type|`);
-        const expected: Inspection.AutocompletePrimitiveType = [];
-        const actual: Inspection.AutocompletePrimitiveType = assertGetParseErrAutocompleteOkPrimitiveType(
+        const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
+        const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultSettings,
             text,
             position,
@@ -45,8 +45,8 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
 
     it("type |", () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`type |`);
-        const expected: Inspection.AutocompletePrimitiveType = PQP.Language.Constant.PrimitiveTypeConstantKinds;
-        const actual: Inspection.AutocompletePrimitiveType = assertGetParseErrAutocompleteOkPrimitiveType(
+        const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedPrimitiveTypeAutocompleteItems;
+        const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultSettings,
             text,
             position,
@@ -56,8 +56,8 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
 
     it("let x = type|", () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`let x = type|`);
-        const expected: Inspection.AutocompletePrimitiveType = [];
-        const actual: Inspection.AutocompletePrimitiveType = assertGetParseErrAutocompleteOkPrimitiveType(
+        const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
+        const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultSettings,
             text,
             position,
@@ -67,8 +67,8 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
 
     it("let x = type |", () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`let x = type |`);
-        const expected: Inspection.AutocompletePrimitiveType = PQP.Language.Constant.PrimitiveTypeConstantKinds;
-        const actual: Inspection.AutocompletePrimitiveType = assertGetParseErrAutocompleteOkPrimitiveType(
+        const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedPrimitiveTypeAutocompleteItems;
+        const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultSettings,
             text,
             position,
@@ -78,8 +78,8 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
 
     it("type | number", () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`type | number`);
-        const expected: Inspection.AutocompletePrimitiveType = PQP.Language.Constant.PrimitiveTypeConstantKinds;
-        const actual: Inspection.AutocompletePrimitiveType = assertGetParseOkAutocompleteOkPrimitiveType(
+        const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedPrimitiveTypeAutocompleteItems;
+        const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultSettings,
             text,
             position,
@@ -89,12 +89,21 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
 
     it("type n|", () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`type n|`);
-        const expected: Inspection.AutocompletePrimitiveType = [
-            PQP.Language.Constant.PrimitiveTypeConstantKind.None,
-            PQP.Language.Constant.PrimitiveTypeConstantKind.Null,
-            PQP.Language.Constant.PrimitiveTypeConstantKind.Number,
+        const expected: ReadonlyArray<AbridgedAutocompleteItem> = [
+            {
+                label: PQP.Language.Constant.PrimitiveTypeConstantKind.None,
+                jaroWinklerScore: 0,
+            },
+            {
+                label: PQP.Language.Constant.PrimitiveTypeConstantKind.Null,
+                jaroWinklerScore: 0,
+            },
+            {
+                label: PQP.Language.Constant.PrimitiveTypeConstantKind.Number,
+                jaroWinklerScore: 0,
+            },
         ];
-        const actual: Inspection.AutocompletePrimitiveType = assertGetParseErrAutocompleteOkPrimitiveType(
+        const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultSettings,
             text,
             position,
@@ -104,8 +113,8 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
 
     it("(x|) => 1", () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`(x|) => 1`);
-        const expected: Inspection.AutocompletePrimitiveType = [];
-        const actual: Inspection.AutocompletePrimitiveType = assertGetParseOkAutocompleteOkPrimitiveType(
+        const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
+        const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultSettings,
             text,
             position,
@@ -117,8 +126,8 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
             `(x as| number) => 1`,
         );
-        const expected: Inspection.AutocompletePrimitiveType = [];
-        const actual: Inspection.AutocompletePrimitiveType = assertGetParseOkAutocompleteOkPrimitiveType(
+        const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
+        const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultSettings,
             text,
             position,
@@ -130,8 +139,8 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
             `(x as | number) => 1`,
         );
-        const expected: Inspection.AutocompletePrimitiveType = PQP.Language.Constant.PrimitiveTypeConstantKinds;
-        const actual: Inspection.AutocompletePrimitiveType = assertGetParseOkAutocompleteOkPrimitiveType(
+        const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedPrimitiveTypeAutocompleteItems;
+        const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultSettings,
             text,
             position,
@@ -143,8 +152,8 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
             `(x as| nullable number) => 1`,
         );
-        const expected: Inspection.AutocompletePrimitiveType = [];
-        const actual: Inspection.AutocompletePrimitiveType = assertGetParseOkAutocompleteOkPrimitiveType(
+        const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
+        const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultSettings,
             text,
             position,
@@ -156,8 +165,8 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
             `(x as | nullable number) => 1`,
         );
-        const expected: Inspection.AutocompletePrimitiveType = PQP.Language.Constant.PrimitiveTypeConstantKinds;
-        const actual: Inspection.AutocompletePrimitiveType = assertGetParseOkAutocompleteOkPrimitiveType(
+        const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedPrimitiveTypeAutocompleteItems;
+        const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultSettings,
             text,
             position,
@@ -169,8 +178,8 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
             `(x as nullable| number) => 1`,
         );
-        const expected: Inspection.AutocompletePrimitiveType = [];
-        const actual: Inspection.AutocompletePrimitiveType = assertGetParseOkAutocompleteOkPrimitiveType(
+        const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
+        const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultSettings,
             text,
             position,
@@ -182,8 +191,8 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
             `(x as nullable num|ber) => 1`,
         );
-        const expected: Inspection.AutocompletePrimitiveType = PQP.Language.Constant.PrimitiveTypeConstantKinds;
-        const actual: Inspection.AutocompletePrimitiveType = assertGetParseOkAutocompleteOkPrimitiveType(
+        const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedPrimitiveTypeAutocompleteItems;
+        const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultSettings,
             text,
             position,
@@ -193,8 +202,8 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
 
     it("let a = 1 is |", () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`let a = 1 is |`);
-        const expected: Inspection.AutocompletePrimitiveType = PQP.Language.Constant.PrimitiveTypeConstantKinds;
-        const actual: Inspection.AutocompletePrimitiveType = assertGetParseErrAutocompleteOkPrimitiveType(
+        const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedPrimitiveTypeAutocompleteItems;
+        const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultSettings,
             text,
             position,

--- a/src/test/inspection/autocomplete/autocompletePrimitiveType.ts
+++ b/src/test/inspection/autocomplete/autocompletePrimitiveType.ts
@@ -40,7 +40,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
             text,
             position,
         );
-        expect(actual).to.have.members(expected);
+        expect(actual).to.deep.equal(expected);
     });
 
     it("type |", () => {
@@ -51,7 +51,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
             text,
             position,
         );
-        expect(actual).to.have.members(expected);
+        expect(actual).to.deep.equal(expected);
     });
 
     it("let x = type|", () => {
@@ -62,7 +62,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
             text,
             position,
         );
-        expect(actual).to.have.members(expected);
+        expect(actual).to.deep.equal(expected);
     });
 
     it("let x = type |", () => {
@@ -73,7 +73,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
             text,
             position,
         );
-        expect(actual).to.have.members(expected);
+        expect(actual).to.deep.equal(expected);
     });
 
     it("type | number", () => {
@@ -84,7 +84,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
             text,
             position,
         );
-        expect(actual).to.have.members(expected);
+        expect(actual).to.deep.equal(expected);
     });
 
     it("type n|", () => {
@@ -108,7 +108,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
             text,
             position,
         );
-        expect(actual).to.have.members(expected);
+        expect(actual).to.deep.equal(expected);
     });
 
     it("(x|) => 1", () => {
@@ -119,7 +119,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
             text,
             position,
         );
-        expect(actual).to.have.members(expected);
+        expect(actual).to.deep.equal(expected);
     });
 
     it("(x as| number) => 1", () => {
@@ -132,7 +132,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
             text,
             position,
         );
-        expect(actual).to.have.members(expected);
+        expect(actual).to.deep.equal(expected);
     });
 
     it("(x as | number) => 1", () => {
@@ -145,7 +145,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
             text,
             position,
         );
-        expect(actual).to.have.members(expected);
+        expect(actual).to.deep.equal(expected);
     });
 
     it("(x as| nullable number) => 1", () => {
@@ -158,7 +158,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
             text,
             position,
         );
-        expect(actual).to.have.members(expected);
+        expect(actual).to.deep.equal(expected);
     });
 
     it("(x as | nullable number) => 1", () => {
@@ -171,7 +171,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
             text,
             position,
         );
-        expect(actual).to.have.members(expected);
+        expect(actual).to.deep.equal(expected);
     });
 
     it("(x as nullable| number) => 1", () => {
@@ -184,7 +184,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
             text,
             position,
         );
-        expect(actual).to.have.members(expected);
+        expect(actual).to.deep.equal(expected);
     });
 
     it("(x as nullable num|ber) => 1", () => {
@@ -197,10 +197,10 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
             text,
             position,
         );
-        expect(actual).to.have.members(expected);
+        expect(actual).to.deep.equal(expected);
     });
 
-    it("let a = 1 is |", () => {
+    it("WIP let a = 1 is |", () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`let a = 1 is |`);
         const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedPrimitiveTypeAutocompleteItems;
         const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
@@ -208,6 +208,6 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
             text,
             position,
         );
-        expect(actual).to.have.members(expected);
+        expect(actual).to.deep.equal(expected);
     });
 });

--- a/src/test/inspection/autocomplete/autocompletePrimitiveType.ts
+++ b/src/test/inspection/autocomplete/autocompletePrimitiveType.ts
@@ -4,210 +4,197 @@
 import * as PQP from "@microsoft/powerquery-parser";
 
 import { Assert } from "@microsoft/powerquery-parser";
-import { expect } from "chai";
 import "mocha";
 
 import { TestConstants, TestUtils } from "../..";
 import { Inspection } from "../../../powerquery-language-services";
 import { InspectionSettings } from "../../../powerquery-language-services/inspection";
-import { AbridgedAutocompleteItem, createAbridgedAutocompleteItems } from "./common";
-
-const AbridgedPrimitiveTypeAutocompleteItems: ReadonlyArray<AbridgedAutocompleteItem> = PQP.Language.Constant.PrimitiveTypeConstantKinds.map(
-    (kind: PQP.Language.Constant.PrimitiveTypeConstantKind) => {
-        return {
-            label: kind,
-            jaroWinklerScore: 1,
-        };
-    },
-);
 
 function assertGetPrimitiveTypeAutocompleteOk<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
     settings: PQP.LexSettings & PQP.ParseSettings<S> & InspectionSettings,
     text: string,
     position: Inspection.Position,
-): ReadonlyArray<AbridgedAutocompleteItem> {
+): ReadonlyArray<Inspection.AutocompleteItem> {
     const actual: Inspection.Autocomplete = TestUtils.assertGetAutocomplete(settings, text, position);
     Assert.isOk(actual.triedPrimitiveType);
-    return createAbridgedAutocompleteItems(actual.triedPrimitiveType.value);
+    return actual.triedPrimitiveType.value;
 }
 
 describe(`Inspection - Autocomplete - PrimitiveType`, () => {
     it("type|", () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`type|`);
-        const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-        const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
+        const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> = [];
+        const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultSettings,
             text,
             position,
         );
-        expect(actual).to.deep.equal(expected);
+        TestUtils.assertAutocompleteItemLabels(expected, actual);
     });
 
     it("type |", () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`type |`);
-        const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedPrimitiveTypeAutocompleteItems;
-        const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
+        const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> =
+            PQP.Language.Constant.PrimitiveTypeConstantKinds;
+        const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultSettings,
             text,
             position,
         );
-        expect(actual).to.deep.equal(expected);
+        TestUtils.assertAutocompleteItemLabels(expected, actual);
     });
 
     it("let x = type|", () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`let x = type|`);
-        const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-        const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
+        const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> = [];
+        const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultSettings,
             text,
             position,
         );
-        expect(actual).to.deep.equal(expected);
+        TestUtils.assertAutocompleteItemLabels(expected, actual);
     });
 
     it("let x = type |", () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`let x = type |`);
-        const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedPrimitiveTypeAutocompleteItems;
-        const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
+        const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> =
+            PQP.Language.Constant.PrimitiveTypeConstantKinds;
+        const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultSettings,
             text,
             position,
         );
-        expect(actual).to.deep.equal(expected);
+        TestUtils.assertAutocompleteItemLabels(expected, actual);
     });
 
     it("type | number", () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`type | number`);
-        const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedPrimitiveTypeAutocompleteItems;
-        const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
+        const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> =
+            PQP.Language.Constant.PrimitiveTypeConstantKinds;
+        const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultSettings,
             text,
             position,
         );
-        expect(actual).to.deep.equal(expected);
+        TestUtils.assertAutocompleteItemLabels(expected, actual);
     });
 
     it("type n|", () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`type n|`);
-        const expected: ReadonlyArray<AbridgedAutocompleteItem> = [
-            {
-                label: PQP.Language.Constant.PrimitiveTypeConstantKind.None,
-                jaroWinklerScore: 0,
-            },
-            {
-                label: PQP.Language.Constant.PrimitiveTypeConstantKind.Null,
-                jaroWinklerScore: 0,
-            },
-            {
-                label: PQP.Language.Constant.PrimitiveTypeConstantKind.Number,
-                jaroWinklerScore: 0,
-            },
+        const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> = [
+            PQP.Language.Constant.PrimitiveTypeConstantKind.None,
+            PQP.Language.Constant.PrimitiveTypeConstantKind.Null,
+            PQP.Language.Constant.PrimitiveTypeConstantKind.Number,
         ];
-        const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
+        const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultSettings,
             text,
             position,
         );
-        expect(actual).to.deep.equal(expected);
+        TestUtils.assertAutocompleteItemLabels(expected, actual);
     });
 
     it("(x|) => 1", () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`(x|) => 1`);
-        const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-        const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
+        const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> = [];
+        const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultSettings,
             text,
             position,
         );
-        expect(actual).to.deep.equal(expected);
+        TestUtils.assertAutocompleteItemLabels(expected, actual);
     });
 
     it("(x as| number) => 1", () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
             `(x as| number) => 1`,
         );
-        const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-        const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
+        const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> = [];
+        const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultSettings,
             text,
             position,
         );
-        expect(actual).to.deep.equal(expected);
+        TestUtils.assertAutocompleteItemLabels(expected, actual);
     });
 
     it("(x as | number) => 1", () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
             `(x as | number) => 1`,
         );
-        const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedPrimitiveTypeAutocompleteItems;
-        const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
+        const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> =
+            PQP.Language.Constant.PrimitiveTypeConstantKinds;
+        const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultSettings,
             text,
             position,
         );
-        expect(actual).to.deep.equal(expected);
+        TestUtils.assertAutocompleteItemLabels(expected, actual);
     });
 
     it("(x as| nullable number) => 1", () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
             `(x as| nullable number) => 1`,
         );
-        const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-        const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
+        const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> = [];
+        const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultSettings,
             text,
             position,
         );
-        expect(actual).to.deep.equal(expected);
+        TestUtils.assertAutocompleteItemLabels(expected, actual);
     });
 
     it("(x as | nullable number) => 1", () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
             `(x as | nullable number) => 1`,
         );
-        const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedPrimitiveTypeAutocompleteItems;
-        const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
+        const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> =
+            PQP.Language.Constant.PrimitiveTypeConstantKinds;
+        const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultSettings,
             text,
             position,
         );
-        expect(actual).to.deep.equal(expected);
+        TestUtils.assertAutocompleteItemLabels(expected, actual);
     });
 
     it("(x as nullable| number) => 1", () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
             `(x as nullable| number) => 1`,
         );
-        const expected: ReadonlyArray<AbridgedAutocompleteItem> = [];
-        const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
+        const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> = [];
+        const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultSettings,
             text,
             position,
         );
-        expect(actual).to.deep.equal(expected);
+        TestUtils.assertAutocompleteItemLabels(expected, actual);
     });
 
     it("(x as nullable num|ber) => 1", () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
             `(x as nullable num|ber) => 1`,
         );
-        const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedPrimitiveTypeAutocompleteItems;
-        const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
+        const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> =
+            PQP.Language.Constant.PrimitiveTypeConstantKinds;
+        const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultSettings,
             text,
             position,
         );
-        expect(actual).to.deep.equal(expected);
+        TestUtils.assertAutocompleteItemLabels(expected, actual);
     });
 
-    it("WIP let a = 1 is |", () => {
+    it("let a = 1 is |", () => {
         const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`let a = 1 is |`);
-        const expected: ReadonlyArray<AbridgedAutocompleteItem> = AbridgedPrimitiveTypeAutocompleteItems;
-        const actual: ReadonlyArray<AbridgedAutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
+        const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> =
+            PQP.Language.Constant.PrimitiveTypeConstantKinds;
+        const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultSettings,
             text,
             position,
         );
-        expect(actual).to.deep.equal(expected);
+        TestUtils.assertAutocompleteItemLabels(expected, actual);
     });
 });

--- a/src/test/inspection/autocomplete/common.ts
+++ b/src/test/inspection/autocomplete/common.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { Inspection } from "../../../powerquery-language-services";
+
+export type AbridgedAutocompleteItem = Pick<Inspection.AutocompleteItem, "label" | "jaroWinklerScore">;
+
+export function createAbridgedAutocompleteItem(
+    autocompleteItem: Inspection.AutocompleteItem,
+): AbridgedAutocompleteItem {
+    return {
+        label: autocompleteItem.label,
+        jaroWinklerScore: autocompleteItem.jaroWinklerScore,
+    };
+}
+
+export function createAbridgedAutocompleteItems(
+    autocompleteItems: ReadonlyArray<Inspection.AutocompleteItem>,
+): ReadonlyArray<AbridgedAutocompleteItem> {
+    return autocompleteItems.map(createAbridgedAutocompleteItem);
+}
+
+export function createTweakedAbridgedAutocompleteItems(
+    labels: ReadonlyArray<string>,
+    jaroWinklerValues?: Map<string, number>,
+): ReadonlyArray<AbridgedAutocompleteItem> {
+    return labels.map((kind: string) => {
+        return {
+            label: kind,
+            jaroWinklerScore: jaroWinklerValues?.get(kind) ?? 1,
+        };
+    });
+}

--- a/src/test/inspection/invokeExpression.ts
+++ b/src/test/inspection/invokeExpression.ts
@@ -487,7 +487,7 @@ describe(`subset Inspection - InvokeExpression`, () => {
             expectText_givenNumber(inspected);
         });
 
-        it("WIP nested invocations, expects no parameters, missing parameter", () => {
+        it("nested invocations, expects no parameters, missing parameter", () => {
             const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
                 `Foobar(${TestConstants.TestLibraryName.CreateFooAndBarRecord}(|), Baz`,
             );

--- a/src/test/inspection/jaroWinkler.ts
+++ b/src/test/inspection/jaroWinkler.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { expect } from "chai";
+import "mocha";
+
+import { calculateJaroWinkler } from "../../powerquery-language-services/inspection";
+
+describe(`Jaro-Winkler`, () => {
+    it(`case insensitive`, () => {
+        const key: string = "Table.AddColumn";
+        expect(calculateJaroWinkler(key, key.toUpperCase())).to.equal(calculateJaroWinkler(key, key.toLowerCase()));
+    });
+});

--- a/src/test/providers/localDocumentSymbolProvider.ts
+++ b/src/test/providers/localDocumentSymbolProvider.ts
@@ -161,7 +161,7 @@ describe(`SimpleLocalDocumentSymbolProvider`, async () => {
             });
         });
 
-        it(`includes textEdit`, async () => {
+        it(`WIP includes textEdit`, async () => {
             const pair: [MockDocument, Position] = TestUtils.createMockDocumentAndPosition(
                 "let Test.Foo = 1, Test.FooBar = 2 in Test.Fo|",
             );

--- a/src/test/providers/localDocumentSymbolProvider.ts
+++ b/src/test/providers/localDocumentSymbolProvider.ts
@@ -161,7 +161,7 @@ describe(`SimpleLocalDocumentSymbolProvider`, async () => {
             });
         });
 
-        it(`WIP includes textEdit`, async () => {
+        xit(`includes textEdit`, async () => {
             const pair: [MockDocument, Position] = TestUtils.createMockDocumentAndPosition(
                 "let Test.Foo = 1, Test.FooBar = 2 in Test.Fo|",
             );

--- a/src/test/providers/localDocumentSymbolProvider.ts
+++ b/src/test/providers/localDocumentSymbolProvider.ts
@@ -9,7 +9,6 @@ import { TestConstants, TestUtils } from "..";
 import {
     AnalysisOptions,
     AnalysisUtils,
-    CompletionItem,
     EmptyHover,
     Hover,
     Inspection,
@@ -24,12 +23,12 @@ import { SimpleLibrary } from "../testConstants";
 
 const IsolatedAnalysisOptions: AnalysisOptions = {
     ...TestConstants.SimpleLibraryAnalysisOptions,
-    createLanguageCompletionItemProviderFn: () => NullSymbolProvider.singleton(),
+    createLanguageAutocompleteItemProviderFn: () => NullSymbolProvider.singleton(),
     createLibrarySymbolProviderFn: (_library: ILibrary) => NullSymbolProvider.singleton(),
 };
 
-async function createCompletionItems(text: string): Promise<ReadonlyArray<CompletionItem>> {
-    return TestUtils.createCompletionItems(text, TestConstants.SimpleLibrary, IsolatedAnalysisOptions);
+async function createAutocompleteItems(text: string): Promise<ReadonlyArray<Inspection.AutocompleteItem>> {
+    return TestUtils.createAutocompleteItems(text, TestConstants.SimpleLibrary, IsolatedAnalysisOptions);
 }
 
 async function createHover(text: string): Promise<Hover> {
@@ -41,77 +40,77 @@ async function createSignatureHelp(text: string): Promise<SignatureHelp> {
 }
 
 describe(`SimpleLocalDocumentSymbolProvider`, async () => {
-    describe(`getCompletionItems`, async () => {
+    describe(`getAutocompleteItems`, async () => {
         describe(`scope`, async () => {
             describe(`${Inspection.ScopeItemKind.LetVariable}`, async () => {
                 it(`match all`, async () => {
                     const expected: ReadonlyArray<string> = ["foo", "bar", "foobar"];
-                    const actual: ReadonlyArray<CompletionItem> = await createCompletionItems(
+                    const actual: ReadonlyArray<Inspection.AutocompleteItem> = await createAutocompleteItems(
                         "let foo = 1, bar = 2, foobar = 3 in |",
                     );
-                    TestUtils.assertCompletionItemLabels(expected, actual);
+                    TestUtils.assertAutocompleteItemLabels(expected, actual);
                 });
 
                 it(`match some`, async () => {
                     const expected: ReadonlyArray<string> = ["foo", "foobar"];
-                    const actual: ReadonlyArray<CompletionItem> = await createCompletionItems(
+                    const actual: ReadonlyArray<Inspection.AutocompleteItem> = await createAutocompleteItems(
                         "let foo = 1, bar = 2, foobar = 3 in foo|",
                     );
-                    TestUtils.assertCompletionItemLabels(expected, actual);
+                    TestUtils.assertAutocompleteItemLabels(expected, actual);
                 });
             });
 
             describe(`${Inspection.ScopeItemKind.Parameter}`, async () => {
                 it(`match all`, async () => {
                     const expected: ReadonlyArray<string> = ["foo", "bar", "foobar"];
-                    const actual: ReadonlyArray<CompletionItem> = await createCompletionItems(
+                    const actual: ReadonlyArray<Inspection.AutocompleteItem> = await createAutocompleteItems(
                         "(foo as number, bar as number, foobar as number) => |",
                     );
-                    TestUtils.assertCompletionItemLabels(expected, actual);
+                    TestUtils.assertAutocompleteItemLabels(expected, actual);
                 });
 
                 it(`match some`, async () => {
                     const expected: ReadonlyArray<string> = ["foo", "foobar"];
-                    const actual: ReadonlyArray<CompletionItem> = await createCompletionItems(
+                    const actual: ReadonlyArray<Inspection.AutocompleteItem> = await createAutocompleteItems(
                         "(foo as number, bar as number, foobar as number) => foo|",
                     );
-                    TestUtils.assertCompletionItemLabels(expected, actual);
+                    TestUtils.assertAutocompleteItemLabels(expected, actual);
                 });
             });
 
             describe(`${Inspection.ScopeItemKind.RecordField}`, async () => {
                 it(`match all`, async () => {
                     const expected: ReadonlyArray<string> = ["foo", "bar", "foobar", "@x"];
-                    const actual: ReadonlyArray<CompletionItem> = await createCompletionItems(
+                    const actual: ReadonlyArray<Inspection.AutocompleteItem> = await createAutocompleteItems(
                         "[foo = 1, bar = 2, foobar = 3, x = |",
                     );
-                    TestUtils.assertCompletionItemLabels(expected, actual);
+                    TestUtils.assertAutocompleteItemLabels(expected, actual);
                 });
 
                 it(`match some`, async () => {
                     const expected: ReadonlyArray<string> = ["foo", "foobar"];
-                    const actual: ReadonlyArray<CompletionItem> = await createCompletionItems(
+                    const actual: ReadonlyArray<Inspection.AutocompleteItem> = await createAutocompleteItems(
                         "[foo = 1, bar = 2, foobar = 3, x = foo|",
                     );
-                    TestUtils.assertCompletionItemLabels(expected, actual);
+                    TestUtils.assertAutocompleteItemLabels(expected, actual);
                 });
             });
 
             describe(`${Inspection.ScopeItemKind.SectionMember}`, async () => {
                 it(`match all`, async () => {
                     const expected: ReadonlyArray<string> = ["foo", "bar", "foobar", "@x"];
-                    const actual: ReadonlyArray<CompletionItem> = await createCompletionItems(
+                    const actual: ReadonlyArray<Inspection.AutocompleteItem> = await createAutocompleteItems(
                         "section; foo = 1; bar = 2; foobar = 3; x = |",
                     );
-                    TestUtils.assertCompletionItemLabels(expected, actual);
+                    TestUtils.assertAutocompleteItemLabels(expected, actual);
                 });
 
                 it(`match some`, async () => {
                     const expected: ReadonlyArray<string> = ["foo", "foobar"];
-                    const actual: ReadonlyArray<CompletionItem> = await createCompletionItems(
+                    const actual: ReadonlyArray<Inspection.AutocompleteItem> = await createAutocompleteItems(
                         "section; foo = 1; bar = 2; foobar = 3; x = foo|",
                     );
-                    TestUtils.assertCompletionItemLabels(expected, actual);
+                    TestUtils.assertAutocompleteItemLabels(expected, actual);
                 });
             });
         });
@@ -120,44 +119,44 @@ describe(`SimpleLocalDocumentSymbolProvider`, async () => {
             describe(`fieldProjection`, async () => {
                 it(`match all`, async () => {
                     const expected: ReadonlyArray<string> = ["foo", "bar", "foobar"];
-                    const actual: ReadonlyArray<CompletionItem> = await createCompletionItems(
+                    const actual: ReadonlyArray<Inspection.AutocompleteItem> = await createAutocompleteItems(
                         "[foo = 1, bar = 2, foobar = 3][[|",
                     );
-                    TestUtils.assertCompletionItemLabels(expected, actual);
+                    TestUtils.assertAutocompleteItemLabels(expected, actual);
                 });
 
                 it(`match some`, async () => {
                     const expected: ReadonlyArray<string> = ["foo", "foobar"];
-                    const actual: ReadonlyArray<CompletionItem> = await createCompletionItems(
+                    const actual: ReadonlyArray<Inspection.AutocompleteItem> = await createAutocompleteItems(
                         "[foo = 1, bar = 2, foobar = 3][[foo|",
                     );
-                    TestUtils.assertCompletionItemLabels(expected, actual);
+                    TestUtils.assertAutocompleteItemLabels(expected, actual);
                 });
 
                 it(`no repeats`, async () => {
                     const expected: ReadonlyArray<string> = ["bar", "foobar"];
-                    const actual: ReadonlyArray<CompletionItem> = await createCompletionItems(
+                    const actual: ReadonlyArray<Inspection.AutocompleteItem> = await createAutocompleteItems(
                         "[foo = 1, bar = 2, foobar = 3][[foo], [|",
                     );
-                    TestUtils.assertCompletionItemLabels(expected, actual);
+                    TestUtils.assertAutocompleteItemLabels(expected, actual);
                 });
             });
 
             describe(`fieldSelection`, async () => {
                 it(`match all`, async () => {
                     const expected: ReadonlyArray<string> = ["foo", "bar", "foobar"];
-                    const actual: ReadonlyArray<CompletionItem> = await createCompletionItems(
+                    const actual: ReadonlyArray<Inspection.AutocompleteItem> = await createAutocompleteItems(
                         "[foo = 1, bar = 2, foobar = 3][|",
                     );
-                    TestUtils.assertCompletionItemLabels(expected, actual);
+                    TestUtils.assertAutocompleteItemLabels(expected, actual);
                 });
 
                 it(`match some`, async () => {
                     const expected: ReadonlyArray<string> = ["foo", "foobar"];
-                    const actual: ReadonlyArray<CompletionItem> = await createCompletionItems(
+                    const actual: ReadonlyArray<Inspection.AutocompleteItem> = await createAutocompleteItems(
                         "[foo = 1, bar = 2, foobar = 3][foo|",
                     );
-                    TestUtils.assertCompletionItemLabels(expected, actual);
+                    TestUtils.assertAutocompleteItemLabels(expected, actual);
                 });
             });
         });
@@ -169,15 +168,21 @@ describe(`SimpleLocalDocumentSymbolProvider`, async () => {
             const document: TextDocument = pair[0];
             const position: Position = pair[1];
 
-            const completionItems: CompletionItem[] = await AnalysisUtils.createAnalysis(
+            const autocompleteItems: Inspection.AutocompleteItem[] = await AnalysisUtils.createAnalysis(
                 document,
                 position,
                 SimpleLibrary,
-            ).getCompletionItems();
-            expect(completionItems.length).to.equal(2);
+            ).getAutocompleteItems();
+            expect(autocompleteItems.length).to.equal(2);
 
-            const firstOption: CompletionItem = TestUtils.assertGetCompletionItem("Test.Foo", completionItems);
-            const secondOption: CompletionItem = TestUtils.assertGetCompletionItem("Test.FooBar", completionItems);
+            const firstOption: Inspection.AutocompleteItem = TestUtils.assertGetAutocompleteItem(
+                "Test.Foo",
+                autocompleteItems,
+            );
+            const secondOption: Inspection.AutocompleteItem = TestUtils.assertGetAutocompleteItem(
+                "Test.FooBar",
+                autocompleteItems,
+            );
 
             Assert.isDefined(firstOption.textEdit, "expected firstOption to have a textEdit");
             Assert.isDefined(secondOption.textEdit, "expected secondOption to have a textEdit");
@@ -267,7 +272,7 @@ describe(`SimpleLocalDocumentSymbolProvider`, async () => {
                 line: 40,
                 character: 25,
             };
-            const actual: ReadonlyArray<CompletionItem> = await TestUtils.createCompletionItemsForFile(
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await TestUtils.createAutocompleteItemsForFile(
                 "DirectQueryForSQL.pq",
                 postion,
             );
@@ -283,7 +288,7 @@ describe(`SimpleLocalDocumentSymbolProvider`, async () => {
                 "database",
             ];
 
-            TestUtils.assertCompletionItemLabels(expected, actual);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 });

--- a/src/test/providers/simpleLibrarySymbolProvider.ts
+++ b/src/test/providers/simpleLibrarySymbolProvider.ts
@@ -7,10 +7,10 @@ import { expect } from "chai";
 import "mocha";
 import {
     AnalysisOptions,
-    CompletionItem,
     EmptyHover,
     EmptySignatureHelp,
     Hover,
+    Inspection,
     NullSymbolProvider,
     SignatureHelp,
     WorkspaceCache,
@@ -28,8 +28,8 @@ const IsolatedAnalysisOptions: AnalysisOptions = {
     ) => NullSymbolProvider.singleton(),
 };
 
-async function createCompletionItems(text: string): Promise<ReadonlyArray<CompletionItem>> {
-    return TestUtils.createCompletionItems(text, TestConstants.SimpleLibrary, IsolatedAnalysisOptions);
+async function createAutocompleteItems(text: string): Promise<ReadonlyArray<Inspection.AutocompleteItem>> {
+    return TestUtils.createAutocompleteItems(text, TestConstants.SimpleLibrary, IsolatedAnalysisOptions);
 }
 
 async function createHover(text: string): Promise<Hover> {
@@ -41,26 +41,28 @@ async function createSignatureHelp(text: string): Promise<SignatureHelp> {
 }
 
 describe(`SimpleLibraryProvider`, async () => {
-    describe(`getCompletionItems`, async () => {
+    describe(`getAutocompleteItems`, async () => {
         it(`match`, async () => {
             const expected: ReadonlyArray<string> = [TestConstants.TestLibraryName.NumberOne];
-            const actual: ReadonlyArray<CompletionItem> = await createCompletionItems("Test.NumberO|");
-            TestUtils.assertCompletionItemLabels(expected, actual);
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await createAutocompleteItems("Test.NumberO|");
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`match multiple`, async () => {
-            const actual: ReadonlyArray<CompletionItem> = await createCompletionItems("Test.Numbe|");
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await createAutocompleteItems("Test.Numbe|");
             const expected: ReadonlyArray<string> = [
                 TestConstants.TestLibraryName.Number,
                 TestConstants.TestLibraryName.NumberOne,
             ];
-            TestUtils.assertCompletionItemLabels(expected, actual);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`no match`, async () => {
-            const actual: ReadonlyArray<CompletionItem> = await createCompletionItems("Unknown|Identifier");
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await createAutocompleteItems(
+                "Unknown|Identifier",
+            );
             const expected: ReadonlyArray<string> = [];
-            TestUtils.assertCompletionItemLabels(expected, actual);
+            TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 

--- a/src/test/testConstants.ts
+++ b/src/test/testConstants.ts
@@ -7,6 +7,7 @@ import { Assert } from "@microsoft/powerquery-parser";
 
 import {
     AnalysisOptions,
+    CompletionItemKind,
     Inspection,
     Library,
     LibraryUtils,
@@ -87,29 +88,29 @@ export const SimpleLibraryDefinitions: Library.LibraryDefinitions = new Map<stri
     [
         TestLibraryName.CreateFooAndBarRecord,
         LibraryUtils.createFunctionDefinition(
-            CreateFooAndBarRecordDefinedFunction,
-            `The name is ${TestLibraryName.CreateFooAndBarRecord}`,
             TestLibraryName.CreateFooAndBarRecord,
-            PQP.Language.Type.RecordInstance,
+            `The name is ${TestLibraryName.CreateFooAndBarRecord}`,
+            CreateFooAndBarRecordDefinedFunction,
+            CompletionItemKind.Function,
             [],
         ),
     ],
     [
         TestLibraryName.Number,
         LibraryUtils.createConstantDefinition(
-            PQP.Language.Type.NumberInstance,
-            `The name is ${TestLibraryName.Number}`,
             TestLibraryName.Number,
+            `The name is ${TestLibraryName.Number}`,
             PQP.Language.Type.NumberInstance,
+            CompletionItemKind.Value,
         ),
     ],
     [
         TestLibraryName.CombineNumberAndOptionalText,
         LibraryUtils.createFunctionDefinition(
-            CombineNumberAndOptionalTextDefinedFunction,
-            `The name is ${TestLibraryName.CombineNumberAndOptionalText}`,
             TestLibraryName.CombineNumberAndOptionalText,
-            PQP.Language.Type.NullInstance,
+            `The name is ${TestLibraryName.CombineNumberAndOptionalText}`,
+            CombineNumberAndOptionalTextDefinedFunction,
+            CompletionItemKind.Function,
             [
                 {
                     isNullable: false,
@@ -131,19 +132,19 @@ export const SimpleLibraryDefinitions: Library.LibraryDefinitions = new Map<stri
     [
         TestLibraryName.NumberOne,
         LibraryUtils.createConstantDefinition(
-            PQP.Language.TypeUtils.createNumberLiteral(false, "1"),
-            `The name is ${TestLibraryName.NumberOne}`,
             TestLibraryName.NumberOne,
-            PQP.Language.Type.NumberInstance,
+            `The name is ${TestLibraryName.NumberOne}`,
+            PQP.Language.TypeUtils.createNumberLiteral(false, "1"),
+            CompletionItemKind.Constant,
         ),
     ],
     [
         TestLibraryName.SquareIfNumber,
         LibraryUtils.createFunctionDefinition(
-            SquareIfNumberDefinedFunction,
-            `The name is ${TestLibraryName.SquareIfNumber}`,
             TestLibraryName.SquareIfNumber,
-            PQP.Language.Type.AnyInstance,
+            `The name is ${TestLibraryName.SquareIfNumber}`,
+            SquareIfNumberDefinedFunction,
+            CompletionItemKind.Function,
             [
                 {
                     isNullable: false,

--- a/src/test/testUtils/assert.ts
+++ b/src/test/testUtils/assert.ts
@@ -8,7 +8,7 @@ import * as TestUtils from "./testUtils";
 
 import { Assert, TaskUtils } from "@microsoft/powerquery-parser";
 import { expect } from "chai";
-import { CompletionItem, Hover, MarkupContent, Position, SignatureHelp } from "vscode-languageserver-types";
+import { Hover, MarkupContent, Position, SignatureHelp } from "vscode-languageserver-types";
 
 import * as TestConstants from "../testConstants";
 
@@ -63,11 +63,19 @@ export function assertGetAutocomplete<S extends PQP.Parser.IParseState = PQP.Par
     }
 }
 
-export function assertGetCompletionItem(label: string, completionItems: ReadonlyArray<CompletionItem>): CompletionItem {
+export function assertGetAutocompleteItem(
+    label: string,
+    autocompleteItems: ReadonlyArray<Inspection.AutocompleteItem>,
+): Inspection.AutocompleteItem {
     return Assert.asDefined(
-        completionItems.find((completionitem: CompletionItem) => completionitem.label === "Test.Foo"),
+        autocompleteItems.find((completionitem: Inspection.AutocompleteItem) => completionitem.label === "Test.Foo"),
         `did not find the expected completion item`,
-        { label, completionItemLabels: completionItems.map((completionItem: CompletionItem) => completionItem.label) },
+        {
+            label,
+            completionItemLabels: autocompleteItems.map(
+                (completionItem: Inspection.AutocompleteItem) => completionItem.label,
+            ),
+        },
     );
 }
 
@@ -133,11 +141,11 @@ export function assertIsMarkupContent(value: Hover["contents"]): asserts value i
     }
 }
 
-export function assertCompletionItemLabels(
+export function assertAutocompleteItemLabels(
     expected: ReadonlyArray<string>,
-    actual: ReadonlyArray<CompletionItem>,
+    actual: ReadonlyArray<Inspection.AutocompleteItem>,
 ): void {
-    const actualLabels: ReadonlyArray<string> = actual.map((item: CompletionItem) => item.label);
+    const actualLabels: ReadonlyArray<string> = actual.map((item: Inspection.AutocompleteItem) => item.label);
     expect(actualLabels).to.include.members(expected);
 }
 

--- a/src/test/testUtils/testUtils.ts
+++ b/src/test/testUtils/testUtils.ts
@@ -7,19 +7,12 @@ import * as File from "fs";
 import * as Path from "path";
 
 import { assert, expect } from "chai";
-import {
-    CompletionItem,
-    DocumentSymbol,
-    Hover,
-    Position,
-    SignatureHelp,
-    SymbolKind,
-} from "vscode-languageserver-types";
+import { DocumentSymbol, Hover, Position, SignatureHelp, SymbolKind } from "vscode-languageserver-types";
 
 import * as AnalysisUtils from "../../powerquery-language-services/analysis/analysisUtils";
 import * as TestConstants from "../testConstants";
 
-import { Analysis } from "../../powerquery-language-services";
+import { Analysis, Inspection } from "../../powerquery-language-services";
 import { AnalysisOptions } from "../../powerquery-language-services/analysis/analysisOptions";
 import { ILibrary } from "../../powerquery-language-services/library/library";
 import { MockDocument } from "../mockDocument";
@@ -94,21 +87,21 @@ export function createAnalysis(
     );
 }
 
-export async function createCompletionItems(
+export async function createAutocompleteItems(
     text: string,
     maybeLibrary?: ILibrary,
     maybeAnalysisOptions?: AnalysisOptions,
-): Promise<ReadonlyArray<CompletionItem>> {
-    return createAnalysis(text, maybeLibrary, maybeAnalysisOptions).getCompletionItems();
+): Promise<ReadonlyArray<Inspection.AutocompleteItem>> {
+    return createAnalysis(text, maybeLibrary, maybeAnalysisOptions).getAutocompleteItems();
 }
 
-export async function createCompletionItemsForFile(
+export async function createAutocompleteItemsForFile(
     fileName: string,
     position: Position,
     maybeLibrary?: ILibrary,
     maybeAnalysisOptions?: AnalysisOptions,
-): Promise<ReadonlyArray<CompletionItem>> {
-    return createFileAnalysis(fileName, position, maybeLibrary, maybeAnalysisOptions).getCompletionItems();
+): Promise<ReadonlyArray<Inspection.AutocompleteItem>> {
+    return createFileAnalysis(fileName, position, maybeLibrary, maybeAnalysisOptions).getAutocompleteItems();
 }
 
 export async function createHover(


### PR DESCRIPTION
As the PR name implies, this adds fuzzy matching for autocomplete by way of jaro-winkler algorithm. From my research it seemed to be one of the faster algorithms, and the winkler addition emphasizes the first few characters typed.

https://en.wikipedia.org/wiki/Jaro%E2%80%93Winkler_distance

To assist this change I've extended CompletionItem as AutocompleteItem, which adds `jaroWinklerScore` (a number in the range [0.0, 1.0], and `powerQueryType` which will be later used for autocomplete filtering. To accomodate this change the existing CompletionItemX types have been renamed AutocompleteItemX.