### PR TITLE
Remove Position

### DIFF
--- a/src/powerquery-language-services/inspection/activeNode/activeNode.ts
+++ b/src/powerquery-language-services/inspection/activeNode/activeNode.ts
@@ -3,7 +3,7 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
-import { Position } from "../position";
+import { Position } from "vscode-languageserver-types";
 
 export type TMaybeActiveNode =
     // A Position located inside an Ast (either fully or partially parsed).

--- a/src/powerquery-language-services/inspection/activeNode/activeNode.ts
+++ b/src/powerquery-language-services/inspection/activeNode/activeNode.ts
@@ -3,7 +3,7 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
-import { Position } from "vscode-languageserver-types";
+import type { Position } from "vscode-languageserver-types";
 
 export type TMaybeActiveNode =
     // A Position located inside an Ast (either fully or partially parsed).

--- a/src/powerquery-language-services/inspection/activeNode/activeNodeUtils.ts
+++ b/src/powerquery-language-services/inspection/activeNode/activeNodeUtils.ts
@@ -3,7 +3,9 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
-import { Position, PositionUtils } from "../position";
+import { Position } from "vscode-languageserver-types";
+
+import { PositionUtils } from "..";
 import { ActiveNode, ActiveNodeKind, ActiveNodeLeafKind, OutOfBoundPosition, TMaybeActiveNode } from "./activeNode";
 
 // Searches all leaf PQP.Language.Ast.TNodes and all Context nodes to find the "active" node.

--- a/src/powerquery-language-services/inspection/activeNode/activeNodeUtils.ts
+++ b/src/powerquery-language-services/inspection/activeNode/activeNodeUtils.ts
@@ -3,7 +3,7 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
-import { Position } from "vscode-languageserver-types";
+import type { Position } from "vscode-languageserver-types";
 
 import { PositionUtils } from "..";
 import { ActiveNode, ActiveNodeKind, ActiveNodeLeafKind, OutOfBoundPosition, TMaybeActiveNode } from "./activeNode";

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteFieldAccess.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteFieldAccess.ts
@@ -4,9 +4,10 @@
 import * as PQP from "@microsoft/powerquery-parser";
 
 import { Assert } from "@microsoft/powerquery-parser";
+import { Position } from "vscode-languageserver-types";
 
+import { PositionUtils } from "..";
 import { ActiveNode, ActiveNodeUtils, TMaybeActiveNode } from "../activeNode";
-import { Position, PositionUtils } from "../position";
 import { InspectionSettings } from "../settings";
 import { TriedType, tryType } from "../type";
 import { TypeCache } from "../typeCache";

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteFieldAccess.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteFieldAccess.ts
@@ -4,7 +4,7 @@
 import * as PQP from "@microsoft/powerquery-parser";
 
 import { Assert } from "@microsoft/powerquery-parser";
-import { Position } from "vscode-languageserver-types";
+import type { Position } from "vscode-languageserver-types";
 
 import { PositionUtils } from "..";
 import { ActiveNode, ActiveNodeUtils, TMaybeActiveNode } from "../activeNode";

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeyword.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeyword.ts
@@ -3,8 +3,8 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { PositionUtils } from "../..";
 import { ActiveNode, ActiveNodeLeafKind, ActiveNodeUtils, TMaybeActiveNode } from "../../activeNode";
-import { PositionUtils } from "../../position";
 import { AutocompleteItem, AutocompleteItemUtils } from "../autocompleteItem";
 import { TrailingToken, TriedAutocompleteKeyword } from "../commonTypes";
 import { autocompleteKeywordDefault } from "./autocompleteKeywordDefault";

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordDefault.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordDefault.ts
@@ -3,8 +3,8 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { PositionUtils } from "../..";
 import { ActiveNode, ActiveNodeLeafKind } from "../../activeNode";
-import { PositionUtils } from "../../position";
 import { InspectAutocompleteKeywordState } from "./commonTypes";
 
 export function autocompleteKeywordDefault(

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordErrorHandlingExpression.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordErrorHandlingExpression.ts
@@ -3,7 +3,9 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
-import { Position, PositionUtils } from "../../position";
+import { Position } from "vscode-languageserver-types";
+
+import { PositionUtils } from "../..";
 import { TrailingToken } from "../commonTypes";
 import { InspectAutocompleteKeywordState } from "./commonTypes";
 

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordErrorHandlingExpression.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordErrorHandlingExpression.ts
@@ -3,7 +3,7 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
-import { Position } from "vscode-languageserver-types";
+import type { Position } from "vscode-languageserver-types";
 
 import { PositionUtils } from "../..";
 import { TrailingToken } from "../commonTypes";

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordIdentifierPairedExpression.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordIdentifierPairedExpression.ts
@@ -3,7 +3,7 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
-import { PositionUtils } from "../../position";
+import { PositionUtils } from "../..";
 import { InspectAutocompleteKeywordState } from "./commonTypes";
 
 export function autocompleteKeywordIdentifierPairedExpression(

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordLetExpression.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordLetExpression.ts
@@ -3,7 +3,7 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
-import { PositionUtils } from "../../position";
+import { PositionUtils } from "../..";
 import { autocompleteKeywordDefault } from "./autocompleteKeywordDefault";
 import { autocompleteKeywordTrailingText } from "./autocompleteKeywordTrailingText";
 import { autocompleteKeywordRightMostLeaf } from "./common";

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordListExpression.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordListExpression.ts
@@ -4,9 +4,9 @@
 import * as PQP from "@microsoft/powerquery-parser";
 
 import { Assert } from "@microsoft/powerquery-parser";
+import { PositionUtils } from "../..";
 
 import { ActiveNode } from "../../activeNode";
-import { PositionUtils } from "../../position";
 import { InspectAutocompleteKeywordState } from "./commonTypes";
 
 export function autocompleteKeywordListExpression(

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteLanguageConstant.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteLanguageConstant.ts
@@ -3,7 +3,7 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
-import { Position } from "vscode-languageserver-types";
+import type { Position } from "vscode-languageserver-types";
 import { PositionUtils } from "..";
 import { ActiveNode, ActiveNodeUtils, TMaybeActiveNode } from "../activeNode";
 import { AutocompleteItem, AutocompleteItemUtils } from "./autocompleteItem";

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteLanguageConstant.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteLanguageConstant.ts
@@ -3,8 +3,9 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { Position } from "vscode-languageserver-types";
+import { PositionUtils } from "..";
 import { ActiveNode, ActiveNodeUtils, TMaybeActiveNode } from "../activeNode";
-import { Position, PositionUtils } from "../position";
 import { AutocompleteItem, AutocompleteItemUtils } from "./autocompleteItem";
 import { TriedAutocompleteLanguageConstant } from "./commonTypes";
 

--- a/src/powerquery-language-services/inspection/autocomplete/autocompletePrimitiveType.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompletePrimitiveType.ts
@@ -3,8 +3,8 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { PositionUtils } from "..";
 import { ActiveNode, ActiveNodeUtils, TMaybeActiveNode } from "../activeNode";
-import { PositionUtils } from "../position";
 import { AutocompleteItem, AutocompleteItemUtils } from "./autocompleteItem";
 import { TrailingToken, TriedAutocompletePrimitiveType } from "./commonTypes";
 

--- a/src/powerquery-language-services/inspection/autocomplete/common.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/common.ts
@@ -3,7 +3,7 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
-import { Position } from "vscode-languageserver-types";
+import type { Position } from "vscode-languageserver-types";
 
 import { PositionUtils } from "..";
 import { TrailingToken } from "./commonTypes";

--- a/src/powerquery-language-services/inspection/autocomplete/common.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/common.ts
@@ -3,7 +3,9 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
-import { Position, PositionUtils } from "../position";
+import { Position } from "vscode-languageserver-types";
+
+import { PositionUtils } from "..";
 import { TrailingToken } from "./commonTypes";
 
 export function createTrailingToken(position: Position, parseErrorToken: PQP.Language.Token.Token): TrailingToken {

--- a/src/powerquery-language-services/inspection/index.ts
+++ b/src/powerquery-language-services/inspection/index.ts
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+export * as PositionUtils from "./positionUtils";
 export * from "./activeNode";
 export * from "./autocomplete";
 export * from "./commonTypes";
 export * from "./externalType";
 export * from "./invokeExpression";
 export * from "./jaroWinkler";
-export * from "./position";
 export * from "./settings";
 export * from "./scope";
 export * from "./task";

--- a/src/powerquery-language-services/inspection/position/index.ts
+++ b/src/powerquery-language-services/inspection/position/index.ts
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-
-import * as PositionUtils from "./positionUtils";
-
-export { PositionUtils };
-export * from "./position";

--- a/src/powerquery-language-services/inspection/position/position.ts
+++ b/src/powerquery-language-services/inspection/position/position.ts
@@ -1,8 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-
-// Represents a cursor position in a text editor.
-export interface Position {
-    readonly lineNumber: number;
-    readonly lineCodeUnit: number;
-}

--- a/src/powerquery-language-services/inspection/positionUtils.ts
+++ b/src/powerquery-language-services/inspection/positionUtils.ts
@@ -3,7 +3,7 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
-import { Position } from "./position";
+import { Position } from "vscode-languageserver-types";
 
 export function isBeforeXor(position: Position, xorNode: PQP.Parser.TXorNode, isBoundIncluded: boolean): boolean {
     switch (xorNode.kind) {
@@ -202,7 +202,7 @@ export function isBeforeTokenPosition(
     tokenPosition: PQP.Language.Token.TokenPosition,
     isBoundIncluded: boolean,
 ): boolean {
-    const positionLineNumber: number = position.lineNumber;
+    const positionLineNumber: number = position.line;
 
     if (positionLineNumber < tokenPosition.lineNumber) {
         return true;
@@ -210,12 +210,12 @@ export function isBeforeTokenPosition(
         return false;
     } else {
         const upperBound: number = isBoundIncluded ? tokenPosition.lineCodeUnit : tokenPosition.lineCodeUnit + 1;
-        return position.lineCodeUnit < upperBound;
+        return position.character < upperBound;
     }
 }
 
 export function isOnTokenPosition(position: Position, tokenPosition: PQP.Language.Token.TokenPosition): boolean {
-    return position.lineNumber === tokenPosition.lineNumber && position.lineCodeUnit === tokenPosition.lineCodeUnit;
+    return position.line === tokenPosition.lineNumber && position.character === tokenPosition.lineCodeUnit;
 }
 
 export function isAfterTokenPosition(
@@ -223,7 +223,7 @@ export function isAfterTokenPosition(
     tokenPosition: PQP.Language.Token.TokenPosition,
     isBoundIncluded: boolean,
 ): boolean {
-    const positionLineNumber: number = position.lineNumber;
+    const positionLineNumber: number = position.line;
 
     if (positionLineNumber < tokenPosition.lineNumber) {
         return false;
@@ -231,6 +231,6 @@ export function isAfterTokenPosition(
         return true;
     } else {
         const upperBound: number = isBoundIncluded ? tokenPosition.lineCodeUnit : tokenPosition.lineCodeUnit - 1;
-        return position.lineCodeUnit > upperBound;
+        return position.character > upperBound;
     }
 }

--- a/src/powerquery-language-services/inspection/positionUtils.ts
+++ b/src/powerquery-language-services/inspection/positionUtils.ts
@@ -3,7 +3,7 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
-import { Position } from "vscode-languageserver-types";
+import type { Position } from "vscode-languageserver-types";
 
 export function isBeforeXor(position: Position, xorNode: PQP.Parser.TXorNode, isBoundIncluded: boolean): boolean {
     switch (xorNode.kind) {

--- a/src/powerquery-language-services/inspection/task.ts
+++ b/src/powerquery-language-services/inspection/task.ts
@@ -3,7 +3,7 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
-import { Position } from "vscode-languageserver-types";
+import type { Position } from "vscode-languageserver-types";
 
 import { ActiveNode, ActiveNodeUtils, TMaybeActiveNode } from "./activeNode";
 import { autocomplete } from "./autocomplete";

--- a/src/powerquery-language-services/inspection/task.ts
+++ b/src/powerquery-language-services/inspection/task.ts
@@ -3,12 +3,13 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { Position } from "vscode-languageserver-types";
+
 import { ActiveNode, ActiveNodeUtils, TMaybeActiveNode } from "./activeNode";
 import { autocomplete } from "./autocomplete";
 import { Inspection } from "./commonTypes";
 import { TriedExpectedType, tryExpectedType } from "./expectedType";
 import { TriedInvokeExpression, tryInvokeExpression } from "./invokeExpression";
-import type { Position } from "./position";
 import { TriedNodeScope, tryNodeScope } from "./scope";
 import type { InspectionSettings } from "./settings";
 import { TriedScopeType, tryScopeType } from "./type";

--- a/src/powerquery-language-services/workspaceCache/workspaceCacheUtils.ts
+++ b/src/powerquery-language-services/workspaceCache/workspaceCacheUtils.ts
@@ -3,7 +3,7 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 import { TextDocument, TextDocumentContentChangeEvent } from "vscode-languageserver-textdocument";
-import { Position } from "vscode-languageserver-types";
+import type { Position } from "vscode-languageserver-types";
 
 import { Inspection } from "..";
 import type {

--- a/src/powerquery-language-services/workspaceCache/workspaceCacheUtils.ts
+++ b/src/powerquery-language-services/workspaceCache/workspaceCacheUtils.ts
@@ -196,10 +196,7 @@ function getOrCreateInspectionCacheItem<S extends PQP.Parser.IParseState = PQP.P
         inspectionSettings,
         parseState,
         PQP.TaskUtils.isParseStageParseError(parseCacheItem) ? parseCacheItem.error : undefined,
-        {
-            lineNumber: position.line,
-            lineCodeUnit: position.character,
-        },
+        position,
     );
     const inspectionCacheItem: InspectionCacheItem = {
         ...inspection,

--- a/src/test/inspection/autocomplete/autocompleteFieldAccess.ts
+++ b/src/test/inspection/autocomplete/autocompleteFieldAccess.ts
@@ -5,7 +5,7 @@ import * as PQP from "@microsoft/powerquery-parser";
 
 import { Assert } from "@microsoft/powerquery-parser";
 import "mocha";
-import { Position } from "vscode-languageserver-types";
+import type { Position } from "vscode-languageserver-types";
 
 import { TestConstants, TestUtils } from "../..";
 import { Inspection } from "../../../powerquery-language-services";

--- a/src/test/inspection/autocomplete/autocompleteFieldAccess.ts
+++ b/src/test/inspection/autocomplete/autocompleteFieldAccess.ts
@@ -5,6 +5,7 @@ import * as PQP from "@microsoft/powerquery-parser";
 
 import { Assert } from "@microsoft/powerquery-parser";
 import "mocha";
+import { Position } from "vscode-languageserver-types";
 
 import { TestConstants, TestUtils } from "../..";
 import { Inspection } from "../../../powerquery-language-services";
@@ -12,7 +13,7 @@ import { Inspection } from "../../../powerquery-language-services";
 function assertGetFieldAccessAutocomplete<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
     settings: Inspection.InspectionSettings<S>,
     text: string,
-    position: Inspection.Position,
+    position: Position,
 ): ReadonlyArray<Inspection.AutocompleteItem> {
     const actual: Inspection.Autocomplete = TestUtils.assertGetAutocomplete(settings, text, position);
     Assert.isOk(actual.triedFieldAccess);
@@ -24,7 +25,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
     describe(`Selection`, () => {
         describe(`ParseOk`, () => {
             it(`[cat = 1, car = 2][x|]`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][x|]`,
                 );
                 const expected: ReadonlyArray<string> = [];
@@ -37,7 +38,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
             });
 
             it(`[cat = 1, car = 2][c|]`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][c|]`,
                 );
                 const expected: ReadonlyArray<string> = ["cat", "car"];
@@ -50,7 +51,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
             });
 
             it(`[cat = 1, car = 2][| c]`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][| c]`,
                 );
                 const expected: ReadonlyArray<string> = [];
@@ -63,7 +64,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
             });
 
             it(`[cat = 1, car = 2][c |]`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][c |]`,
                 );
                 const expected: ReadonlyArray<string> = [];
@@ -76,7 +77,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
             });
 
             it(`section x; value = [foo = 1, bar = 2, foobar = 3]; valueAccess = value[f|];`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `section x; value = [foo = 1, bar = 2, foobar = 3]; valueAccess = value[f|];`,
                 );
                 const expected: ReadonlyArray<string> = ["foo", "foobar"];
@@ -91,7 +92,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
 
         describe(`ParseErr`, () => {
             it(`[cat = 1, car = 2][|]`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][|]`,
                 );
                 const expected: ReadonlyArray<string> = ["cat", "car"];
@@ -104,7 +105,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
             });
 
             it(`[cat = 1, car = 2]|[`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2]|[`,
                 );
                 const expected: ReadonlyArray<string> = [];
@@ -117,7 +118,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
             });
 
             it(`[cat = 1, car = 2][|`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][|`,
                 );
                 const expected: ReadonlyArray<string> = ["cat", "car"];
@@ -130,7 +131,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
             });
 
             it(`[cat = 1, car = 2][x|`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][x|`,
                 );
                 const expected: ReadonlyArray<string> = [];
@@ -143,7 +144,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
             });
 
             it(`[cat = 1, car = 2][c|`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][c|`,
                 );
                 const expected: ReadonlyArray<string> = ["cat", "car"];
@@ -156,7 +157,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
             });
 
             it(`[cat = 1, car = 2][c |`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][c |`,
                 );
                 const expected: ReadonlyArray<string> = [];
@@ -169,7 +170,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
             });
 
             it(`section x; value = [foo = 1, bar = 2, foobar = 3]; valueAccess = value[|`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `section x; value = [foo = 1, bar = 2, foobar = 3]; valueAccess = value[|`,
                 );
                 const expected: ReadonlyArray<string> = ["foo", "bar", "foobar"];
@@ -186,7 +187,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
     describe("Projection", () => {
         describe("ParseOk", () => {
             it(`[cat = 1, car = 2][ [x|] ]`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [x|] ]`,
                 );
                 const expected: ReadonlyArray<string> = [];
@@ -199,7 +200,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
             });
 
             it(`[cat = 1, car = 2][ [c|] ]`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [c|] ]`,
                 );
                 const expected: ReadonlyArray<string> = ["cat", "car"];
@@ -213,7 +214,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
             });
 
             it(`[cat = 1, car = 2][ [c |] ]`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [c |] ]`,
                 );
                 const expected: ReadonlyArray<string> = [];
@@ -226,7 +227,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
             });
 
             it(`[cat = 1, car = 2][ [x], [c|] ]`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [x], [c|] ]`,
                 );
                 const expected: ReadonlyArray<string> = ["cat", "car"];
@@ -239,7 +240,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
             });
 
             it(`[cat = 1, car = 2][ [cat], [c|] ]`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [cat], [c|] ]`,
                 );
                 const expected: ReadonlyArray<string> = ["car"];
@@ -252,7 +253,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
             });
 
             it(`[cat = 1, car = 2][ [cat], [car], [c|] ]`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [cat], [car], [c|] ]`,
                 );
                 const expected: ReadonlyArray<string> = [];
@@ -267,7 +268,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
 
         describe(`ParseErr`, () => {
             it(`[cat = 1, car = 2][ [|`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [|`,
                 );
                 const expected: ReadonlyArray<string> = ["cat", "car"];
@@ -280,7 +281,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
             });
 
             it(`[cat = 1, car = 2][ [ |`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [ |`,
                 );
                 const expected: ReadonlyArray<string> = ["cat", "car"];
@@ -293,7 +294,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
             });
 
             it(`[cat = 1, car = 2][ [ c|`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [ c|`,
                 );
                 const expected: ReadonlyArray<string> = ["cat", "car"];
@@ -306,7 +307,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
             });
 
             it(`[cat = 1, car = 2][ [ cat|`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [ cat|`,
                 );
                 const expected: ReadonlyArray<string> = ["cat"];
@@ -319,7 +320,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
             });
 
             it(`[cat = 1, car = 2][ [ cat |`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [ cat |`,
                 );
                 const expected: ReadonlyArray<string> = [];
@@ -332,7 +333,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
             });
 
             it(`[cat = 1, car = 2][ [ cat ]|`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [ cat ]|`,
                 );
                 const expected: ReadonlyArray<string> = [];
@@ -345,7 +346,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
             });
 
             it(`[cat = 1, car = 2][ [ cat ] |`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [ cat ] |`,
                 );
                 const expected: ReadonlyArray<string> = [];
@@ -358,7 +359,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
             });
 
             it(`[cat = 1, car = 2][ [ cat ]|`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [ cat ]|`,
                 );
                 const expected: ReadonlyArray<string> = [];
@@ -371,7 +372,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
             });
 
             it(`[cat = 1, car = 2][ [ cat ]|`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [ cat ]|`,
                 );
                 const expected: ReadonlyArray<string> = [];
@@ -384,7 +385,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
             });
 
             it(`[cat = 1, car = 2][ [ cat ], |`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [ cat ], |`,
                 );
                 const expected: ReadonlyArray<string> = [];
@@ -397,7 +398,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
             });
 
             it(`[cat = 1, car = 2][ [ cat ], [|`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [ cat ], [|`,
                 );
                 const expected: ReadonlyArray<string> = ["car"];
@@ -410,7 +411,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
             });
 
             it(`[cat = 1, car = 2][ [ cat ], [|<>`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [ cat ], [|<>`,
                 );
                 const expected: ReadonlyArray<string> = ["car"];
@@ -423,7 +424,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
             });
 
             it(`[cat = 1, car = 2][ [ cat ], [| <>`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [ cat ], [| <>`,
                 );
                 const expected: ReadonlyArray<string> = ["car"];
@@ -436,7 +437,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
             });
 
             it(`[cat = 1, car = 2][ [ cat ], [<>|`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [ cat ], [<>|`,
                 );
                 const expected: ReadonlyArray<string> = [];
@@ -452,7 +453,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
 
     describe(`Indirection`, () => {
         it(`let fn = () => [cat = 1, car = 2] in fn()[|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `let fn = () => [cat = 1, car = 2] in fn()[|`,
             );
             const expected: ReadonlyArray<string> = ["cat", "car"];
@@ -465,7 +466,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
         });
 
         it(`let foo = () => [cat = 1, car = 2], bar = foo in bar()[|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `let foo = () => [cat = 1, car = 2], bar = foo in bar()[|`,
             );
             const expected: ReadonlyArray<string> = ["cat", "car"];
@@ -478,7 +479,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
         });
 
         it(`let foo = () => [cat = 1, car = 2], bar = () => foo in bar()()[|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `let foo = () => [cat = 1, car = 2], bar = () => foo in bar()()[|`,
             );
             const expected: ReadonlyArray<string> = ["cat", "car"];
@@ -491,7 +492,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
         });
 
         it(`let foo = () => if true then [cat = 1] else [car = 2] in foo()[|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `let foo = () => if true then [cat = 1] else [car = 2] in foo()[|`,
             );
             const expected: ReadonlyArray<string> = ["cat", "car"];
@@ -506,7 +507,7 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
 
     describe(`GeneralizedIdentifier`, () => {
         it(`[#"regularIdentifier" = 1, #"generalized identifier" = 2][|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `[#"regularIdentifier" = 1, #"generalized identifier" = 2][|`,
             );
             const expected: ReadonlyArray<string> = [`regularIdentifier`, `#"generalized identifier"`];

--- a/src/test/inspection/autocomplete/autocompleteKeyword.ts
+++ b/src/test/inspection/autocomplete/autocompleteKeyword.ts
@@ -5,14 +5,12 @@ import * as PQP from "@microsoft/powerquery-parser";
 
 import { Assert } from "@microsoft/powerquery-parser";
 import "mocha";
+import { Position } from "vscode-languageserver-types";
 
 import { TestConstants, TestUtils } from "../..";
 import { Inspection } from "../../../powerquery-language-services";
 
-function assertGetKeywordAutocomplete(
-    text: string,
-    position: Inspection.Position,
-): ReadonlyArray<Inspection.AutocompleteItem> {
+function assertGetKeywordAutocomplete(text: string, position: Position): ReadonlyArray<Inspection.AutocompleteItem> {
     const actual: Inspection.Autocomplete = TestUtils.assertGetAutocomplete(
         TestConstants.DefaultInspectionSettings,
         text,
@@ -24,7 +22,7 @@ function assertGetKeywordAutocomplete(
 
 describe(`Inspection - Autocomplete - Keyword`, () => {
     it("|", () => {
-        const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`|`);
+        const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`|`);
         const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
             ...PQP.Language.Keyword.ExpressionKeywordKinds,
             PQP.Language.Keyword.KeywordKind.Section,
@@ -35,14 +33,14 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
 
     describe("partial keyword", () => {
         it("a|", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`a|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`a|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("x a|", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`x a|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`x a|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
                 PQP.Language.Keyword.KeywordKind.And,
                 PQP.Language.Keyword.KeywordKind.As,
@@ -52,7 +50,7 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it("e|", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`e|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`e|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
                 PQP.Language.Keyword.KeywordKind.Each,
                 PQP.Language.Keyword.KeywordKind.Error,
@@ -62,58 +60,56 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it("if x then x e|", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                `if x then x e|`,
-            );
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if x then x e|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Else];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("i|", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`i|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`i|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.If];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("l|", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`l|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`l|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Let];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("m|", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`m|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`m|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("x m|", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`x m|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`x m|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Meta];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("n|", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`n|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`n|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Not];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("true o|", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`true o|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`true o|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Or];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("try true o|", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`try true o|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`try true o|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
                 PQP.Language.Keyword.KeywordKind.Or,
                 PQP.Language.Keyword.KeywordKind.Otherwise,
@@ -123,14 +119,14 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it("try true o |", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`try true o |`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`try true o |`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("try true ot|", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`try true ot|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`try true ot|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
                 PQP.Language.Keyword.KeywordKind.Otherwise,
             ];
@@ -139,9 +135,7 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it("try true oth|", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                `try true oth|`,
-            );
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`try true oth|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
                 PQP.Language.Keyword.KeywordKind.Otherwise,
             ];
@@ -150,7 +144,7 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it("s|", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`s|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`s|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
                 PQP.Language.Keyword.KeywordKind.Section,
             ];
@@ -159,7 +153,7 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it("[] |", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`[] |`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[] |`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
                 PQP.Language.Keyword.KeywordKind.Section,
             ];
@@ -168,14 +162,14 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it("[] |s", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`[] |s`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[] |s`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("[] s|", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`[] s|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[] s|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
                 PQP.Language.Keyword.KeywordKind.Section,
             ];
@@ -184,46 +178,42 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it("[] s |", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`[] s |`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[] s |`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("section; s|", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`section; s|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`section; s|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Shared];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("section; shared x|", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                `section; shared x|`,
-            );
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`section; shared x|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("section; [] s|", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                `section; [] s|`,
-            );
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`section; [] s|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Shared];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("if true t|", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if true t|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if true t|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Then];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("t|", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`t|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`t|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
                 PQP.Language.Keyword.KeywordKind.True,
                 PQP.Language.Keyword.KeywordKind.Try,
@@ -236,7 +226,7 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
 
     describe(`${PQP.Language.Ast.NodeKind.ErrorHandlingExpression}`, () => {
         it(`try |`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`try |`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`try |`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
                 PQP.Language.Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
@@ -244,14 +234,14 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it(`try true|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`try true|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`try true|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.True];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`try true |`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`try true |`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`try true |`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
                 PQP.Language.Keyword.KeywordKind.And,
                 PQP.Language.Keyword.KeywordKind.As,
@@ -267,7 +257,7 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
 
     describe(`${PQP.Language.Ast.NodeKind.ErrorRaisingExpression}`, () => {
         it(`if |error`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if |error`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if |error`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
                 PQP.Language.Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
@@ -275,14 +265,14 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it(`if error|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if error|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if error|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`error |`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`error |`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`error |`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
                 PQP.Language.Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
@@ -292,18 +282,14 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
 
     describe(`${PQP.Language.Ast.NodeKind.FunctionExpression}`, () => {
         it(`let x = (_ |) => a in x`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                `let x = (_ |) => a in x`,
-            );
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let x = (_ |) => a in x`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.As];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`let x = (_ a|) => a in`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                `let x = (_ a|) => a in`,
-            );
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let x = (_ a|) => a in`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.As];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
@@ -312,14 +298,14 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
 
     describe(`${PQP.Language.Ast.NodeKind.IfExpression}`, () => {
         it(`if|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(` if |`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if |`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if |`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
                 PQP.Language.Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
@@ -327,14 +313,14 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it(`if 1|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if 1|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if 1|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if |if`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if |if`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if |if`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
                 PQP.Language.Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
@@ -342,14 +328,14 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it(`if i|f`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if i|f`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if i|f`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.If];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if if | `, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if if |`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if if |`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
                 PQP.Language.Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
@@ -357,21 +343,21 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it(`if 1 |`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if 1 |`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if 1 |`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Then];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if 1 t|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if 1 t|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if 1 t|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Then];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if 1 then |`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if 1 then |`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if 1 then |`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
                 PQP.Language.Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
@@ -379,43 +365,35 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it(`if 1 then 1|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if 1 then 1|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if 1 then 1|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if 1 then 1 e|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                `if 1 then 1 e|`,
-            );
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if 1 then 1 e|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Else];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if 1 then 1 else|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                `if 1 then 1 else|`,
-            );
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if 1 then 1 else|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if 1 th|en 1 else`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                `if 1 th|en 1 else`,
-            );
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if 1 th|en 1 else`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Then];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if 1 then 1 else |`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                `if 1 then 1 else |`,
-            );
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if 1 then 1 else |`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
                 PQP.Language.Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
@@ -425,7 +403,7 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
 
     describe(`${PQP.Language.Ast.NodeKind.InvokeExpression}`, () => {
         it(`foo(|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`foo(|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`foo(|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
                 PQP.Language.Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
@@ -433,21 +411,21 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it(`foo(a|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`foo(a|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`foo(a|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`foo(a|,`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`foo(a|,`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`foo(a|,`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`foo(a,|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`foo(a,|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`foo(a,|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
                 PQP.Language.Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
@@ -457,7 +435,7 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
 
     describe(`${PQP.Language.Ast.NodeKind.ListExpression}`, () => {
         it(`{|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`{|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`{|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
                 PQP.Language.Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
@@ -465,21 +443,21 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it(`{1|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`{1|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`{1|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`{1|,`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`{1|,`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`{1|,`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`{1,|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`{1,|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`{1,|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
                 PQP.Language.Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
@@ -487,7 +465,7 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it(`{1,|2`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`{1,|2`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`{1,|2`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
                 PQP.Language.Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
@@ -495,7 +473,7 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it(`{1,|2,`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`{1,|2,`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`{1,|2,`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
                 PQP.Language.Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
@@ -503,7 +481,7 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it(`{1..|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`{1..|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`{1..|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
                 PQP.Language.Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
@@ -513,7 +491,7 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
 
     describe(`${PQP.Language.Ast.NodeKind.OtherwiseExpression}`, () => {
         it(`try true otherwise| false`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `try true otherwise| false`,
             );
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
@@ -522,7 +500,7 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it(`try true otherwise |false`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `try true otherwise |false`,
             );
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
@@ -532,9 +510,7 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it(`try true oth|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                `try true oth|`,
-            );
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`try true oth|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
                 PQP.Language.Keyword.KeywordKind.Otherwise,
             ];
@@ -543,9 +519,7 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it(`try true otherwise |`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                `try true otherwise |`,
-            );
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`try true otherwise |`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
                 PQP.Language.Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
@@ -555,7 +529,7 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
 
     describe(`${PQP.Language.Ast.NodeKind.ParenthesizedExpression}`, () => {
         it(`+(|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+(|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+(|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
                 PQP.Language.Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
@@ -565,14 +539,14 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
 
     describe(`${PQP.Language.Ast.NodeKind.RecordExpression}`, () => {
         it(`+[|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+[a=|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[a=|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[a=|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
                 PQP.Language.Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
@@ -580,28 +554,28 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it(`+[a=1|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[a=1|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[a=1|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+[a|=1`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[a|=1`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[a|=1`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+[a=1|]`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[a=1|]`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[a=1|]`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+[a=|1]`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[a=| 1]`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[a=| 1]`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
                 PQP.Language.Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
@@ -609,35 +583,35 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it(`+[a=1|,`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[a=1|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[a=1|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+[a=1,|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[a=1,|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[a=1,|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+[a=1|,b`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[a=1|,b`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[a=1|,b`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+[a=1|,b=`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[a=1|,b=`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[a=1|,b=`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+[a=|1,b=`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[a=|1,b=`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[a=|1,b=`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
                 PQP.Language.Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
@@ -645,14 +619,14 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it(`+[a=1,b=2|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[a=1,b=2|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[a=1,b=2|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+[a=1,b=2 |`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+[a=1,b=2 |`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[a=1,b=2 |`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
@@ -661,7 +635,7 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
 
     describe(`AutocompleteExpression`, () => {
         it(`error |`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`error |`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`error |`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
                 PQP.Language.Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
@@ -669,7 +643,7 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it(`let x = |`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`let x = |`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let x = |`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
                 PQP.Language.Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
@@ -677,7 +651,7 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it(`() => |`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`() => |`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`() => |`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
                 PQP.Language.Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
@@ -685,7 +659,7 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it(`if |`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`if |`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if |`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
                 PQP.Language.Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
@@ -693,9 +667,7 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it(`if true then |`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                `if true then |`,
-            );
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if true then |`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
                 PQP.Language.Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
@@ -703,7 +675,7 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it(`if true then true else |`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `if true then true else |`,
             );
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
@@ -713,7 +685,7 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it(`foo(|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`foo(|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`foo(|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
                 PQP.Language.Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
@@ -721,9 +693,7 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it(`let x = 1 in |`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                `let x = 1 in |`,
-            );
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let x = 1 in |`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
                 PQP.Language.Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
@@ -731,7 +701,7 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it(`+{|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+{|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+{|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
                 PQP.Language.Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
@@ -739,9 +709,7 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it(`try true otherwise |`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                `try true otherwise |`,
-            );
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`try true otherwise |`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
                 PQP.Language.Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
@@ -749,7 +717,7 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it(`+(|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`+(|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+(|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
                 PQP.Language.Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
@@ -759,27 +727,21 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
 
     describe(`${PQP.Language.Ast.NodeKind.SectionMember}`, () => {
         it(`section; [] |`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                `section; [] |`,
-            );
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`section; [] |`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Shared];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`section; [] x |`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                `section; [] x |`,
-            );
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`section; [] x |`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`section; x = |`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                `section; x = |`,
-            );
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`section; x = |`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
                 PQP.Language.Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
@@ -787,9 +749,7 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it(`section; x = 1 |`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                `section; x = 1 |`,
-            );
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`section; x = 1 |`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
                 PQP.Language.Keyword.KeywordKind.And,
                 PQP.Language.Keyword.KeywordKind.As,
@@ -802,16 +762,14 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it(`section; x = 1 i|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                `section; x = 1 i|`,
-            );
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`section; x = 1 i|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Is];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`section foo; a = () => true; b = "string"; c = 1; d = |;`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `section foo; a = () => true; b = "string"; c = 1; d = |;`,
             );
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
@@ -823,7 +781,7 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
 
     describe(`${PQP.Language.Ast.NodeKind.LetExpression}`, () => {
         it(`let a = |`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`let a = |`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = |`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
                 PQP.Language.Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
@@ -831,14 +789,14 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it(`let a = 1|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`let a = 1|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = 1|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`let a = 1 |`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`let a = 1 |`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = 1 |`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
                 PQP.Language.Keyword.KeywordKind.And,
                 PQP.Language.Keyword.KeywordKind.As,
@@ -852,9 +810,7 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it(`let a = 1 | foobar`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                `let a = 1 | foobar`,
-            );
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = 1 | foobar`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
                 PQP.Language.Keyword.KeywordKind.And,
                 PQP.Language.Keyword.KeywordKind.As,
@@ -868,7 +824,7 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it(`let a = 1 i|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`let a = 1 i|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = 1 i|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
                 PQP.Language.Keyword.KeywordKind.Is,
                 PQP.Language.Keyword.KeywordKind.In,
@@ -878,30 +834,28 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it(`let a = 1 o|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`let a = 1 o|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = 1 o|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Or];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`let a = 1 m|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`let a = 1 m|`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = 1 m|`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Meta];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`let a = 1, |`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`let a = 1, |`);
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = 1, |`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`let a = let b = |`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                `let a = let b = |`,
-            );
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = let b = |`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
                 PQP.Language.Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
@@ -909,9 +863,7 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it(`let a = let b = 1 |`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                `let a = let b = 1 |`,
-            );
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = let b = 1 |`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
                 PQP.Language.Keyword.KeywordKind.And,
                 PQP.Language.Keyword.KeywordKind.As,
@@ -925,9 +877,7 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
         });
 
         it(`let a = let b = 1, |`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                `let a = let b = 1, |`,
-            );
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = let b = 1, |`);
             const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);

--- a/src/test/inspection/autocomplete/autocompleteKeyword.ts
+++ b/src/test/inspection/autocomplete/autocompleteKeyword.ts
@@ -5,7 +5,7 @@ import * as PQP from "@microsoft/powerquery-parser";
 
 import { Assert } from "@microsoft/powerquery-parser";
 import "mocha";
-import { Position } from "vscode-languageserver-types";
+import type { Position } from "vscode-languageserver-types";
 
 import { TestConstants, TestUtils } from "../..";
 import { Inspection } from "../../../powerquery-language-services";

--- a/src/test/inspection/autocomplete/autocompleteLanguageConstant.ts
+++ b/src/test/inspection/autocomplete/autocompleteLanguageConstant.ts
@@ -6,7 +6,7 @@ import * as PQP from "@microsoft/powerquery-parser";
 import { Assert } from "@microsoft/powerquery-parser";
 import { expect } from "chai";
 import "mocha";
-import { Position } from "vscode-languageserver-types";
+import type { Position } from "vscode-languageserver-types";
 
 import { TestConstants, TestUtils } from "../..";
 import { Inspection } from "../../../powerquery-language-services";

--- a/src/test/inspection/autocomplete/autocompleteLanguageConstant.ts
+++ b/src/test/inspection/autocomplete/autocompleteLanguageConstant.ts
@@ -6,6 +6,7 @@ import * as PQP from "@microsoft/powerquery-parser";
 import { Assert } from "@microsoft/powerquery-parser";
 import { expect } from "chai";
 import "mocha";
+import { Position } from "vscode-languageserver-types";
 
 import { TestConstants, TestUtils } from "../..";
 import { Inspection } from "../../../powerquery-language-services";
@@ -14,7 +15,7 @@ import { AbridgedAutocompleteItem, createAbridgedAutocompleteItem } from "./comm
 function assertGetLanguageConstantAutocomplete<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
     settings: Inspection.InspectionSettings<S>,
     text: string,
-    position: Inspection.Position,
+    position: Position,
 ): AbridgedAutocompleteItem | undefined {
     const actual: Inspection.Autocomplete = TestUtils.assertGetAutocomplete(settings, text, position);
     Assert.isOk(actual.triedLanguageConstant);
@@ -26,7 +27,7 @@ function assertGetLanguageConstantAutocomplete<S extends PQP.Parser.IParseState 
 
 describe(`Inspection - Autocomplete - Language constants`, () => {
     it(`a as |`, () => {
-        const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`a as |`);
+        const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`a as |`);
         const expected: AbridgedAutocompleteItem | undefined = {
             jaroWinklerScore: 1,
             label: PQP.Language.Constant.LanguageConstantKind.Nullable,
@@ -40,7 +41,7 @@ describe(`Inspection - Autocomplete - Language constants`, () => {
     });
 
     it(`a as n|`, () => {
-        const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`a as n|`);
+        const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`a as n|`);
         const expected: AbridgedAutocompleteItem | undefined = {
             jaroWinklerScore: 1,
             label: PQP.Language.Constant.LanguageConstantKind.Nullable,
@@ -54,7 +55,7 @@ describe(`Inspection - Autocomplete - Language constants`, () => {
     });
 
     it(`(a as |`, () => {
-        const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`(a as |`);
+        const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(a as |`);
         const expected: AbridgedAutocompleteItem | undefined = {
             jaroWinklerScore: 1,
             label: PQP.Language.Constant.LanguageConstantKind.Nullable,
@@ -68,7 +69,7 @@ describe(`Inspection - Autocomplete - Language constants`, () => {
     });
 
     it(`(a as n|`, () => {
-        const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`(a as n|`);
+        const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(a as n|`);
         const expected: AbridgedAutocompleteItem | undefined = {
             jaroWinklerScore: 1,
             label: PQP.Language.Constant.LanguageConstantKind.Nullable,
@@ -82,7 +83,7 @@ describe(`Inspection - Autocomplete - Language constants`, () => {
     });
 
     it(`(x, |`, () => {
-        const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`(x, |`);
+        const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(x, |`);
         const expected: AbridgedAutocompleteItem | undefined = {
             jaroWinklerScore: 1,
             label: PQP.Language.Constant.LanguageConstantKind.Optional,
@@ -96,7 +97,7 @@ describe(`Inspection - Autocomplete - Language constants`, () => {
     });
 
     it(`(x, op|`, () => {
-        const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`(x, op|`);
+        const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(x, op|`);
         const expected: AbridgedAutocompleteItem | undefined = {
             jaroWinklerScore: 1,
             label: PQP.Language.Constant.LanguageConstantKind.Optional,

--- a/src/test/inspection/autocomplete/autocompletePrimitiveType.ts
+++ b/src/test/inspection/autocomplete/autocompletePrimitiveType.ts
@@ -5,6 +5,7 @@ import * as PQP from "@microsoft/powerquery-parser";
 
 import { Assert } from "@microsoft/powerquery-parser";
 import "mocha";
+import { Position } from "vscode-languageserver-types";
 
 import { TestConstants, TestUtils } from "../..";
 import { Inspection } from "../../../powerquery-language-services";
@@ -13,7 +14,7 @@ import { InspectionSettings } from "../../../powerquery-language-services/inspec
 function assertGetPrimitiveTypeAutocompleteOk<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
     settings: InspectionSettings<S>,
     text: string,
-    position: Inspection.Position,
+    position: Position,
 ): ReadonlyArray<Inspection.AutocompleteItem> {
     const actual: Inspection.Autocomplete = TestUtils.assertGetAutocomplete(settings, text, position);
     Assert.isOk(actual.triedPrimitiveType);
@@ -22,7 +23,7 @@ function assertGetPrimitiveTypeAutocompleteOk<S extends PQP.Parser.IParseState =
 
 describe(`Inspection - Autocomplete - PrimitiveType`, () => {
     it("type|", () => {
-        const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`type|`);
+        const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`type|`);
         const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> = [];
         const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultInspectionSettings,
@@ -33,7 +34,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
     });
 
     it("type |", () => {
-        const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`type |`);
+        const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`type |`);
         const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> =
             PQP.Language.Constant.PrimitiveTypeConstantKinds;
         const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
@@ -45,7 +46,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
     });
 
     it("let x = type|", () => {
-        const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`let x = type|`);
+        const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let x = type|`);
         const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> = [];
         const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultInspectionSettings,
@@ -56,7 +57,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
     });
 
     it("let x = type |", () => {
-        const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`let x = type |`);
+        const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let x = type |`);
         const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> =
             PQP.Language.Constant.PrimitiveTypeConstantKinds;
         const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
@@ -68,7 +69,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
     });
 
     it("type | number", () => {
-        const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`type | number`);
+        const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`type | number`);
         const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> =
             PQP.Language.Constant.PrimitiveTypeConstantKinds;
         const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
@@ -80,7 +81,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
     });
 
     it("type n|", () => {
-        const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`type n|`);
+        const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`type n|`);
         const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> = [
             PQP.Language.Constant.PrimitiveTypeConstantKind.None,
             PQP.Language.Constant.PrimitiveTypeConstantKind.Null,
@@ -95,7 +96,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
     });
 
     it("(x|) => 1", () => {
-        const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`(x|) => 1`);
+        const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(x|) => 1`);
         const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> = [];
         const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultInspectionSettings,
@@ -106,9 +107,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
     });
 
     it("(x as| number) => 1", () => {
-        const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-            `(x as| number) => 1`,
-        );
+        const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(x as| number) => 1`);
         const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> = [];
         const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultInspectionSettings,
@@ -119,9 +118,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
     });
 
     it("(x as | number) => 1", () => {
-        const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-            `(x as | number) => 1`,
-        );
+        const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(x as | number) => 1`);
         const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> =
             PQP.Language.Constant.PrimitiveTypeConstantKinds;
         const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
@@ -133,7 +130,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
     });
 
     it("(x as| nullable number) => 1", () => {
-        const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+        const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
             `(x as| nullable number) => 1`,
         );
         const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> = [];
@@ -146,7 +143,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
     });
 
     it("(x as | nullable number) => 1", () => {
-        const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+        const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
             `(x as | nullable number) => 1`,
         );
         const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> =
@@ -160,7 +157,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
     });
 
     it("(x as nullable| number) => 1", () => {
-        const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+        const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
             `(x as nullable| number) => 1`,
         );
         const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> = [];
@@ -173,7 +170,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
     });
 
     it("(x as nullable num|ber) => 1", () => {
-        const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+        const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
             `(x as nullable num|ber) => 1`,
         );
         const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> =
@@ -187,7 +184,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
     });
 
     it("let a = 1 is |", () => {
-        const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`let a = 1 is |`);
+        const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = 1 is |`);
         const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> =
             PQP.Language.Constant.PrimitiveTypeConstantKinds;
         const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(

--- a/src/test/inspection/autocomplete/autocompletePrimitiveType.ts
+++ b/src/test/inspection/autocomplete/autocompletePrimitiveType.ts
@@ -5,7 +5,7 @@ import * as PQP from "@microsoft/powerquery-parser";
 
 import { Assert } from "@microsoft/powerquery-parser";
 import "mocha";
-import { Position } from "vscode-languageserver-types";
+import type { Position } from "vscode-languageserver-types";
 
 import { TestConstants, TestUtils } from "../..";
 import { Inspection } from "../../../powerquery-language-services";

--- a/src/test/inspection/invokeExpression.ts
+++ b/src/test/inspection/invokeExpression.ts
@@ -6,7 +6,7 @@ import * as PQP from "@microsoft/powerquery-parser";
 import { Assert } from "@microsoft/powerquery-parser";
 import { expect } from "chai";
 import "mocha";
-import { Position } from "vscode-languageserver-types";
+import type { Position } from "vscode-languageserver-types";
 import { Inspection } from "../../powerquery-language-services";
 
 import { TestConstants, TestUtils } from "..";

--- a/src/test/inspection/invokeExpression.ts
+++ b/src/test/inspection/invokeExpression.ts
@@ -6,6 +6,7 @@ import * as PQP from "@microsoft/powerquery-parser";
 import { Assert } from "@microsoft/powerquery-parser";
 import { expect } from "chai";
 import "mocha";
+import { Position } from "vscode-languageserver-types";
 import { Inspection } from "../../powerquery-language-services";
 
 import { TestConstants, TestUtils } from "..";
@@ -15,7 +16,7 @@ import { InspectionSettings } from "../../powerquery-language-services/inspectio
 function assertInvokeExpressionOk<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
     settings: InspectionSettings<S>,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
-    position: Inspection.Position,
+    position: Position,
 ): Inspection.InvokeExpression | undefined {
     const activeNode: Inspection.ActiveNode = Inspection.ActiveNodeUtils.assertActiveNode(
         nodeIdMapCollection,
@@ -34,7 +35,7 @@ function assertInvokeExpressionOk<S extends PQP.Parser.IParseState = PQP.Parser.
 function assertParseOkInvokeExpressionOk<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
     settings: InspectionSettings<S>,
     text: string,
-    position: Inspection.Position,
+    position: Position,
 ): Inspection.InvokeExpression | undefined {
     const parseOk: PQP.Task.ParseTaskOk = TestUtils.assertGetLexParseOk(settings, text);
     return assertInvokeExpressionOk(settings, parseOk.nodeIdMapCollection, position);
@@ -43,7 +44,7 @@ function assertParseOkInvokeExpressionOk<S extends PQP.Parser.IParseState = PQP.
 function assertParseErrInvokeExpressionOk<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
     settings: InspectionSettings<S>,
     text: string,
-    position: Inspection.Position,
+    position: Position,
 ): Inspection.InvokeExpression | undefined {
     const parseError: PQP.Task.ParseTaskParseError = TestUtils.assertGetLexParseError(settings, text);
     return assertInvokeExpressionOk(settings, parseError.nodeIdMapCollection, position);
@@ -268,7 +269,7 @@ function expectNestedInvocation(inspected: Inspection.InvokeExpression | undefin
 describe(`subset Inspection - InvokeExpression`, () => {
     describe(`parse Ok`, () => {
         it("expects no parameters, given no parameters", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `${TestConstants.TestLibraryName.CreateFooAndBarRecord}(|)`,
             );
             const inspected: Inspection.InvokeExpression | undefined = assertParseOkInvokeExpressionOk(
@@ -281,7 +282,7 @@ describe(`subset Inspection - InvokeExpression`, () => {
         });
 
         it("expects no parameters, given extraneous parameter", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `${TestConstants.TestLibraryName.CreateFooAndBarRecord}(1|)`,
             );
             const inspected: Inspection.InvokeExpression | undefined = assertParseOkInvokeExpressionOk(
@@ -293,7 +294,7 @@ describe(`subset Inspection - InvokeExpression`, () => {
         });
 
         it("expect number parameter, missing parameter", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `${TestConstants.TestLibraryName.SquareIfNumber}(|)`,
             );
             const inspected: Inspection.InvokeExpression | undefined = assertParseOkInvokeExpressionOk(
@@ -305,7 +306,7 @@ describe(`subset Inspection - InvokeExpression`, () => {
         });
 
         it("expects required and optional, given required", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `${TestConstants.TestLibraryName.CombineNumberAndOptionalText}(1|)`,
             );
             const inspected: Inspection.InvokeExpression | undefined = assertParseOkInvokeExpressionOk(
@@ -318,7 +319,7 @@ describe(`subset Inspection - InvokeExpression`, () => {
         });
 
         it("expects required and optional, given required and optional", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `${TestConstants.TestLibraryName.CombineNumberAndOptionalText}(1, "secondArg"|)`,
             );
             const inspected: Inspection.InvokeExpression | undefined = assertParseOkInvokeExpressionOk(
@@ -331,7 +332,7 @@ describe(`subset Inspection - InvokeExpression`, () => {
         });
 
         it("expects text, given text", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `${TestConstants.TestLibraryName.DuplicateText}("foo"|)`,
             );
             const inspected: Inspection.InvokeExpression | undefined = assertParseOkInvokeExpressionOk(
@@ -344,7 +345,7 @@ describe(`subset Inspection - InvokeExpression`, () => {
         });
 
         it("expects text, given nothing", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `${TestConstants.TestLibraryName.DuplicateText}(|)`,
             );
             const inspected: Inspection.InvokeExpression | undefined = assertParseOkInvokeExpressionOk(
@@ -356,7 +357,7 @@ describe(`subset Inspection - InvokeExpression`, () => {
         });
 
         it("expects text, given number", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `${TestConstants.TestLibraryName.DuplicateText}(1|)`,
             );
             const inspected: Inspection.InvokeExpression | undefined = assertParseOkInvokeExpressionOk(
@@ -369,7 +370,7 @@ describe(`subset Inspection - InvokeExpression`, () => {
         });
 
         it("nested invocations, expects no parameters, missing parameter", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `Foobar(${TestConstants.TestLibraryName.CreateFooAndBarRecord}(|), Baz)`,
             );
             const inspected: Inspection.InvokeExpression | undefined = assertParseOkInvokeExpressionOk(
@@ -384,7 +385,7 @@ describe(`subset Inspection - InvokeExpression`, () => {
 
     describe(`parse error`, () => {
         it("expects no parameters, given no parameters", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `${TestConstants.TestLibraryName.CreateFooAndBarRecord}(|`,
             );
             const inspected: Inspection.InvokeExpression | undefined = assertParseErrInvokeExpressionOk(
@@ -397,7 +398,7 @@ describe(`subset Inspection - InvokeExpression`, () => {
         });
 
         it("expects no parameters, given extraneous parameter", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `${TestConstants.TestLibraryName.CreateFooAndBarRecord}(1|`,
             );
             const inspected: Inspection.InvokeExpression | undefined = assertParseErrInvokeExpressionOk(
@@ -409,7 +410,7 @@ describe(`subset Inspection - InvokeExpression`, () => {
         });
 
         it("expect number parameter, missing parameter", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `${TestConstants.TestLibraryName.SquareIfNumber}(|`,
             );
             const inspected: Inspection.InvokeExpression | undefined = assertParseErrInvokeExpressionOk(
@@ -421,7 +422,7 @@ describe(`subset Inspection - InvokeExpression`, () => {
         });
 
         it("expects required and optional, given required", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `${TestConstants.TestLibraryName.CombineNumberAndOptionalText}(1|`,
             );
             const inspected: Inspection.InvokeExpression | undefined = assertParseErrInvokeExpressionOk(
@@ -434,7 +435,7 @@ describe(`subset Inspection - InvokeExpression`, () => {
         });
 
         it("expects required and optional, given required and optional", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `${TestConstants.TestLibraryName.CombineNumberAndOptionalText}(1, "secondArg"|`,
             );
             const inspected: Inspection.InvokeExpression | undefined = assertParseErrInvokeExpressionOk(
@@ -447,7 +448,7 @@ describe(`subset Inspection - InvokeExpression`, () => {
         });
 
         it("expects text, given text", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `${TestConstants.TestLibraryName.DuplicateText}("foo"|`,
             );
             const inspected: Inspection.InvokeExpression | undefined = assertParseErrInvokeExpressionOk(
@@ -460,7 +461,7 @@ describe(`subset Inspection - InvokeExpression`, () => {
         });
 
         it("expects text, given nothing", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `${TestConstants.TestLibraryName.DuplicateText}(|`,
             );
             const inspected: Inspection.InvokeExpression | undefined = assertParseErrInvokeExpressionOk(
@@ -472,7 +473,7 @@ describe(`subset Inspection - InvokeExpression`, () => {
         });
 
         it("expects text, given number", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `${TestConstants.TestLibraryName.DuplicateText}(1|`,
             );
             const inspected: Inspection.InvokeExpression | undefined = assertParseErrInvokeExpressionOk(
@@ -485,7 +486,7 @@ describe(`subset Inspection - InvokeExpression`, () => {
         });
 
         it("nested invocations, expects no parameters, missing parameter", () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `Foobar(${TestConstants.TestLibraryName.CreateFooAndBarRecord}(|), Baz`,
             );
             const inspected: Inspection.InvokeExpression | undefined = assertParseErrInvokeExpressionOk(

--- a/src/test/inspection/scope.ts
+++ b/src/test/inspection/scope.ts
@@ -6,6 +6,7 @@ import * as PQP from "@microsoft/powerquery-parser";
 import { Assert } from "@microsoft/powerquery-parser";
 import { expect } from "chai";
 import "mocha";
+import { Position } from "vscode-languageserver-types";
 
 import { TestUtils } from "..";
 import { Inspection } from "../../powerquery-language-services";
@@ -136,7 +137,7 @@ function createAbridgedParameterScopeItems(nodeScope: Inspection.NodeScope): Rea
 function assertNodeScopeOk(
     settings: PQP.CommonSettings,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
-    position: Inspection.Position,
+    position: Position,
 ): Inspection.NodeScope {
     const maybeActiveNode: Inspection.TMaybeActiveNode = Inspection.ActiveNodeUtils.maybeActiveNode(
         nodeIdMapCollection,
@@ -161,7 +162,7 @@ function assertNodeScopeOk(
 export function assertGetParseOkScopeOk(
     settings: PQP.LexSettings & PQP.ParseSettings<PQP.Parser.IParseState>,
     text: string,
-    position: Inspection.Position,
+    position: Position,
 ): Inspection.NodeScope {
     const parseOk: PQP.Task.ParseTaskOk = TestUtils.assertGetLexParseOk(settings, text);
     return assertNodeScopeOk(settings, parseOk.nodeIdMapCollection, position);
@@ -170,7 +171,7 @@ export function assertGetParseOkScopeOk(
 export function assertGetParseErrScopeOk(
     settings: PQP.LexSettings & PQP.ParseSettings<PQP.Parser.IParseState>,
     text: string,
-    position: Inspection.Position,
+    position: Position,
 ): Inspection.NodeScope {
     const parseError: PQP.Task.ParseTaskParseError = TestUtils.assertGetLexParseError(settings, text);
     return assertNodeScopeOk(settings, parseError.nodeIdMapCollection, position);
@@ -180,7 +181,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
     describe(`Scope`, () => {
         describe(`${PQP.Language.Ast.NodeKind.EachExpression} (Ast)`, () => {
             it(`|each 1`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`|each 1`);
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`|each 1`);
                 const expected: ReadonlyArray<TAbridgedNodeScopeItem> = [];
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
                     assertGetParseOkScopeOk(DefaultSettings, text, position),
@@ -189,7 +190,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`each| 1`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`each| 1`);
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`each| 1`);
                 const expected: AbridgedNodeScope = [];
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
                     assertGetParseOkScopeOk(DefaultSettings, text, position),
@@ -198,7 +199,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`each |1`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`each |1`);
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`each |1`);
                 const expected: AbridgedNodeScope = [
                     {
                         identifier: "_",
@@ -214,7 +215,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`each 1|`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`each 1|`);
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`each 1|`);
                 const expected: AbridgedNodeScope = [
                     {
                         identifier: "_",
@@ -230,9 +231,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`each each 1|`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                    `each each 1|`,
-                );
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`each each 1|`);
                 const expected: AbridgedNodeScope = [
                     {
                         identifier: "_",
@@ -250,7 +249,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
 
         describe(`${PQP.Language.Ast.NodeKind.EachExpression} (ParserContext)`, () => {
             it(`each|`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`each|`);
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`each|`);
                 const expected: AbridgedNodeScope = [];
                 const actual: AbridgedNodeScope = createAbridgedNodeScopeItems(
                     assertGetParseErrScopeOk(DefaultSettings, text, position),
@@ -259,7 +258,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`each |`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`each |`);
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`each |`);
                 const expected: AbridgedNodeScope = [
                     {
                         identifier: "_",
@@ -277,9 +276,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
 
         describe(`${PQP.Language.Ast.NodeKind.FunctionExpression} (Ast)`, () => {
             it(`|(x) => z`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                    `|(x) => z`,
-                );
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`|(x) => z`);
                 const expected: AbridgedNodeScope = [];
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
                     assertGetParseOkScopeOk(DefaultSettings, text, position),
@@ -288,9 +285,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`(x|, y) => z`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                    `(x|, y) => z`,
-                );
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(x|, y) => z`);
                 const expected: AbridgedNodeScope = [];
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
                     assertGetParseOkScopeOk(DefaultSettings, text, position),
@@ -299,9 +294,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`(x, y)| => z`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                    `(x, y)| => z`,
-                );
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(x, y)| => z`);
                 const expected: AbridgedNodeScope = [];
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
                     assertGetParseOkScopeOk(DefaultSettings, text, position),
@@ -310,9 +303,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`(x, y) => z|`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                    `(x, y) => z|`,
-                );
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(x, y) => z|`);
                 const expected: AbridgedNodeScope = [
                     {
                         identifier: "x",
@@ -340,7 +331,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
 
         describe(`${PQP.Language.Ast.NodeKind.FunctionExpression} (ParserContext)`, () => {
             it(`|(x) =>`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`|(x) =>`);
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`|(x) =>`);
                 const expected: AbridgedNodeScope = [];
                 const actual: AbridgedNodeScope = createAbridgedNodeScopeItems(
                     assertGetParseErrScopeOk(DefaultSettings, text, position),
@@ -349,9 +340,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`(x|, y) =>`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                    `(x|, y) =>`,
-                );
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(x|, y) =>`);
                 const expected: AbridgedNodeScope = [];
                 const actual: AbridgedNodeScope = createAbridgedNodeScopeItems(
                     assertGetParseErrScopeOk(DefaultSettings, text, position),
@@ -360,9 +349,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`(x, y)| =>`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                    `(x, y)| =>`,
-                );
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(x, y)| =>`);
                 const expected: AbridgedNodeScope = [];
                 const actual: AbridgedNodeScope = createAbridgedNodeScopeItems(
                     assertGetParseErrScopeOk(DefaultSettings, text, position),
@@ -371,9 +358,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`(x, y) =>|`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                    `(x, y) =>|`,
-                );
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(x, y) =>|`);
                 const expected: AbridgedNodeScope = [
                     {
                         identifier: "x",
@@ -401,7 +386,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
 
         describe(`${PQP.Language.Ast.NodeKind.IdentifierExpression} (Ast)`, () => {
             it(`let x = 1, y = x in 1|`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `let x = 1, y = x in 1|`,
                 );
                 const expected: AbridgedNodeScope = [
@@ -429,7 +414,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
 
         describe(`${PQP.Language.Ast.NodeKind.RecordExpression} (Ast)`, () => {
             it(`|[a=1]`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`|[a=1]`);
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`|[a=1]`);
                 const expected: AbridgedNodeScope = [];
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
                     assertGetParseOkScopeOk(DefaultSettings, text, position),
@@ -438,7 +423,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`[|a=1]`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`[|a=1]`);
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[|a=1]`);
                 const expected: AbridgedNodeScope = [];
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
                     assertGetParseOkScopeOk(DefaultSettings, text, position),
@@ -447,7 +432,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`[a=1|]`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`[a=1|]`);
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[a=1|]`);
                 const expected: AbridgedNodeScope = [
                     {
                         identifier: "a",
@@ -464,9 +449,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`[a=1, b=2|]`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                    `[a=1, b=2|]`,
-                );
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[a=1, b=2|]`);
                 const expected: AbridgedNodeScope = [
                     {
                         identifier: "a",
@@ -490,9 +473,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`[a=1, b=2|, c=3]`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                    `[a=1, b=2|, c=3]`,
-                );
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[a=1, b=2|, c=3]`);
                 const expected: AbridgedNodeScope = [
                     {
                         identifier: "a",
@@ -523,7 +504,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`[a=1]|`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`[a=1]|`);
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[a=1]|`);
                 const expected: AbridgedNodeScope = [];
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
                     assertGetParseOkScopeOk(DefaultSettings, text, position),
@@ -532,9 +513,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`[a=[|b=1]]`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                    `[a=[|b=1]]`,
-                );
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[a=[|b=1]]`);
                 const expected: AbridgedNodeScope = [
                     {
                         identifier: "a",
@@ -553,7 +532,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
 
         describe(`${PQP.Language.Ast.NodeKind.RecordExpression} (ParserContext)`, () => {
             it(`|[a=1`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`|[a=1`);
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`|[a=1`);
                 const expected: AbridgedNodeScope = [];
                 const actual: AbridgedNodeScope = createAbridgedNodeScopeItems(
                     assertGetParseErrScopeOk(DefaultSettings, text, position),
@@ -562,7 +541,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`[|a=1`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`[|a=1`);
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[|a=1`);
                 const expected: AbridgedNodeScope = [];
                 const actual: AbridgedNodeScope = createAbridgedNodeScopeItems(
                     assertGetParseErrScopeOk(DefaultSettings, text, position),
@@ -571,7 +550,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`[a=|1`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`[a=|1`);
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[a=|1`);
                 const expected: AbridgedNodeScope = [
                     {
                         identifier: "a",
@@ -588,7 +567,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`[a=1|`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`[a=1|`);
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[a=1|`);
                 const expected: AbridgedNodeScope = [
                     {
                         identifier: "a",
@@ -605,9 +584,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`[a=1, b=|`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                    `[a=1, b=|`,
-                );
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[a=1, b=|`);
                 const expected: AbridgedNodeScope = [
                     {
                         identifier: "a",
@@ -631,9 +608,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`[a=1, b=2|, c=3`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                    `[a=1, b=2|, c=3`,
-                );
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[a=1, b=2|, c=3`);
                 const expected: AbridgedNodeScope = [
                     {
                         identifier: "a",
@@ -664,7 +639,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`[a=[|b=1`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`[a=[|b=1`);
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[a=[|b=1`);
                 const expected: AbridgedNodeScope = [
                     {
                         identifier: "a",
@@ -681,7 +656,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`[a=[b=|`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(`[a=[b=|`);
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[a=[b=|`);
                 const expected: AbridgedNodeScope = [
                     {
                         identifier: "a",
@@ -707,7 +682,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
 
         describe(`${PQP.Language.Ast.NodeKind.Section} (Ast)`, () => {
             it(`s|ection foo; x = 1; y = 2;`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `s|ection foo; x = 1; y = 2;`,
                 );
                 const expected: AbridgedNodeScope = [];
@@ -718,7 +693,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`section foo; x = 1|; y = 2;`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `section foo; x = 1|; y = 2;`,
                 );
                 const expected: AbridgedNodeScope = [
@@ -744,7 +719,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`section foo; x = 1; y = 2|;`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `section foo; x = 1; y = 2|;`,
                 );
                 const expected: AbridgedNodeScope = [
@@ -770,7 +745,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`section foo; x = 1; y = 2;|`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `section foo; x = 1; y = 2;|`,
                 );
                 const expected: AbridgedNodeScope = [];
@@ -781,7 +756,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`section foo; x = 1; y = 2; z = let a = 1 in |b;`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `section foo; x = 1; y = 2; z = let a = 1 in |b;`,
                 );
                 const expected: AbridgedNodeScope = [
@@ -823,7 +798,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
 
         describe(`${PQP.Language.Ast.NodeKind.SectionMember} (ParserContext)`, () => {
             it(`s|ection foo; x = 1; y = 2`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `s|ection foo; x = 1; y = 2`,
                 );
                 const expected: AbridgedNodeScope = [];
@@ -834,7 +809,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`section foo; x = 1|; y = 2`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `section foo; x = 1|; y = 2`,
                 );
                 const expected: AbridgedNodeScope = [
@@ -860,7 +835,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`section foo; x = 1; y = 2|`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `section foo; x = 1; y = 2|`,
                 );
                 const expected: AbridgedNodeScope = [
@@ -886,7 +861,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`section foo; x = 1; y = () => 10|`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `section foo; x = 1; y = () => 10|`,
                 );
                 const expected: AbridgedNodeScope = [
@@ -914,9 +889,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
 
         describe(`${PQP.Language.Ast.NodeKind.LetExpression} (Ast)`, () => {
             it(`let a = 1 in |x`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                    `let a = 1 in |x`,
-                );
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = 1 in |x`);
                 const expected: AbridgedNodeScope = [
                     {
                         identifier: "a",
@@ -933,9 +906,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`let a = 1 in x|`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                    `let a = 1 in x|`,
-                );
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = 1 in x|`);
                 const expected: AbridgedNodeScope = [
                     {
                         identifier: "a",
@@ -952,9 +923,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`let a = |1 in x`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                    `let a = |1 in x`,
-                );
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = |1 in x`);
                 const expected: AbridgedNodeScope = [
                     {
                         identifier: "a",
@@ -971,7 +940,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`let a = 1, b = 2 in x|`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `let a = 1, b = 2 in x|`,
                 );
                 const expected: AbridgedNodeScope = [
@@ -997,7 +966,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`let a = 1|, b = 2 in x`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `let a = 1|, b = 2 in x`,
                 );
                 const expected: AbridgedNodeScope = [
@@ -1023,7 +992,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`(p1, p2) => let a = 1, b = 2, c = 3| in c`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `(p1, p2) => let a = 1, b = 2, c = 3| in c`,
                 );
                 const expected: AbridgedNodeScope = [
@@ -1072,7 +1041,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`let eggs = let ham = 0 in 1, foo = 2, bar = 3 in 4|`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `let eggs = let ham = 0 in 1, foo = 2, bar = 3 in 4|`,
                 );
                 const expected: AbridgedNodeScope = [
@@ -1105,7 +1074,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`let eggs = let ham = 0 in |1, foo = 2, bar = 3 in 4`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `let eggs = let ham = 0 in |1, foo = 2, bar = 3 in 4`,
                 );
                 const expected: AbridgedNodeScope = [
@@ -1147,9 +1116,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
 
         describe(`${PQP.Language.Ast.NodeKind.LetExpression} (ParserContext)`, () => {
             it(`let a = 1 in |`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-                    `let a = 1 in |`,
-                );
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = 1 in |`);
                 const expected: AbridgedNodeScope = [
                     {
                         identifier: "a",
@@ -1166,7 +1133,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`let a = 1, b = 2 in |`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `let a = 1, b = 2 in |`,
                 );
                 const expected: AbridgedNodeScope = [
@@ -1192,7 +1159,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`let a = 1|, b = 2 in`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `let a = 1|, b = 2 in `,
                 );
                 const expected: AbridgedNodeScope = [
@@ -1218,7 +1185,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`let x = (let y = 1 in z|) in`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `let x = (let y = 1 in z|) in`,
                 );
                 const expected: AbridgedNodeScope = [
@@ -1244,7 +1211,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
 
             it(`let x = (let y = 1 in z) in |`, () => {
-                const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+                const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `let x = (let y = 1 in z) in |`,
                 );
                 const expected: AbridgedNodeScope = [
@@ -1266,7 +1233,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
 
     describe(`Parameter`, () => {
         it(`(a, b as number, c as nullable function, optional d, optional e as table) => 1|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `(a, b as number, c as nullable function, optional d, optional e as table) => 1|`,
             );
             const expected: ReadonlyArray<AbridgedParameterScopeItem> = [

--- a/src/test/inspection/scope.ts
+++ b/src/test/inspection/scope.ts
@@ -6,7 +6,7 @@ import * as PQP from "@microsoft/powerquery-parser";
 import { Assert } from "@microsoft/powerquery-parser";
 import { expect } from "chai";
 import "mocha";
-import { Position } from "vscode-languageserver-types";
+import type { Position } from "vscode-languageserver-types";
 
 import { TestUtils } from "..";
 import { Inspection } from "../../powerquery-language-services";

--- a/src/test/inspection/type.ts
+++ b/src/test/inspection/type.ts
@@ -6,6 +6,7 @@ import * as PQP from "@microsoft/powerquery-parser";
 import { Assert } from "@microsoft/powerquery-parser";
 import { expect } from "chai";
 import "mocha";
+import { Position } from "vscode-languageserver-types";
 
 import { TestUtils } from "..";
 import { Inspection } from "../../powerquery-language-services";
@@ -79,9 +80,7 @@ function assertParseOkScopeTypeEqual<S extends PQP.Parser.IParseState = PQP.Pars
     textWithPipe: string,
     expected: Inspection.ScopeTypeByKey,
 ): void {
-    const [textWithoutPipe, position]: [string, Inspection.Position] = TestUtils.assertGetTextWithPosition(
-        textWithPipe,
-    );
+    const [textWithoutPipe, position]: [string, Position] = TestUtils.assertGetTextWithPosition(textWithPipe);
     const parseOk: PQP.Task.ParseTaskOk = TestUtils.assertGetLexParseOk(TestSettings, textWithoutPipe);
 
     const actual: Inspection.ScopeTypeByKey = assertGetParseOkScopeTypeOk(
@@ -96,7 +95,7 @@ function assertParseOkScopeTypeEqual<S extends PQP.Parser.IParseState = PQP.Pars
 function assertGetParseOkScopeTypeOk<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
     settings: Inspection.InspectionSettings<S>,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
-    position: Inspection.Position,
+    position: Position,
 ): Inspection.ScopeTypeByKey {
     const activeNodeLeaf: PQP.Parser.TXorNode = Inspection.ActiveNodeUtils.assertGetLeaf(
         Inspection.ActiveNodeUtils.assertActiveNode(nodeIdMapCollection, position),

--- a/src/test/inspection/type.ts
+++ b/src/test/inspection/type.ts
@@ -6,7 +6,7 @@ import * as PQP from "@microsoft/powerquery-parser";
 import { Assert } from "@microsoft/powerquery-parser";
 import { expect } from "chai";
 import "mocha";
-import { Position } from "vscode-languageserver-types";
+import type { Position } from "vscode-languageserver-types";
 
 import { TestUtils } from "..";
 import { Inspection } from "../../powerquery-language-services";

--- a/src/test/testUtils/assert.ts
+++ b/src/test/testUtils/assert.ts
@@ -25,7 +25,7 @@ export function assertAsMarkupContent(value: Hover["contents"]): MarkupContent {
 export function assertGetAutocomplete<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
     settings: InspectionSettings<S>,
     text: string,
-    position: Inspection.Position,
+    position: Position,
 ): Inspection.Autocomplete {
     const triedLexParseTask: PQP.Task.TriedLexParseTask<S> = PQP.TaskUtils.tryLexParse(settings, text);
     TaskUtils.assertIsParseStage(triedLexParseTask);
@@ -103,15 +103,15 @@ export function assertGetLexParseError<S extends PQP.Parser.IParseState = PQP.Pa
 }
 
 // Only works with single line expressions
-export function assertGetTextWithPosition(text: string): [string, Inspection.Position] {
+export function assertGetTextWithPosition(text: string): [string, Position] {
     const indexOfPipe: number = text.indexOf("|");
 
     expect(indexOfPipe).to.be.greaterThan(-1, "text must have | marker");
     expect(indexOfPipe).to.equal(text.lastIndexOf("|"), "text must have one and only one '|'");
 
-    const position: Inspection.Position = {
-        lineNumber: 0,
-        lineCodeUnit: indexOfPipe,
+    const position: Position = {
+        line: 0,
+        character: indexOfPipe,
     };
 
     return [text.replace("|", ""), position];

--- a/src/test/workspaceCacheTest.ts
+++ b/src/test/workspaceCacheTest.ts
@@ -6,7 +6,7 @@ import * as PQLS from "../powerquery-language-services";
 
 import { expect } from "chai";
 import "mocha";
-import { Position } from "vscode-languageserver-types";
+import type { Position } from "vscode-languageserver-types";
 
 import { TestUtils } from ".";
 import { TextDocument, WorkspaceCache, WorkspaceCacheUtils } from "../powerquery-language-services";


### PR DESCRIPTION
Now that the inspection code was moved to this layer we have direct access to vscode types, meaning it's time to remove the old Position interface.