### PR TITLE
Refactor maybeScopeById into scopeById

### DIFF
--- a/src/powerquery-language-services/inspection/invokeExpression/currentInvokeExpression.ts
+++ b/src/powerquery-language-services/inspection/invokeExpression/currentInvokeExpression.ts
@@ -25,7 +25,7 @@ export function tryCurrentInvokeExpression<S extends PQP.Parser.IParseState = PQ
     settings: InspectionSettings<S>,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
     maybeActiveNode: TMaybeActiveNode,
-    // If a TypeCache is given, then potentially mutate its values,
+    // If a TypeCache is given, then potentially add to its values and include it as part of the return,
     // Else create a new TypeCache and include it in the return.
     typeCache: TypeCache = TypeCacheUtils.createEmptyCache(),
 ): TriedCurrentInvokeExpression {

--- a/src/powerquery-language-services/inspection/invokeExpression/invokeExpression.ts
+++ b/src/powerquery-language-services/inspection/invokeExpression/invokeExpression.ts
@@ -20,7 +20,7 @@ export function tryInvokeExpression<S extends PQP.Parser.IParseState = PQP.Parse
     settings: InspectionSettings<S>,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
     invokeExpressionId: number,
-    // If a TypeCache is given, then potentially mutate its values,
+    // If a TypeCache is given, then potentially add to its values and include it as part of the return,
     // Else create a new TypeCache and include it in the return.
     typeCache: TypeCache = TypeCacheUtils.createEmptyCache(),
 ): TriedInvokeExpression {

--- a/src/powerquery-language-services/inspection/scope/scope.ts
+++ b/src/powerquery-language-services/inspection/scope/scope.ts
@@ -6,8 +6,6 @@ import * as PQP from "@microsoft/powerquery-parser";
 // Keys are identifier literals.
 export type ScopeTypeByKey = Map<string, PQP.Language.Type.TPowerQueryType>;
 
-export type TriedScope = PQP.Result<ScopeById, PQP.CommonError.CommonError>;
-
 export type TriedNodeScope = PQP.Result<NodeScope, PQP.CommonError.CommonError>;
 
 // Scopes for multiple nodes, where the keys are nodeIds.

--- a/src/powerquery-language-services/inspection/task.ts
+++ b/src/powerquery-language-services/inspection/task.ts
@@ -21,7 +21,7 @@ export function inspection<S extends PQP.Parser.IParseState = PQP.Parser.IParseS
     parseState: S,
     maybeParseError: PQP.Parser.ParseError.ParseError<S> | undefined,
     position: Position,
-    // If a TypeCache is given, then potentially mutate its values,
+    // If a TypeCache is given, then potentially add to its values and include it as part of the return,
     // Else create a new TypeCache and include it in the return.
     typeCache: TypeCache = TypeCacheUtils.createEmptyCache(),
 ): Inspection {

--- a/src/powerquery-language-services/inspection/type/task.ts
+++ b/src/powerquery-language-services/inspection/type/task.ts
@@ -19,7 +19,7 @@ export function tryScopeType<S extends PQP.Parser.IParseState = PQP.Parser.IPars
     settings: InspectionSettings<S>,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
     nodeId: number,
-    // If a TypeCache is given, then potentially mutate its values,
+    // If a TypeCache is given, then potentially add to its values and include it as part of the return,
     // Else create a new TypeCache and include it in the return.
     typeCache: TypeCache = TypeCacheUtils.createEmptyCache(),
 ): TriedScopeType {

--- a/src/test/inspection/scope.ts
+++ b/src/test/inspection/scope.ts
@@ -152,7 +152,7 @@ function assertNodeScopeOk(
         settings,
         nodeIdMapCollection,
         activeNode.ancestry[0].node.id,
-        undefined,
+        new Map(),
     );
     Assert.isOk(triedNodeScope);
 


### PR DESCRIPTION
Replacing `maybeScopeById: ScopeById | undefined` with `scopeById: ScopeById`. The existing AnalysisDocument already handles passing in a a truthy ScopeById. The narrower type signature makes things cleaner, and potential consumers of the library are less likely to accidently not provide a cache for inspection.