### PR TITLE
Promote PositionUtils

### DIFF
--- a/src/powerquery-language-services/index.ts
+++ b/src/powerquery-language-services/index.ts
@@ -7,6 +7,7 @@ import { WorkspaceCacheUtils } from "./workspaceCache";
 export * as CommonTypesUtils from "./commonTypesUtils";
 export * as Inspection from "./inspection";
 export * as InspectionUtils from "./inspectionUtils";
+export * as PositionUtils from "./positionUtils";
 export * from "./analysis";
 export * from "./commonTypes";
 export * from "./diagnosticErrorCode";

--- a/src/powerquery-language-services/inspection/activeNode/activeNodeUtils.ts
+++ b/src/powerquery-language-services/inspection/activeNode/activeNodeUtils.ts
@@ -5,7 +5,7 @@ import * as PQP from "@microsoft/powerquery-parser";
 
 import type { Position } from "vscode-languageserver-types";
 
-import { PositionUtils } from "..";
+import { PositionUtils } from "../..";
 import { ActiveNode, ActiveNodeKind, ActiveNodeLeafKind, OutOfBoundPosition, TMaybeActiveNode } from "./activeNode";
 
 // Searches all leaf PQP.Language.Ast.TNodes and all Context nodes to find the "active" node.

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteFieldAccess.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteFieldAccess.ts
@@ -6,7 +6,7 @@ import * as PQP from "@microsoft/powerquery-parser";
 import { Assert } from "@microsoft/powerquery-parser";
 import type { Position } from "vscode-languageserver-types";
 
-import { PositionUtils } from "..";
+import { PositionUtils } from "../..";
 import { ActiveNode, ActiveNodeUtils, TMaybeActiveNode } from "../activeNode";
 import { InspectionSettings } from "../settings";
 import { TriedType, tryType } from "../type";

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeyword.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeyword.ts
@@ -3,7 +3,7 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
-import { PositionUtils } from "../..";
+import { PositionUtils } from "../../..";
 import { ActiveNode, ActiveNodeLeafKind, ActiveNodeUtils, TMaybeActiveNode } from "../../activeNode";
 import { AutocompleteItem, AutocompleteItemUtils } from "../autocompleteItem";
 import { TrailingToken, TriedAutocompleteKeyword } from "../commonTypes";

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordDefault.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordDefault.ts
@@ -3,7 +3,7 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
-import { PositionUtils } from "../..";
+import { PositionUtils } from "../../..";
 import { ActiveNode, ActiveNodeLeafKind } from "../../activeNode";
 import { InspectAutocompleteKeywordState } from "./commonTypes";
 

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordErrorHandlingExpression.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordErrorHandlingExpression.ts
@@ -5,7 +5,7 @@ import * as PQP from "@microsoft/powerquery-parser";
 
 import type { Position } from "vscode-languageserver-types";
 
-import { PositionUtils } from "../..";
+import { PositionUtils } from "../../..";
 import { TrailingToken } from "../commonTypes";
 import { InspectAutocompleteKeywordState } from "./commonTypes";
 

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordIdentifierPairedExpression.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordIdentifierPairedExpression.ts
@@ -3,7 +3,7 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
-import { PositionUtils } from "../..";
+import { PositionUtils } from "../../..";
 import { InspectAutocompleteKeywordState } from "./commonTypes";
 
 export function autocompleteKeywordIdentifierPairedExpression(

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordLetExpression.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordLetExpression.ts
@@ -3,7 +3,7 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
-import { PositionUtils } from "../..";
+import { PositionUtils } from "../../..";
 import { autocompleteKeywordDefault } from "./autocompleteKeywordDefault";
 import { autocompleteKeywordTrailingText } from "./autocompleteKeywordTrailingText";
 import { autocompleteKeywordRightMostLeaf } from "./common";

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordListExpression.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordListExpression.ts
@@ -4,7 +4,7 @@
 import * as PQP from "@microsoft/powerquery-parser";
 
 import { Assert } from "@microsoft/powerquery-parser";
-import { PositionUtils } from "../..";
+import { PositionUtils } from "../../..";
 
 import { ActiveNode } from "../../activeNode";
 import { InspectAutocompleteKeywordState } from "./commonTypes";

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteLanguageConstant.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteLanguageConstant.ts
@@ -4,7 +4,7 @@
 import * as PQP from "@microsoft/powerquery-parser";
 
 import type { Position } from "vscode-languageserver-types";
-import { PositionUtils } from "..";
+import { PositionUtils } from "../..";
 import { ActiveNode, ActiveNodeUtils, TMaybeActiveNode } from "../activeNode";
 import { AutocompleteItem, AutocompleteItemUtils } from "./autocompleteItem";
 import { TriedAutocompleteLanguageConstant } from "./commonTypes";

--- a/src/powerquery-language-services/inspection/autocomplete/autocompletePrimitiveType.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompletePrimitiveType.ts
@@ -3,7 +3,7 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
-import { PositionUtils } from "..";
+import { PositionUtils } from "../..";
 import { ActiveNode, ActiveNodeUtils, TMaybeActiveNode } from "../activeNode";
 import { AutocompleteItem, AutocompleteItemUtils } from "./autocompleteItem";
 import { TrailingToken, TriedAutocompletePrimitiveType } from "./commonTypes";

--- a/src/powerquery-language-services/inspection/autocomplete/common.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/common.ts
@@ -5,7 +5,7 @@ import * as PQP from "@microsoft/powerquery-parser";
 
 import type { Position } from "vscode-languageserver-types";
 
-import { PositionUtils } from "..";
+import { PositionUtils } from "../..";
 import { TrailingToken } from "./commonTypes";
 
 export function createTrailingToken(position: Position, parseErrorToken: PQP.Language.Token.Token): TrailingToken {

--- a/src/powerquery-language-services/inspection/index.ts
+++ b/src/powerquery-language-services/inspection/index.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export * as PositionUtils from "./positionUtils";
 export * from "./activeNode";
 export * from "./autocomplete";
 export * from "./commonTypes";

--- a/src/powerquery-language-services/inspectionUtils.ts
+++ b/src/powerquery-language-services/inspectionUtils.ts
@@ -5,9 +5,7 @@ import * as PQP from "@microsoft/powerquery-parser";
 
 import { DocumentSymbol, SignatureHelp, SymbolKind } from "vscode-languageserver-types";
 
-import * as LanguageServiceUtils from "./languageServiceUtils";
-
-import { Inspection } from ".";
+import { Inspection, PositionUtils } from ".";
 import { AutocompleteItemUtils } from "./inspection/autocomplete";
 import { ExternalType } from "./inspection/externalType";
 import { AutocompleteItemProviderContext, SignatureProviderContext } from "./providers/commonTypes";
@@ -189,8 +187,8 @@ export function getSymbolsForRecord(
             kind: SymbolKind.Field,
             deprecated: false,
             name: element.node.key.literal,
-            range: LanguageServiceUtils.tokenRangeToRange(element.node.tokenRange),
-            selectionRange: LanguageServiceUtils.tokenRangeToRange(element.node.key.tokenRange),
+            range: PositionUtils.createRangeFromTokenRange(element.node.tokenRange),
+            selectionRange: PositionUtils.createRangeFromTokenRange(element.node.key.tokenRange),
         });
     }
 
@@ -210,8 +208,8 @@ export function getSymbolForIdentifierPairedExpression(
         kind: getSymbolKindFromNode(identifierPairedExpressionNode.value),
         deprecated: false,
         name: identifierPairedExpressionNode.key.literal,
-        range: LanguageServiceUtils.tokenRangeToRange(identifierPairedExpressionNode.tokenRange),
-        selectionRange: LanguageServiceUtils.tokenRangeToRange(identifierPairedExpressionNode.key.tokenRange),
+        range: PositionUtils.createRangeFromTokenRange(identifierPairedExpressionNode.tokenRange),
+        selectionRange: PositionUtils.createRangeFromTokenRange(identifierPairedExpressionNode.key.tokenRange),
     };
 }
 

--- a/src/powerquery-language-services/languageServiceUtils.ts
+++ b/src/powerquery-language-services/languageServiceUtils.ts
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
-
-import { CompletionItemKind, Position, Range, SymbolKind } from "vscode-languageserver-types";
+import { CompletionItemKind, SymbolKind } from "vscode-languageserver-types";
 
 export function symbolKindToCompletionItemKind(symbolKind: SymbolKind): CompletionItemKind | undefined {
     switch (symbolKind) {
@@ -47,29 +45,4 @@ export function symbolKindToCompletionItemKind(symbolKind: SymbolKind): Completi
         default:
             return undefined;
     }
-}
-
-export function tokenPositionToPosition(tokenPosition: PQP.Language.Token.TokenPosition): Position {
-    return {
-        line: tokenPosition.lineNumber,
-        character: tokenPosition.lineCodeUnit,
-    };
-}
-
-export function tokenPositionToRange(
-    startTokenPosition: PQP.Language.Token.TokenPosition | undefined,
-    endTokenPosition: PQP.Language.Token.TokenPosition | undefined,
-): Range | undefined {
-    if (startTokenPosition && endTokenPosition) {
-        return {
-            start: tokenPositionToPosition(startTokenPosition),
-            end: tokenPositionToPosition(endTokenPosition),
-        };
-    }
-
-    return undefined;
-}
-
-export function tokenRangeToRange(tokenRange: PQP.Language.Token.TokenRange): Range {
-    return tokenPositionToRange(tokenRange.positionStart, tokenRange.positionEnd) as Range;
 }

--- a/src/powerquery-language-services/validate/validateDuplicateIdentifiers.ts
+++ b/src/powerquery-language-services/validate/validateDuplicateIdentifiers.ts
@@ -3,16 +3,14 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
-import type { Diagnostic, DiagnosticRelatedInformation, DocumentUri } from "vscode-languageserver-types";
-import { DiagnosticSeverity } from "vscode-languageserver-types";
-
-import * as LanguageServiceUtils from "../languageServiceUtils";
+import { Diagnostic, DiagnosticSeverity, DiagnosticRelatedInformation, DocumentUri } from "vscode-languageserver-types";
 
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { DiagnosticErrorCode } from "../diagnosticErrorCode";
 import { Localization, LocalizationUtils } from "../localization";
 import { WorkspaceCache, WorkspaceCacheUtils } from "../workspaceCache";
 import { ValidationSettings } from "./validationSettings";
+import { PositionUtils } from "..";
 
 export function validateDuplicateIdentifiers<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
     textDocument: TextDocument,
@@ -153,7 +151,7 @@ function validateDuplicateIdentifiersForKeyValuePair<S extends PQP.Parser.IParse
                     return {
                         location: {
                             uri: documentUri,
-                            range: LanguageServiceUtils.tokenRangeToRange(keyValuePair.key.tokenRange),
+                            range: PositionUtils.createRangeFromTokenRange(keyValuePair.key.tokenRange),
                         },
                         message: createDuplicateIdentifierDiagnosticMessage(keyValuePair, validationSettings),
                     };
@@ -183,7 +181,7 @@ function createDuplicateIdentifierDiagnostic<S extends PQP.Parser.IParseState = 
     return {
         code: DiagnosticErrorCode.DuplicateIdentifier,
         message: createDuplicateIdentifierDiagnosticMessage(keyValuePair, validationSettings),
-        range: LanguageServiceUtils.tokenRangeToRange(keyValuePair.key.tokenRange),
+        range: PositionUtils.createRangeFromTokenRange(keyValuePair.key.tokenRange),
         relatedInformation,
         severity: DiagnosticSeverity.Error,
         source: validationSettings.source,


### PR DESCRIPTION
With the old parser Position interface gone (replaced with the vscode interface), we should elevate PositionUtils out of Inspection. Doubly so as non-Inspection code is now also relying on PositionUtils.