### PR TITLE
Update parser and formatter package versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,21 +31,11 @@
       }
     },
     "@microsoft/powerquery-formatter": {
-      "version": "0.0.28",
-      "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.0.28.tgz",
-      "integrity": "sha512-3wAQp41mUe9JWSwhrW8FkVnOheFPL0pzMRdO8LRfShRh95n/47/jHwFnvaItWatDk1kIgGoNJrjOYY7SHbpPVA==",
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.0.29.tgz",
+      "integrity": "sha512-vH73HkWw3czCSIWRLrEBbwQzJc6jIX+OKaU0Y4IbJeBV1tuuunZ2leJyUWDctzm4kbr1xAoYwZZKis6DxKjRSQ==",
       "requires": {
-        "@microsoft/powerquery-parser": "0.4.0"
-      },
-      "dependencies": {
-        "@microsoft/powerquery-parser": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.4.0.tgz",
-          "integrity": "sha512-oECktiufRL+nDTbACW+lFu/erS6l+egCX5iIWjbpNOgmAdcDT1AzJsuFV8f7AJvJNli6KqU60ywOmHNy7nKz9g==",
-          "requires": {
-            "grapheme-splitter": "^1.0.4"
-          }
-        }
+        "@microsoft/powerquery-parser": "0.4.2"
       }
     },
     "@microsoft/powerquery-parser": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/powerquery-language-services",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -36,12 +36,22 @@
       "integrity": "sha512-3wAQp41mUe9JWSwhrW8FkVnOheFPL0pzMRdO8LRfShRh95n/47/jHwFnvaItWatDk1kIgGoNJrjOYY7SHbpPVA==",
       "requires": {
         "@microsoft/powerquery-parser": "0.4.0"
+      },
+      "dependencies": {
+        "@microsoft/powerquery-parser": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.4.0.tgz",
+          "integrity": "sha512-oECktiufRL+nDTbACW+lFu/erS6l+egCX5iIWjbpNOgmAdcDT1AzJsuFV8f7AJvJNli6KqU60ywOmHNy7nKz9g==",
+          "requires": {
+            "grapheme-splitter": "^1.0.4"
+          }
+        }
       }
     },
     "@microsoft/powerquery-parser": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.4.0.tgz",
-      "integrity": "sha512-oECktiufRL+nDTbACW+lFu/erS6l+egCX5iIWjbpNOgmAdcDT1AzJsuFV8f7AJvJNli6KqU60ywOmHNy7nKz9g==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.4.2.tgz",
+      "integrity": "sha512-CGC/6K/Zj3CB6/wbTv85in1CBqzhjBV4FXxXQ5Aa2m8vBXM/6zPIk2VR5iJU1FKziYHaHx3nfYPt/y7e0GK6QQ==",
       "requires": {
         "grapheme-splitter": "^1.0.4"
       }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "typescript": "^3.9.6"
     },
     "dependencies": {
-        "@microsoft/powerquery-formatter": "0.0.28",
+        "@microsoft/powerquery-formatter": "0.0.29",
         "@microsoft/powerquery-parser": "0.4.2",
         "vscode-languageserver-textdocument": "1.0.1",
         "vscode-languageserver-types": "3.15.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.2.4",
+    "version": "0.2.5",
     "author": "Microsoft",
     "license": "MIT",
     "scripts": {
@@ -48,7 +48,7 @@
     },
     "dependencies": {
         "@microsoft/powerquery-formatter": "0.0.28",
-        "@microsoft/powerquery-parser": "0.4.0",
+        "@microsoft/powerquery-parser": "0.4.2",
         "vscode-languageserver-textdocument": "1.0.1",
         "vscode-languageserver-types": "3.15.1"
     },

--- a/src/powerquery-language-services/inspection/activeNode/activeNodeUtils.ts
+++ b/src/powerquery-language-services/inspection/activeNode/activeNodeUtils.ts
@@ -25,11 +25,10 @@ import { ActiveNode, ActiveNodeKind, ActiveNodeLeafKind, OutOfBoundPosition, TMa
 // '[foo = bar|' should be anchored on the identifier 'bar' and not the context node for the ']' PQP.Language.constant.
 export function maybeActiveNode(
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
-    leafNodeIds: ReadonlyArray<number>,
     position: Position,
 ): TMaybeActiveNode {
     // Search for the closest Ast node on or to the left of Position, as well as the closest shifted right Ast node.
-    const astSearch: AstNodeSearch = maybeFindAstNodes(nodeIdMapCollection, leafNodeIds, position);
+    const astSearch: AstNodeSearch = maybeFindAstNodes(nodeIdMapCollection, position);
     // Search for the closest Context node on or to the right of the closest Ast node.
     const maybeContextNode: PQP.Parser.ParseContext.Node | undefined = maybeFindContext(nodeIdMapCollection, astSearch);
 
@@ -93,12 +92,8 @@ export function createOutOfBoundPosition(position: Position): OutOfBoundPosition
     };
 }
 
-export function assertActiveNode(
-    nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
-    leafNodeIds: ReadonlyArray<number>,
-    position: Position,
-): ActiveNode {
-    const maybeValue: TMaybeActiveNode = maybeActiveNode(nodeIdMapCollection, leafNodeIds, position);
+export function assertActiveNode(nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection, position: Position): ActiveNode {
+    const maybeValue: TMaybeActiveNode = maybeActiveNode(nodeIdMapCollection, position);
     assertPositionInBounds(maybeValue);
     return maybeValue;
 }
@@ -193,11 +188,7 @@ function isAnchorNode(position: Position, astNode: PQP.Language.Ast.TNode): bool
     }
 }
 
-function maybeFindAstNodes(
-    nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
-    leafNodeIds: ReadonlyArray<number>,
-    position: Position,
-): AstNodeSearch {
+function maybeFindAstNodes(nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection, position: Position): AstNodeSearch {
     const astNodeById: PQP.Parser.NodeIdMap.AstNodeById = nodeIdMapCollection.astNodeById;
     let maybeBestOnOrBeforeNode: PQP.Language.Ast.TNode | undefined;
     let maybeBestAfter: PQP.Language.Ast.TNode | undefined;
@@ -206,7 +197,7 @@ function maybeFindAstNodes(
     // Find:
     //  the closest leaf to the left or on position.
     //  the closest leaf to the right of position.
-    for (const nodeId of leafNodeIds) {
+    for (const nodeId of nodeIdMapCollection.leafIds) {
         const maybeCandidate: PQP.Language.Ast.TNode | undefined = astNodeById.get(nodeId);
         if (maybeCandidate === undefined) {
             continue;

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteFieldAccess.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteFieldAccess.ts
@@ -86,13 +86,7 @@ function autocompleteFieldAccess<S extends PQP.Parser.IParseState = PQP.Parser.I
     }
     const field: PQP.Parser.TXorNode = maybeField;
 
-    const triedFieldType: TriedType = tryType(
-        settings,
-        nodeIdMapCollection,
-        parseState.contextState.leafNodeIds,
-        field.node.id,
-        typeCache,
-    );
+    const triedFieldType: TriedType = tryType(settings, nodeIdMapCollection, field.node.id, typeCache);
     if (PQP.ResultUtils.isError(triedFieldType)) {
         throw triedFieldType.error;
     }

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeyword.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeyword.ts
@@ -19,7 +19,6 @@ import { InspectAutocompleteKeywordState } from "./commonTypes";
 export function tryAutocompleteKeyword(
     settings: PQP.CommonSettings,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
-    leafNodeIds: ReadonlyArray<number>,
     maybeActiveNode: TMaybeActiveNode,
     maybeTrailingToken: TrailingToken | undefined,
 ): TriedAutocompleteKeyword {
@@ -33,13 +32,12 @@ export function tryAutocompleteKeyword(
     }
 
     return PQP.ResultUtils.ensureResult(settings.locale, () => {
-        return autocompleteKeyword(nodeIdMapCollection, leafNodeIds, maybeActiveNode, maybeTrailingToken);
+        return autocompleteKeyword(nodeIdMapCollection, maybeActiveNode, maybeTrailingToken);
     });
 }
 
 export function autocompleteKeyword(
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
-    leafNodeIds: ReadonlyArray<number>,
     activeNode: ActiveNode,
     maybeTrailingToken: TrailingToken | undefined,
 ): ReadonlyArray<AutocompleteItem> {
@@ -67,7 +65,6 @@ export function autocompleteKeyword(
 
     const state: InspectAutocompleteKeywordState = {
         nodeIdMapCollection,
-        leafNodeIds,
         activeNode,
         maybeTrailingToken,
         parent: activeNode.ancestry[1],

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/common.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/common.ts
@@ -35,7 +35,6 @@ export function autocompleteKeywordRightMostLeaf(
 
     const inspected: ReadonlyArray<AutocompleteItem> = autocompleteKeyword(
         state.nodeIdMapCollection,
-        state.leafNodeIds,
         shiftedActiveNode,
         state.maybeTrailingToken,
     );

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/commonTypes.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/commonTypes.ts
@@ -8,7 +8,6 @@ import { TrailingToken } from "../commonTypes";
 
 export interface InspectAutocompleteKeywordState {
     readonly nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection;
-    readonly leafNodeIds: ReadonlyArray<number>;
     readonly activeNode: ActiveNode;
     readonly maybeTrailingToken: TrailingToken | undefined;
     parent: PQP.Parser.TXorNode;

--- a/src/powerquery-language-services/inspection/autocomplete/task.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/task.ts
@@ -28,7 +28,6 @@ export function autocomplete<S extends PQP.Parser.IParseState = PQP.Parser.IPars
     maybeParseError: PQP.Parser.ParseError.ParseError<S> | undefined,
 ): Autocomplete {
     const nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection = parseState.contextState.nodeIdMapCollection;
-    const leafNodeIds: ReadonlyArray<number> = parseState.contextState.leafNodeIds;
 
     let maybeTrailingToken: TrailingToken | undefined;
     if (maybeParseError !== undefined) {
@@ -50,7 +49,6 @@ export function autocomplete<S extends PQP.Parser.IParseState = PQP.Parser.IPars
     const triedKeyword: TriedAutocompleteKeyword = tryAutocompleteKeyword(
         settings,
         nodeIdMapCollection,
-        leafNodeIds,
         maybeActiveNode,
         maybeTrailingToken,
     );

--- a/src/powerquery-language-services/inspection/scope/scopeInspection.ts
+++ b/src/powerquery-language-services/inspection/scope/scopeInspection.ts
@@ -29,13 +29,12 @@ import {
 export function tryScope(
     settings: PQP.CommonSettings,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
-    leafNodeIds: ReadonlyArray<number>,
     ancestry: ReadonlyArray<PQP.Parser.TXorNode>,
     // If a map is given, then it's mutated and returned. Else create and return a new instance.
     maybeScopeById: ScopeById | undefined,
 ): TriedScope {
     return PQP.ResultUtils.ensureResult(settings.locale, () =>
-        inspectScope(settings, nodeIdMapCollection, leafNodeIds, ancestry, maybeScopeById),
+        inspectScope(settings, nodeIdMapCollection, ancestry, maybeScopeById),
     );
 }
 
@@ -43,7 +42,6 @@ export function tryScope(
 export function tryNodeScope(
     settings: PQP.CommonSettings,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
-    leafNodeIds: ReadonlyArray<number>,
     nodeId: number,
     // If a map is given, then it's mutated and returned. Else create and return a new instance.
     maybeScopeById: ScopeById | undefined,
@@ -57,7 +55,7 @@ export function tryNodeScope(
             return new Map();
         }
 
-        const inspected: ScopeById = inspectScope(settings, nodeIdMapCollection, leafNodeIds, ancestry, maybeScopeById);
+        const inspected: ScopeById = inspectScope(settings, nodeIdMapCollection, ancestry, maybeScopeById);
         return Assert.asDefined(inspected.get(nodeId), `expected nodeId in scope result`, { nodeId });
     });
 }
@@ -65,7 +63,6 @@ export function tryNodeScope(
 export function assertGetOrCreateNodeScope(
     settings: PQP.CommonSettings,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
-    leafNodeIds: ReadonlyArray<number>,
     nodeId: number,
     // If a map is given, then it's mutated and returned. Else create and return a new instance.
     maybeScopeById: ScopeById | undefined = undefined,
@@ -76,7 +73,7 @@ export function assertGetOrCreateNodeScope(
         return PQP.ResultUtils.createOk(maybeScope);
     }
 
-    const triedNodeScope: TriedNodeScope = tryNodeScope(settings, nodeIdMapCollection, leafNodeIds, nodeId, scopeById);
+    const triedNodeScope: TriedNodeScope = tryNodeScope(settings, nodeIdMapCollection, nodeId, scopeById);
     if (PQP.ResultUtils.isError(triedNodeScope)) {
         throw triedNodeScope.error;
     }
@@ -89,7 +86,6 @@ export function assertGetOrCreateNodeScope(
 export function maybeDereferencedIdentifier(
     settings: PQP.CommonSettings,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
-    leafNodeIds: ReadonlyArray<number>,
     xorNode: PQP.Parser.TXorNode,
     // If a map is given, then it's mutated and returned. Else create and return a new instance.
     maybeScopeById: ScopeById | undefined = undefined,
@@ -125,7 +121,6 @@ export function maybeDereferencedIdentifier(
     const triedNodeScope: Inspection.TriedNodeScope = assertGetOrCreateNodeScope(
         settings,
         nodeIdMapCollection,
-        leafNodeIds,
         xorNode.node.id,
         scopeById,
     );
@@ -173,7 +168,7 @@ export function maybeDereferencedIdentifier(
     ) {
         return PQP.ResultUtils.createOk(xorNode);
     } else {
-        return maybeDereferencedIdentifier(settings, nodeIdMapCollection, leafNodeIds, maybeNextXorNode, scopeById);
+        return maybeDereferencedIdentifier(settings, nodeIdMapCollection, maybeNextXorNode, scopeById);
     }
 }
 
@@ -183,14 +178,12 @@ interface ScopeInspectionState {
     readonly deltaScope: ScopeById;
     readonly ancestry: ReadonlyArray<PQP.Parser.TXorNode>;
     readonly nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection;
-    readonly leafNodeIds: ReadonlyArray<number>;
     ancestryIndex: number;
 }
 
 function inspectScope(
     settings: PQP.CommonSettings,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
-    leafNodeIds: ReadonlyArray<number>,
     ancestry: ReadonlyArray<PQP.Parser.TXorNode>,
     // If a map is given, then it's mutated and returned. Else create and return a new instance.
     maybeScopeById: ScopeById | undefined,
@@ -217,7 +210,6 @@ function inspectScope(
         deltaScope: scopeChanges,
         ancestry,
         nodeIdMapCollection,
-        leafNodeIds,
         ancestryIndex: 0,
     };
 

--- a/src/powerquery-language-services/inspection/task.ts
+++ b/src/powerquery-language-services/inspection/task.ts
@@ -22,19 +22,13 @@ export function inspection<S extends PQP.Parser.IParseState = PQP.Parser.IParseS
 ): Inspection {
     const typeCache: TypeCache = createTypeCache();
     const nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection = parseState.contextState.nodeIdMapCollection;
-    const leafNodeIds: ReadonlyArray<number> = parseState.contextState.leafNodeIds;
 
     // We should only get an undefined for activeNode iff the document is empty
-    const maybeActiveNode: TMaybeActiveNode = ActiveNodeUtils.maybeActiveNode(
-        nodeIdMapCollection,
-        leafNodeIds,
-        position,
-    );
+    const maybeActiveNode: TMaybeActiveNode = ActiveNodeUtils.maybeActiveNode(nodeIdMapCollection, position);
 
     const triedInvokeExpression: TriedInvokeExpression = tryInvokeExpression(
         settings,
         nodeIdMapCollection,
-        leafNodeIds,
         maybeActiveNode,
         typeCache,
     );
@@ -48,13 +42,12 @@ export function inspection<S extends PQP.Parser.IParseState = PQP.Parser.IParseS
         triedNodeScope = tryNodeScope(
             settings,
             nodeIdMapCollection,
-            leafNodeIds,
             ActiveNodeUtils.assertGetLeaf(activeNode).node.id,
             typeCache.scopeById,
         );
 
         const ancestryLeaf: PQP.Parser.TXorNode = PQP.Parser.AncestryUtils.assertGetLeaf(activeNode.ancestry);
-        triedScopeType = tryScopeType(settings, nodeIdMapCollection, leafNodeIds, ancestryLeaf.node.id, typeCache);
+        triedScopeType = tryScopeType(settings, nodeIdMapCollection, ancestryLeaf.node.id, typeCache);
 
         triedExpectedType = tryExpectedType(settings, activeNode);
     } else {

--- a/src/powerquery-language-services/inspection/type/inspectType/common.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/common.ts
@@ -40,7 +40,6 @@ export interface InspectTypeState {
     readonly givenTypeById: TypeById;
     readonly deltaTypeById: TypeById;
     readonly nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection;
-    readonly leafNodeIds: ReadonlyArray<number>;
     scopeById: ScopeById;
 }
 
@@ -81,7 +80,7 @@ export function getOrCreateScope(state: InspectTypeState, nodeId: number): Inspe
         return PQP.ResultUtils.createOk(maybeNodeScope);
     }
 
-    return tryNodeScope(state.settings, state.nodeIdMapCollection, state.leafNodeIds, nodeId, state.scopeById);
+    return tryNodeScope(state.settings, state.nodeIdMapCollection, nodeId, state.scopeById);
 }
 
 export function getOrCreateScopeItemType(

--- a/src/powerquery-language-services/inspection/type/task.ts
+++ b/src/powerquery-language-services/inspection/type/task.ts
@@ -18,7 +18,6 @@ export type TriedType = PQP.Result<PQP.Language.Type.PowerQueryType, PQP.CommonE
 export function tryScopeType(
     settings: InspectionSettings,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
-    leafNodeIds: ReadonlyArray<number>,
     nodeId: number,
     maybeTypeCache: TypeCache | undefined = undefined,
 ): TriedScopeType {
@@ -27,7 +26,6 @@ export function tryScopeType(
         givenTypeById: maybeTypeCache?.typeById ?? new Map(),
         deltaTypeById: new Map(),
         nodeIdMapCollection,
-        leafNodeIds,
         scopeById: maybeTypeCache?.scopeById ?? new Map(),
     };
 
@@ -37,7 +35,6 @@ export function tryScopeType(
 export function tryType(
     settings: InspectionSettings,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
-    leafNodeIds: ReadonlyArray<number>,
     nodeId: number,
     maybeTypeCache: TypeCache | undefined = undefined,
 ): TriedType {
@@ -46,7 +43,6 @@ export function tryType(
         givenTypeById: maybeTypeCache?.typeById ?? new Map(),
         deltaTypeById: new Map(),
         nodeIdMapCollection,
-        leafNodeIds,
         scopeById: maybeTypeCache?.scopeById ?? new Map(),
     };
 

--- a/src/test/inspection/invokeExpression.ts
+++ b/src/test/inspection/invokeExpression.ts
@@ -15,19 +15,16 @@ import { InspectionSettings } from "../../powerquery-language-services/inspectio
 function assertInvokeExpressionOk(
     settings: InspectionSettings,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
-    leafNodeIds: ReadonlyArray<number>,
     position: Inspection.Position,
 ): Inspection.InvokeExpression | undefined {
     const activeNode: Inspection.ActiveNode = Inspection.ActiveNodeUtils.assertActiveNode(
         nodeIdMapCollection,
-        leafNodeIds,
         position,
     );
 
     const triedInspect: Inspection.TriedInvokeExpression = Inspection.tryInvokeExpression(
         settings,
         nodeIdMapCollection,
-        leafNodeIds,
         activeNode,
     );
     Assert.isOk(triedInspect);
@@ -40,7 +37,7 @@ function assertParseOkInvokeExpressionOk(
     position: Inspection.Position,
 ): Inspection.InvokeExpression | undefined {
     const parseOk: PQP.Task.ParseTaskOk = TestUtils.assertGetLexParseOk(settings, text);
-    return assertInvokeExpressionOk(settings, parseOk.nodeIdMapCollection, parseOk.leafNodeIds, position);
+    return assertInvokeExpressionOk(settings, parseOk.nodeIdMapCollection, position);
 }
 
 function assertParseErrInvokeExpressionOk(
@@ -48,8 +45,8 @@ function assertParseErrInvokeExpressionOk(
     text: string,
     position: Inspection.Position,
 ): Inspection.InvokeExpression | undefined {
-    const parseErr: PQP.Task.ParseTaskParseError = TestUtils.assertGetLexParseErr(settings, text);
-    return assertInvokeExpressionOk(settings, parseErr.nodeIdMapCollection, parseErr.leafNodeIds, position);
+    const parseError: PQP.Task.ParseTaskParseError = TestUtils.assertGetLexParseError(settings, text);
+    return assertInvokeExpressionOk(settings, parseError.nodeIdMapCollection, position);
 }
 
 function expectNoParameters_givenExtraneousParameter(inspected: Inspection.InvokeExpression | undefined): void {

--- a/src/test/inspection/scope.ts
+++ b/src/test/inspection/scope.ts
@@ -136,12 +136,10 @@ function createAbridgedParameterScopeItems(nodeScope: Inspection.NodeScope): Rea
 function assertNodeScopeOk(
     settings: PQP.CommonSettings,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
-    leafNodeIds: ReadonlyArray<number>,
     position: Inspection.Position,
 ): Inspection.NodeScope {
     const maybeActiveNode: Inspection.TMaybeActiveNode = Inspection.ActiveNodeUtils.maybeActiveNode(
         nodeIdMapCollection,
-        leafNodeIds,
         position,
     );
     if (!Inspection.ActiveNodeUtils.isPositionInBounds(maybeActiveNode)) {
@@ -152,7 +150,6 @@ function assertNodeScopeOk(
     const triedNodeScope: Inspection.TriedNodeScope = Inspection.tryNodeScope(
         settings,
         nodeIdMapCollection,
-        leafNodeIds,
         activeNode.ancestry[0].node.id,
         undefined,
     );
@@ -167,7 +164,7 @@ export function assertGetParseOkScopeOk(
     position: Inspection.Position,
 ): Inspection.NodeScope {
     const parseOk: PQP.Task.ParseTaskOk = TestUtils.assertGetLexParseOk(settings, text);
-    return assertNodeScopeOk(settings, parseOk.nodeIdMapCollection, parseOk.leafNodeIds, position);
+    return assertNodeScopeOk(settings, parseOk.nodeIdMapCollection, position);
 }
 
 export function assertGetParseErrScopeOk(
@@ -175,8 +172,8 @@ export function assertGetParseErrScopeOk(
     text: string,
     position: Inspection.Position,
 ): Inspection.NodeScope {
-    const parseError: PQP.Task.ParseTaskParseError = TestUtils.assertGetLexParseErr(settings, text);
-    return assertNodeScopeOk(settings, parseError.nodeIdMapCollection, parseError.leafNodeIds, position);
+    const parseError: PQP.Task.ParseTaskParseError = TestUtils.assertGetLexParseError(settings, text);
+    return assertNodeScopeOk(settings, parseError.nodeIdMapCollection, position);
 }
 
 describe(`subset Inspection - Scope - Identifier`, () => {

--- a/src/test/inspection/type.ts
+++ b/src/test/inspection/type.ts
@@ -45,7 +45,6 @@ function assertParseOkNodeTypeEqual(
     const actual: PQP.Language.Type.PowerQueryType = assertGetParseNodeOk(
         settings,
         parseOk.nodeIdMapCollection,
-        parseOk.leafNodeIds,
         PQP.Parser.XorNodeUtils.createAstNode(parseOk.ast),
     );
 
@@ -53,13 +52,12 @@ function assertParseOkNodeTypeEqual(
 }
 
 function assertParseErrNodeTypeEqual(text: string, expected: PQP.Language.Type.PowerQueryType): void {
-    const parseErr: PQP.Task.ParseTaskParseError = TestUtils.assertGetLexParseErr(TestSettings, text);
+    const parseError: PQP.Task.ParseTaskParseError = TestUtils.assertGetLexParseError(TestSettings, text);
 
     const actual: PQP.Language.Type.PowerQueryType = assertGetParseNodeOk(
         TestSettings,
-        parseErr.nodeIdMapCollection,
-        parseErr.leafNodeIds,
-        PQP.Parser.XorNodeUtils.createContextNode(Assert.asDefined(parseErr.parseState.contextState.maybeRoot)),
+        parseError.nodeIdMapCollection,
+        PQP.Parser.XorNodeUtils.createContextNode(Assert.asDefined(parseError.parseState.contextState.maybeRoot)),
     );
 
     expect(actual).deep.equal(expected);
@@ -68,15 +66,9 @@ function assertParseErrNodeTypeEqual(text: string, expected: PQP.Language.Type.P
 function assertGetParseNodeOk(
     settings: PQP.Settings & Inspection.InspectionSettings,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
-    leafNodeIds: ReadonlyArray<number>,
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.PowerQueryType {
-    const triedType: Inspection.TriedType = Inspection.tryType(
-        settings,
-        nodeIdMapCollection,
-        leafNodeIds,
-        xorNode.node.id,
-    );
+    const triedType: Inspection.TriedType = Inspection.tryType(settings, nodeIdMapCollection, xorNode.node.id);
     Assert.isOk(triedType);
 
     return triedType.value;
@@ -95,7 +87,6 @@ function assertParseOkScopeTypeEqual(
     const actual: Inspection.ScopeTypeByKey = assertGetParseOkScopeTypeOk(
         settings,
         parseOk.nodeIdMapCollection,
-        parseOk.leafNodeIds,
         position,
     );
 
@@ -105,16 +96,14 @@ function assertParseOkScopeTypeEqual(
 function assertGetParseOkScopeTypeOk(
     settings: Inspection.InspectionSettings,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
-    leafNodeIds: ReadonlyArray<number>,
     position: Inspection.Position,
 ): Inspection.ScopeTypeByKey {
     const activeNodeLeaf: PQP.Parser.TXorNode = Inspection.ActiveNodeUtils.assertGetLeaf(
-        Inspection.ActiveNodeUtils.assertActiveNode(nodeIdMapCollection, leafNodeIds, position),
+        Inspection.ActiveNodeUtils.assertActiveNode(nodeIdMapCollection, position),
     );
     const triedScopeType: Inspection.TriedScopeType = Inspection.tryScopeType(
         settings,
         nodeIdMapCollection,
-        leafNodeIds,
         activeNodeLeaf.node.id,
     );
     Assert.isOk(triedScopeType);

--- a/src/test/testUtils/assert.ts
+++ b/src/test/testUtils/assert.ts
@@ -35,11 +35,7 @@ export function assertGetAutocomplete<S extends PQP.Parser.IParseState = PQP.Par
             settings,
             triedLexParseTask.parseState,
             Inspection.createTypeCache(),
-            ActiveNodeUtils.maybeActiveNode(
-                triedLexParseTask.nodeIdMapCollection,
-                triedLexParseTask.leafNodeIds,
-                position,
-            ),
+            ActiveNodeUtils.maybeActiveNode(triedLexParseTask.nodeIdMapCollection, position),
             undefined,
         );
     } else if (PQP.TaskUtils.isParseStageError(triedLexParseTask)) {
@@ -51,11 +47,7 @@ export function assertGetAutocomplete<S extends PQP.Parser.IParseState = PQP.Par
             settings,
             triedLexParseTask.parseState,
             Inspection.createTypeCache(),
-            ActiveNodeUtils.maybeActiveNode(
-                triedLexParseTask.nodeIdMapCollection,
-                triedLexParseTask.leafNodeIds,
-                position,
-            ),
+            ActiveNodeUtils.maybeActiveNode(triedLexParseTask.nodeIdMapCollection, position),
             triedLexParseTask.error,
         );
     } else {
@@ -101,7 +93,7 @@ export function assertGetLexParseOk<S extends PQP.Parser.IParseState = PQP.Parse
     return triedLexParseTask;
 }
 
-export function assertGetLexParseErr<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
+export function assertGetLexParseError<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
     settings: PQP.Settings<S>,
     text: string,
 ): PQP.Task.ParseTaskParseError<S> {
@@ -181,7 +173,7 @@ export function assertParserCacheItemOk(
     TaskUtils.assertIsParseStageOk(cacheItem);
 }
 
-export function assertParserCacheItemErr(
+export function assertParserCacheItemError(
     cacheItem: WorkspaceCache.CacheItem,
 ): asserts cacheItem is PQP.Task.ParseTaskOk {
     assertNotInspectionCacheItem(cacheItem);

--- a/src/test/workspaceCacheTest.ts
+++ b/src/test/workspaceCacheTest.ts
@@ -29,7 +29,7 @@ describe("workspaceCache", () => {
     it("getTriedLexParse with error", () => {
         const document: TextDocument = TestUtils.createTextMockDocument("let c = 1, in c");
         const cacheItem: WorkspaceCache.ParseCacheItem = WorkspaceCacheUtils.getTriedParse(document, undefined);
-        TestUtils.assertParserCacheItemErr(cacheItem);
+        TestUtils.assertParserCacheItemError(cacheItem);
     });
 
     it("getInspection", () => {


### PR DESCRIPTION
* Updated parser and formatter packages. Most of the delta is the removal of leafNodeIds (as it was folded into NodeIdMap.Collection)
* Random nit fit fix where ErrX was renamed to ErrorX