### PR TITLE
Add TypeCache to CacheCollection

### DIFF
--- a/src/powerquery-language-services/analysis/documentAnalysis.ts
+++ b/src/powerquery-language-services/analysis/documentAnalysis.ts
@@ -14,14 +14,14 @@ import { AnalysisSettings } from "./analysisSettings";
 export class DocumentAnalysis<S extends PQP.Parser.IParseState = PQP.Parser.IParseState> extends AnalysisBase<S> {
     constructor(
         analysisSettings: AnalysisSettings<S>,
-        private readonly document: TextDocument,
+        private readonly textDocument: TextDocument,
         position: Position,
         library: ILibrary,
     ) {
         super(
             analysisSettings,
             WorkspaceCacheUtils.getOrCreateInspection(
-                document,
+                textDocument,
                 analysisSettings.createInspectionSettingsFn(),
                 position,
             ),
@@ -32,15 +32,18 @@ export class DocumentAnalysis<S extends PQP.Parser.IParseState = PQP.Parser.IPar
 
     public dispose(): void {
         if (!this.analysisSettings.maintainWorkspaceCache) {
-            WorkspaceCacheUtils.close(this.document);
+            WorkspaceCacheUtils.close(this.textDocument);
         }
     }
 
     protected getLexerState(): WorkspaceCache.LexCacheItem {
-        return WorkspaceCacheUtils.getOrCreateLex(this.document, this.analysisSettings.createInspectionSettingsFn());
+        return WorkspaceCacheUtils.getOrCreateLex(
+            this.textDocument,
+            this.analysisSettings.createInspectionSettingsFn(),
+        );
     }
 
     protected getText(range?: Range): string {
-        return this.document.getText(range);
+        return this.textDocument.getText(range);
     }
 }

--- a/src/powerquery-language-services/inspection/invokeExpression.ts
+++ b/src/powerquery-language-services/inspection/invokeExpression.ts
@@ -45,7 +45,7 @@ export function tryInvokeExpression<S extends PQP.Parser.IParseState = PQP.Parse
             settings,
             nodeIdMapCollection,
             maybeActiveNode,
-            maybeTypeCache ?? TypeCacheUtils.createTypeCache(),
+            maybeTypeCache ?? TypeCacheUtils.createEmptyCache(),
         ),
     );
 }

--- a/src/powerquery-language-services/inspection/task.ts
+++ b/src/powerquery-language-services/inspection/task.ts
@@ -19,8 +19,9 @@ export function inspection<S extends PQP.Parser.IParseState = PQP.Parser.IParseS
     parseState: S,
     maybeParseError: PQP.Parser.ParseError.ParseError<S> | undefined,
     position: Position,
+    maybeTypeCache: TypeCache | undefined = undefined,
 ): Inspection {
-    const typeCache: TypeCache = TypeCacheUtils.createTypeCache();
+    const typeCache: TypeCache = maybeTypeCache ?? TypeCacheUtils.createEmptyCache();
     const nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection = parseState.contextState.nodeIdMapCollection;
 
     // We should only get an undefined for activeNode iff the document is empty

--- a/src/powerquery-language-services/inspection/typeCache/typeCacheUtils.ts
+++ b/src/powerquery-language-services/inspection/typeCache/typeCacheUtils.ts
@@ -4,7 +4,7 @@
 import { TypeCache } from "./typeCache";
 
 // A cache that can be re-used for successive calls under the same document.
-export function createTypeCache(): TypeCache {
+export function createEmptyCache(): TypeCache {
     return {
         scopeById: new Map(),
         typeById: new Map(),

--- a/src/powerquery-language-services/workspaceCache/workspaceCache.ts
+++ b/src/powerquery-language-services/workspaceCache/workspaceCache.ts
@@ -29,4 +29,5 @@ export interface CacheCollection<S extends PQP.Parser.IParseState = PQP.Parser.I
     readonly maybeLex: LexCacheItem | undefined;
     readonly maybeParse: ParseCacheItem<S> | undefined;
     readonly maybeInspection: Map<Position, InspectionCacheItem<S>> | undefined;
+    readonly typeCache: Inspection.TypeCache;
 }

--- a/src/powerquery-language-services/workspaceCache/workspaceCacheUtils.ts
+++ b/src/powerquery-language-services/workspaceCache/workspaceCacheUtils.ts
@@ -6,6 +6,7 @@ import { TextDocument, TextDocumentContentChangeEvent } from "vscode-languageser
 import { Position } from "vscode-languageserver-types";
 
 import { Inspection } from "..";
+import { TypeCacheUtils } from "../inspection";
 import type {
     CacheCollection,
     CacheItem,
@@ -24,6 +25,14 @@ export function assertIsInspectionTask<S extends PQP.Parser.IParseState = PQP.Pa
             actualStage: cacheItem?.stage,
         });
     }
+}
+
+export function getOrCreateTypeCache<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
+    textDocument: TextDocument,
+): Inspection.TypeCache {
+    const cacheKey: string = createCacheKey(textDocument);
+    const cacheCollection: CacheCollection<S> = getOrCreateCacheCollection(cacheKey);
+    return cacheCollection.typeCache;
 }
 
 export function getOrCreateLex<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
@@ -196,10 +205,8 @@ function getOrCreateInspectionCacheItem<S extends PQP.Parser.IParseState = PQP.P
         inspectionSettings,
         parseState,
         PQP.TaskUtils.isParseStageParseError(parseCacheItem) ? parseCacheItem.error : undefined,
-        {
-            lineNumber: position.line,
-            lineCodeUnit: position.character,
-        },
+        position,
+        cacheCollection.typeCache,
     );
     const inspectionCacheItem: InspectionCacheItem = {
         ...inspection,
@@ -233,6 +240,7 @@ function createEmptyCollection<S extends PQP.Parser.IParseState = PQP.Parser.IPa
         maybeLex: undefined,
         maybeParse: undefined,
         maybeInspection: undefined,
+        typeCache: TypeCacheUtils.createEmptyCache(),
     };
 }
 

--- a/src/test/testUtils/assert.ts
+++ b/src/test/testUtils/assert.ts
@@ -34,7 +34,7 @@ export function assertGetAutocomplete<S extends PQP.Parser.IParseState = PQP.Par
         return Inspection.autocomplete(
             settings,
             triedLexParseTask.parseState,
-            TypeCacheUtils.createTypeCache(),
+            TypeCacheUtils.createEmptyCache(),
             ActiveNodeUtils.maybeActiveNode(triedLexParseTask.nodeIdMapCollection, position),
             undefined,
         );
@@ -46,7 +46,7 @@ export function assertGetAutocomplete<S extends PQP.Parser.IParseState = PQP.Par
         return Inspection.autocomplete<S>(
             settings,
             triedLexParseTask.parseState,
-            TypeCacheUtils.createTypeCache(),
+            TypeCacheUtils.createEmptyCache(),
             ActiveNodeUtils.maybeActiveNode(triedLexParseTask.nodeIdMapCollection, position),
             triedLexParseTask.error,
         );


### PR DESCRIPTION
Calls to validate will eventually require static type analysis. To prevent them from re-calculating the same work initially done in an inspection pass we'll be saving a TextDocument's TypeCache in WorkspaceCache as well.