### PR TITLE
Update to latest parser

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,15 +9,7 @@
             "request": "launch",
             "name": "Run unit tests",
             "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
-            "args": [
-                "-g",
-                "WIP",
-                "--inspect",
-                "--colors",
-                "--timeout",
-                "999999",
-                "${workspaceFolder}/lib/test/**/*.js"
-            ],
+            "args": ["--inspect", "--colors", "--timeout", "999999", "${workspaceFolder}/lib/test/**/*.js"],
             "preLaunchTask": "preUnitTests",
             "internalConsoleOptions": "openOnSessionStart"
         }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,15 @@
             "request": "launch",
             "name": "Run unit tests",
             "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
-            "args": ["--inspect", "--colors", "--timeout", "999999", "${workspaceFolder}/lib/test/**/*.js"],
+            "args": [
+                "-g",
+                "WIP",
+                "--inspect",
+                "--colors",
+                "--timeout",
+                "999999",
+                "${workspaceFolder}/lib/test/**/*.js"
+            ],
             "preLaunchTask": "preUnitTests",
             "internalConsoleOptions": "openOnSessionStart"
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,17 +31,17 @@
       }
     },
     "@microsoft/powerquery-formatter": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.0.32.tgz",
-      "integrity": "sha512-kOCpSu76yj76jH6oFNXKEswOAjzLDCHW0wwFy5WHvvskgu/gpi1uNXl915rqIZzD8k2QcaZhg49ScihNxTP+NA==",
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.0.33.tgz",
+      "integrity": "sha512-v39Zd9c+lhuvxI0NxXHR1c+yw/BtZz69AQFfGlwlt4PGzAH/TYTBjcZjaUnISNtIEP2hsS3BsaFIE3D6ob5zaQ==",
       "requires": {
-        "@microsoft/powerquery-parser": "0.4.5"
+        "@microsoft/powerquery-parser": "0.4.6"
       }
     },
     "@microsoft/powerquery-parser": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.4.5.tgz",
-      "integrity": "sha512-KnS/McXemO+uhizlXPwDAH9INlOPqhal95XfZhAE638Sk6xVLzb7yxOdROtlCZZAjIkfQci4JNXe+RCk7cJV0Q==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.4.6.tgz",
+      "integrity": "sha512-IBYvAguL5YY1dObaO54cwHBjg4VJCgADJ1nWo0Ed0r9ytV2eA7M6cDIZ7aoIig+Q67UW/zdV7JJBPDW0xBf6Ug==",
       "requires": {
         "grapheme-splitter": "^1.0.4"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,17 +31,17 @@
       }
     },
     "@microsoft/powerquery-formatter": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.0.33.tgz",
-      "integrity": "sha512-v39Zd9c+lhuvxI0NxXHR1c+yw/BtZz69AQFfGlwlt4PGzAH/TYTBjcZjaUnISNtIEP2hsS3BsaFIE3D6ob5zaQ==",
+      "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.0.34.tgz",
+      "integrity": "sha512-wcMW3r9vseZYjL8te6rh2+bKbhkCI52vbOhnLH8RHDWr06CNj6+n5+j9hz0XWLnfMcabkpfnMGIDWeTT6tvYRQ==",
       "requires": {
-        "@microsoft/powerquery-parser": "0.4.6"
+        "@microsoft/powerquery-parser": "0.4.7"
       }
     },
     "@microsoft/powerquery-parser": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.4.6.tgz",
-      "integrity": "sha512-IBYvAguL5YY1dObaO54cwHBjg4VJCgADJ1nWo0Ed0r9ytV2eA7M6cDIZ7aoIig+Q67UW/zdV7JJBPDW0xBf6Ug==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.4.7.tgz",
+      "integrity": "sha512-7PVczXDjW8H+lhFQQBCUU7hTyN5KB05tYnLTmzWy1rP4p6aGu4ptvRPJL0vvAQz1kiB5/n8Q6dW4osfJZbB9wQ==",
       "requires": {
         "grapheme-splitter": "^1.0.4"
       }

--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
         "typescript": "^3.9.6"
     },
     "dependencies": {
-        "@microsoft/powerquery-formatter": "0.0.33",
-        "@microsoft/powerquery-parser": "0.4.6",
+        "@microsoft/powerquery-formatter": "0.0.34",
+        "@microsoft/powerquery-parser": "0.4.7",
         "vscode-languageserver-textdocument": "1.0.1",
         "vscode-languageserver-types": "3.15.1"
     },

--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
         "typescript": "^3.9.6"
     },
     "dependencies": {
-        "@microsoft/powerquery-formatter": "0.0.32",
-        "@microsoft/powerquery-parser": "0.4.5",
+        "@microsoft/powerquery-formatter": "0.0.33",
+        "@microsoft/powerquery-parser": "0.4.6",
         "vscode-languageserver-textdocument": "1.0.1",
         "vscode-languageserver-types": "3.15.1"
     },

--- a/src/powerquery-language-services/analysis/analysisBase.ts
+++ b/src/powerquery-language-services/analysis/analysisBase.ts
@@ -218,18 +218,20 @@ export abstract class AnalysisBase implements Analysis {
         }
 
         const leaf: PQP.Parser.TXorNode = PQP.Assert.asDefined(ancestry[0]);
-        if (leaf.node.kind === PQP.Language.Ast.NodeKind.GeneralizedIdentifier) {
+        const followingNode: PQP.Parser.TXorNode | undefined = ancestry[1];
+
+        if (followingNode?.node?.kind === PQP.Language.Ast.NodeKind.Parameter) {
             return false;
         }
 
-        const followingNode: PQP.Parser.TXorNode = PQP.Assert.asDefined(ancestry[1]);
-        if (followingNode.node.kind === PQP.Language.Ast.NodeKind.Parameter) {
-            return false;
-        }
-        // Allow hover on either the key or value of IdentifierPairedExpression.
-        // Do not allow hover if it's an incomplete Ast, or if you're on the equals symbol.
+        // Allow hover on either the key or value of [Generalized|Identifier]PairedExpression.
+        // Validate it's not an incomplete Ast or that you're on the conjunction.
         else if (
-            followingNode.node.kind === PQP.Language.Ast.NodeKind.IdentifierPairedExpression &&
+            [
+                PQP.Language.Ast.NodeKind.GeneralizedIdentifierPairedAnyLiteral,
+                PQP.Language.Ast.NodeKind.GeneralizedIdentifierPairedExpression,
+                PQP.Language.Ast.NodeKind.IdentifierPairedExpression,
+            ].includes(followingNode.node.kind) &&
             [undefined, 1].includes(PQP.Assert.asDefined(leaf.node.maybeAttributeIndex))
         ) {
             return false;

--- a/src/powerquery-language-services/analysis/analysisSettings.ts
+++ b/src/powerquery-language-services/analysis/analysisSettings.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
-
 import { InspectionSettings } from "../inspectionSettings";
 import { ILibrary } from "../library/library";
 import { AutocompleteItemProvider, ISymbolProvider } from "../providers/commonTypes";

--- a/src/powerquery-language-services/analysis/analysisSettings.ts
+++ b/src/powerquery-language-services/analysis/analysisSettings.ts
@@ -8,8 +8,8 @@ import { ILibrary } from "../library/library";
 import { AutocompleteItemProvider, ISymbolProvider } from "../providers/commonTypes";
 import { WorkspaceCache } from "../workspaceCache";
 
-export interface AnalysisSettings<S extends PQP.Parser.IParseState = PQP.Parser.IParseState> {
-    readonly createInspectionSettingsFn: () => InspectionSettings<S>;
+export interface AnalysisSettings {
+    readonly createInspectionSettingsFn: () => InspectionSettings;
     readonly library: ILibrary;
     readonly maintainWorkspaceCache?: boolean;
     readonly maybeCreateLanguageAutocompleteItemProviderFn?: () => AutocompleteItemProvider;
@@ -17,5 +17,6 @@ export interface AnalysisSettings<S extends PQP.Parser.IParseState = PQP.Parser.
     readonly maybeCreateLocalDocumentSymbolProviderFn?: (
         library: ILibrary,
         maybeTriedInspection: WorkspaceCache.CacheItem | undefined,
+        createInspectionSettingsFn: () => InspectionSettings,
     ) => ISymbolProvider;
 }

--- a/src/powerquery-language-services/analysis/analysisUtils.ts
+++ b/src/powerquery-language-services/analysis/analysisUtils.ts
@@ -10,9 +10,9 @@ import { Analysis } from "./analysis";
 import { AnalysisSettings } from "./analysisSettings";
 import { DocumentAnalysis } from "./documentAnalysis";
 
-export function createAnalysis<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
+export function createAnalysis(
     document: TextDocument,
-    analysisSettings: AnalysisSettings<S>,
+    analysisSettings: AnalysisSettings,
     position: Position,
 ): Analysis {
     return new DocumentAnalysis(document, analysisSettings, position);

--- a/src/powerquery-language-services/analysis/analysisUtils.ts
+++ b/src/powerquery-language-services/analysis/analysisUtils.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
-
 import type { TextDocument } from "vscode-languageserver-textdocument";
 import type { Position } from "vscode-languageserver-types";
 

--- a/src/powerquery-language-services/analysis/documentAnalysis.ts
+++ b/src/powerquery-language-services/analysis/documentAnalysis.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
-
 import type { TextDocument } from "vscode-languageserver-textdocument";
 import type { Position, Range } from "vscode-languageserver-types";
 

--- a/src/powerquery-language-services/analysis/documentAnalysis.ts
+++ b/src/powerquery-language-services/analysis/documentAnalysis.ts
@@ -10,12 +10,8 @@ import { WorkspaceCache, WorkspaceCacheUtils } from "../workspaceCache";
 import { AnalysisBase } from "./analysisBase";
 import { AnalysisSettings } from "./analysisSettings";
 
-export class DocumentAnalysis<S extends PQP.Parser.IParseState = PQP.Parser.IParseState> extends AnalysisBase<S> {
-    constructor(
-        private readonly textDocument: TextDocument,
-        analysisSettings: AnalysisSettings<S>,
-        position: Position,
-    ) {
+export class DocumentAnalysis extends AnalysisBase {
+    constructor(private readonly textDocument: TextDocument, analysisSettings: AnalysisSettings, position: Position) {
         super(
             analysisSettings,
             WorkspaceCacheUtils.getOrCreateInspection(

--- a/src/powerquery-language-services/documentSymbols.ts
+++ b/src/powerquery-language-services/documentSymbols.ts
@@ -8,9 +8,9 @@ import * as InspectionUtils from "./inspectionUtils";
 import { DocumentSymbol, SymbolKind, TextDocument } from "./commonTypes";
 import { WorkspaceCache, WorkspaceCacheUtils } from "./workspaceCache";
 
-export function getDocumentSymbols<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
+export function getDocumentSymbols(
     textDocument: TextDocument,
-    lexAndParseSettings: PQP.LexSettings & PQP.ParseSettings<S>,
+    lexAndParseSettings: PQP.LexSettings & PQP.ParseSettings,
     maintainWorkspaceCache: boolean,
 ): DocumentSymbol[] {
     const cacheItem: WorkspaceCache.ParseCacheItem = WorkspaceCacheUtils.getOrCreateParse(

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteFieldAccess.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteFieldAccess.ts
@@ -16,7 +16,7 @@ import { AutocompleteFieldAccess, InspectedFieldAccess, TriedAutocompleteFieldAc
 
 export function tryAutocompleteFieldAccess(
     settings: InspectionSettings,
-    parseState: S,
+    parseState: PQP.Parser.ParseState,
     maybeActiveNode: TMaybeActiveNode,
     typeCache: TypeCache,
 ): TriedAutocompleteFieldAccess {
@@ -42,7 +42,7 @@ const FieldAccessNodeKinds: ReadonlyArray<PQP.Language.Ast.NodeKind> = [
 
 function autocompleteFieldAccess(
     settings: InspectionSettings,
-    parseState: S,
+    parseState: PQP.Parser.ParseState,
     activeNode: ActiveNode,
     typeCache: TypeCache,
 ): AutocompleteFieldAccess | undefined {

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteFieldAccess.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteFieldAccess.ts
@@ -14,8 +14,8 @@ import { TypeCache } from "../typeCache";
 import { AutocompleteItem, AutocompleteItemUtils } from "./autocompleteItem";
 import { AutocompleteFieldAccess, InspectedFieldAccess, TriedAutocompleteFieldAccess } from "./commonTypes";
 
-export function tryAutocompleteFieldAccess<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    settings: InspectionSettings<S>,
+export function tryAutocompleteFieldAccess(
+    settings: InspectionSettings,
     parseState: S,
     maybeActiveNode: TMaybeActiveNode,
     typeCache: TypeCache,
@@ -40,8 +40,8 @@ const FieldAccessNodeKinds: ReadonlyArray<PQP.Language.Ast.NodeKind> = [
     PQP.Language.Ast.NodeKind.FieldProjection,
 ];
 
-function autocompleteFieldAccess<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    settings: InspectionSettings<S>,
+function autocompleteFieldAccess(
+    settings: InspectionSettings,
     parseState: S,
     activeNode: ActiveNode,
     typeCache: TypeCache,

--- a/src/powerquery-language-services/inspection/autocomplete/task.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/task.ts
@@ -20,12 +20,12 @@ import {
     TriedAutocompletePrimitiveType,
 } from "./commonTypes";
 
-export function autocomplete<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    settings: InspectionSettings<S>,
+export function autocomplete(
+    settings: InspectionSettings,
     parseState: S,
     typeCache: TypeCache,
     maybeActiveNode: TMaybeActiveNode,
-    maybeParseError: PQP.Parser.ParseError.ParseError<S> | undefined,
+    maybeParseError: PQP.Parser.ParseError.ParseError | undefined,
 ): Autocomplete {
     const nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection = parseState.contextState.nodeIdMapCollection;
 

--- a/src/powerquery-language-services/inspection/autocomplete/task.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/task.ts
@@ -22,7 +22,7 @@ import {
 
 export function autocomplete(
     settings: InspectionSettings,
-    parseState: S,
+    parseState: PQP.Parser.ParseState,
     typeCache: TypeCache,
     maybeActiveNode: TMaybeActiveNode,
     maybeParseError: PQP.Parser.ParseError.ParseError | undefined,

--- a/src/powerquery-language-services/inspection/commonTypes.ts
+++ b/src/powerquery-language-services/inspection/commonTypes.ts
@@ -6,6 +6,7 @@ import * as PQP from "@microsoft/powerquery-parser";
 import { Inspection } from "..";
 import { TMaybeActiveNode } from "./activeNode";
 import { TriedExpectedType } from "./expectedType";
+import { TypeCache } from "./typeCache";
 
 export type TriedInspection = PQP.Result<Inspection, PQP.CommonError.CommonError>;
 
@@ -16,4 +17,5 @@ export interface Inspection {
     readonly triedNodeScope: Inspection.TriedNodeScope;
     readonly triedScopeType: Inspection.TriedScopeType;
     readonly triedExpectedType: TriedExpectedType;
+    readonly typeCache: TypeCache;
 }

--- a/src/powerquery-language-services/inspection/invokeExpression/currentInvokeExpression.ts
+++ b/src/powerquery-language-services/inspection/invokeExpression/currentInvokeExpression.ts
@@ -21,8 +21,8 @@ export interface CurrentInvokeExpressionArguments extends InvokeExpressionArgume
     readonly argumentOrdinal: number;
 }
 
-export function tryCurrentInvokeExpression<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    settings: InspectionSettings<S>,
+export function tryCurrentInvokeExpression(
+    settings: InspectionSettings,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
     maybeActiveNode: TMaybeActiveNode,
     // If a TypeCache is given, then potentially add to its values and include it as part of the return,
@@ -38,8 +38,8 @@ export function tryCurrentInvokeExpression<S extends PQP.Parser.IParseState = PQ
     );
 }
 
-function inspectInvokeExpression<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    settings: InspectionSettings<S>,
+function inspectInvokeExpression(
+    settings: InspectionSettings,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
     activeNode: ActiveNode,
     typeCache: TypeCache,

--- a/src/powerquery-language-services/inspection/invokeExpression/invokeExpression.ts
+++ b/src/powerquery-language-services/inspection/invokeExpression/invokeExpression.ts
@@ -16,8 +16,8 @@ export type TriedInvokeExpression = PQP.Result<InvokeExpression, PQP.CommonError
 
 export type InvokeExpression = IInvokeExpression<InvokeExpressionArguments>;
 
-export function tryInvokeExpression<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    settings: InspectionSettings<S>,
+export function tryInvokeExpression(
+    settings: InspectionSettings,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
     invokeExpressionId: number,
     // If a TypeCache is given, then potentially add to its values and include it as part of the return,
@@ -29,8 +29,8 @@ export function tryInvokeExpression<S extends PQP.Parser.IParseState = PQP.Parse
     );
 }
 
-function inspectInvokeExpression<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    settings: InspectionSettings<S>,
+function inspectInvokeExpression(
+    settings: InspectionSettings,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
     invokeExpressionId: number,
     typeCache: TypeCache,
@@ -107,8 +107,8 @@ function inspectInvokeExpression<S extends PQP.Parser.IParseState = PQP.Parser.I
     };
 }
 
-function getIsNameInLocalScope<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    settings: InspectionSettings<S>,
+function getIsNameInLocalScope(
+    settings: InspectionSettings,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
     typeCache: TypeCache,
     invokeExpressionXorNode: PQP.Parser.TXorNode,
@@ -144,8 +144,8 @@ function getNumExpectedArguments(functionType: PQP.Language.Type.DefinedFunction
     return [numMinExpectedArguments, numMaxExpectedArguments];
 }
 
-function getArgumentTypes<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    settings: InspectionSettings<S>,
+function getArgumentTypes(
+    settings: InspectionSettings,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
     typeCache: TypeCache,
     argXorNodes: ReadonlyArray<PQP.Parser.TXorNode>,

--- a/src/powerquery-language-services/inspection/task.ts
+++ b/src/powerquery-language-services/inspection/task.ts
@@ -16,10 +16,10 @@ import { TriedNodeScope, tryNodeScope } from "./scope";
 import { TriedScopeType, tryScopeType } from "./type";
 import { TypeCache, TypeCacheUtils } from "./typeCache";
 
-export function inspection<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    settings: InspectionSettings<S>,
-    parseState: S,
-    maybeParseError: PQP.Parser.ParseError.ParseError<S> | undefined,
+export function inspection(
+    settings: InspectionSettings,
+    parseState: PQP.Parser.ParseState,
+    maybeParseError: PQP.Parser.ParseError.ParseError | undefined,
     position: Position,
     // If a TypeCache is given, then potentially add to its values and include it as part of the return,
     // Else create a new TypeCache and include it in the return.

--- a/src/powerquery-language-services/inspection/task.ts
+++ b/src/powerquery-language-services/inspection/task.ts
@@ -67,5 +67,6 @@ export function inspection(
         triedNodeScope,
         triedScopeType,
         triedExpectedType,
+        typeCache,
     };
 }

--- a/src/powerquery-language-services/inspection/type/inspectType/common.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/common.ts
@@ -36,8 +36,8 @@ import { inspectTypeTableType } from "./inspectTypeTableType";
 import { inspectTypeTBinOpExpression } from "./inspectTypeTBinOpExpression";
 import { inspectTypeUnaryExpression } from "./inspectTypeUnaryExpression";
 
-export interface InspectTypeState<S extends PQP.Parser.IParseState = PQP.Parser.IParseState> {
-    readonly settings: InspectionSettings<S>;
+export interface InspectTypeState {
+    readonly settings: InspectionSettings;
     readonly givenTypeById: TypeById;
     readonly deltaTypeById: TypeById;
     readonly nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection;
@@ -62,10 +62,7 @@ export function allForAnyUnion(
     );
 }
 
-export function assertGetOrCreateNodeScope<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    state: InspectTypeState<S>,
-    nodeId: number,
-): NodeScope {
+export function assertGetOrCreateNodeScope(state: InspectTypeState, nodeId: number): NodeScope {
     state.settings.maybeCancellationToken?.throwIfCancelled();
 
     const triedGetOrCreateScope: Inspection.TriedNodeScope = getOrCreateScope(state, nodeId);
@@ -76,10 +73,7 @@ export function assertGetOrCreateNodeScope<S extends PQP.Parser.IParseState = PQ
     return Assert.asDefined(triedGetOrCreateScope.value);
 }
 
-export function getOrCreateScope<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    state: InspectTypeState<S>,
-    nodeId: number,
-): Inspection.TriedNodeScope {
+export function getOrCreateScope(state: InspectTypeState, nodeId: number): Inspection.TriedNodeScope {
     state.settings.maybeCancellationToken?.throwIfCancelled();
 
     const maybeNodeScope: NodeScope | undefined = state.scopeById.get(nodeId);
@@ -90,8 +84,8 @@ export function getOrCreateScope<S extends PQP.Parser.IParseState = PQP.Parser.I
     return tryNodeScope(state.settings, state.nodeIdMapCollection, nodeId, state.scopeById);
 }
 
-export function getOrCreateScopeItemType<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    state: InspectTypeState<S>,
+export function getOrCreateScopeItemType(
+    state: InspectTypeState,
     scopeItem: TScopeItem,
 ): PQP.Language.Type.TPowerQueryType {
     const nodeId: number = scopeItem.id;
@@ -110,10 +104,7 @@ export function getOrCreateScopeItemType<S extends PQP.Parser.IParseState = PQP.
     return scopeType;
 }
 
-export function inspectScopeItem<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    state: InspectTypeState<S>,
-    scopeItem: TScopeItem,
-): PQP.Language.Type.TPowerQueryType {
+export function inspectScopeItem(state: InspectTypeState, scopeItem: TScopeItem): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
 
     switch (scopeItem.kind) {
@@ -138,8 +129,8 @@ export function inspectScopeItem<S extends PQP.Parser.IParseState = PQP.Parser.I
     }
 }
 
-export function inspectTypeFromChildAttributeIndex<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    state: InspectTypeState<S>,
+export function inspectTypeFromChildAttributeIndex(
+    state: InspectTypeState,
     parentXorNode: PQP.Parser.TXorNode,
     attributeIndex: number,
 ): PQP.Language.Type.TPowerQueryType {
@@ -154,10 +145,7 @@ export function inspectTypeFromChildAttributeIndex<S extends PQP.Parser.IParseSt
     return maybeXorNode !== undefined ? inspectXor(state, maybeXorNode) : PQP.Language.Type.UnknownInstance;
 }
 
-export function inspectXor<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    state: InspectTypeState<S>,
-    xorNode: PQP.Parser.TXorNode,
-): PQP.Language.Type.TPowerQueryType {
+export function inspectXor(state: InspectTypeState, xorNode: PQP.Parser.TXorNode): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
 
     const xorNodeId: number = xorNode.node.id;
@@ -344,8 +332,8 @@ export function inspectXor<S extends PQP.Parser.IParseState = PQP.Parser.IParseS
     return result;
 }
 
-export function maybeDereferencedIdentifierType<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    state: InspectTypeState<S>,
+export function maybeDereferencedIdentifierType(
+    state: InspectTypeState,
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType | undefined {
     state.settings.maybeCancellationToken?.throwIfCancelled();
@@ -408,8 +396,8 @@ export function maybeDereferencedIdentifierType<S extends PQP.Parser.IParseState
 }
 
 // Recursively derefence an identifier if it points to another identifier.
-export function recursiveIdentifierDereference<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    state: InspectTypeState<S>,
+export function recursiveIdentifierDereference(
+    state: InspectTypeState,
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Parser.TXorNode {
     state.settings.maybeCancellationToken?.throwIfCancelled();
@@ -419,8 +407,8 @@ export function recursiveIdentifierDereference<S extends PQP.Parser.IParseState 
 }
 
 // Recursively derefence an identifier if it points to another identifier.
-function recursiveIdentifierDereferenceHelper<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    state: InspectTypeState<S>,
+function recursiveIdentifierDereferenceHelper(
+    state: InspectTypeState,
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Parser.TXorNode | undefined {
     state.settings.maybeCancellationToken?.throwIfCancelled();

--- a/src/powerquery-language-services/inspection/type/inspectType/examineFieldSpecificationList.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/examineFieldSpecificationList.ts
@@ -12,8 +12,8 @@ export interface ExaminedFieldSpecificationList {
 }
 
 // It's called an examination instead of inspection because it doesn't return TType.
-export function examineFieldSpecificationList<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    state: InspectTypeState<S>,
+export function examineFieldSpecificationList(
+    state: InspectTypeState,
     xorNode: PQP.Parser.TXorNode,
 ): ExaminedFieldSpecificationList {
     state.settings.maybeCancellationToken?.throwIfCancelled();

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeEachExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeEachExpression.ts
@@ -5,8 +5,8 @@ import * as PQP from "@microsoft/powerquery-parser";
 
 import { inspectTypeFromChildAttributeIndex, InspectTypeState } from "./common";
 
-export function inspectTypeEachExpression<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    state: InspectTypeState<S>,
+export function inspectTypeEachExpression(
+    state: InspectTypeState,
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeErrorHandlingExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeErrorHandlingExpression.ts
@@ -5,8 +5,8 @@ import * as PQP from "@microsoft/powerquery-parser";
 
 import { inspectTypeFromChildAttributeIndex, InspectTypeState, inspectXor } from "./common";
 
-export function inspectTypeErrorHandlingExpression<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    state: InspectTypeState<S>,
+export function inspectTypeErrorHandlingExpression(
+    state: InspectTypeState,
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFieldProjection.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFieldProjection.ts
@@ -5,8 +5,8 @@ import * as PQP from "@microsoft/powerquery-parser";
 
 import { InspectTypeState, inspectXor } from "./common";
 
-export function inspectTypeFieldProjection<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    state: InspectTypeState<S>,
+export function inspectTypeFieldProjection(
+    state: InspectTypeState,
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFieldSelector.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFieldSelector.ts
@@ -7,8 +7,8 @@ import { Assert } from "@microsoft/powerquery-parser";
 
 import { InspectTypeState, inspectXor } from "./common";
 
-export function inspectTypeFieldSelector<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    state: InspectTypeState<S>,
+export function inspectTypeFieldSelector(
+    state: InspectTypeState,
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFieldSpecification.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFieldSpecification.ts
@@ -5,8 +5,8 @@ import * as PQP from "@microsoft/powerquery-parser";
 
 import { InspectTypeState, inspectXor } from "./common";
 
-export function inspectTypeFieldSpecification<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    state: InspectTypeState<S>,
+export function inspectTypeFieldSpecification(
+    state: InspectTypeState,
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFunctionExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFunctionExpression.ts
@@ -10,8 +10,8 @@ import {
 } from "../../pseudoFunctionExpressionType";
 import { allForAnyUnion, inspectTypeFromChildAttributeIndex, InspectTypeState } from "./common";
 
-export function inspectTypeFunctionExpression<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    state: InspectTypeState<S>,
+export function inspectTypeFunctionExpression(
+    state: InspectTypeState,
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFunctionType.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFunctionType.ts
@@ -5,8 +5,8 @@ import * as PQP from "@microsoft/powerquery-parser";
 
 import { inspectTypeFromChildAttributeIndex, InspectTypeState } from "./common";
 
-export function inspectTypeFunctionType<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    state: InspectTypeState<S>,
+export function inspectTypeFunctionType(
+    state: InspectTypeState,
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.FunctionType | PQP.Language.Type.Unknown {
     state.settings.maybeCancellationToken?.throwIfCancelled();

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIdentifier.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIdentifier.ts
@@ -5,8 +5,8 @@ import * as PQP from "@microsoft/powerquery-parser";
 
 import { InspectTypeState, maybeDereferencedIdentifierType } from "./common";
 
-export function inspectTypeIdentifier<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    state: InspectTypeState<S>,
+export function inspectTypeIdentifier(
+    state: InspectTypeState,
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIdentifierExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIdentifierExpression.ts
@@ -5,8 +5,8 @@ import * as PQP from "@microsoft/powerquery-parser";
 
 import { InspectTypeState, maybeDereferencedIdentifierType } from "./common";
 
-export function inspectTypeIdentifierExpression<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    state: InspectTypeState<S>,
+export function inspectTypeIdentifierExpression(
+    state: InspectTypeState,
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIfExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIfExpression.ts
@@ -5,8 +5,8 @@ import * as PQP from "@microsoft/powerquery-parser";
 
 import { allForAnyUnion, inspectTypeFromChildAttributeIndex, InspectTypeState } from "./common";
 
-export function inspectTypeIfExpression<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    state: InspectTypeState<S>,
+export function inspectTypeIfExpression(
+    state: InspectTypeState,
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeInvokeExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeInvokeExpression.ts
@@ -8,8 +8,8 @@ import { Assert } from "@microsoft/powerquery-parser";
 import { ExternalType, ExternalTypeUtils } from "../../externalType";
 import { InspectTypeState, inspectXor, recursiveIdentifierDereference } from "./common";
 
-export function inspectTypeInvokeExpression<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    state: InspectTypeState<S>,
+export function inspectTypeInvokeExpression(
+    state: InspectTypeState,
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
@@ -44,8 +44,8 @@ export function inspectTypeInvokeExpression<S extends PQP.Parser.IParseState = P
     }
 }
 
-function maybeExternalInvokeRequest<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    state: InspectTypeState<S>,
+function maybeExternalInvokeRequest(
+    state: InspectTypeState,
     xorNode: PQP.Parser.TXorNode,
 ): ExternalType.ExternalInvocationTypeRequest | undefined {
     const maybeIdentifier: PQP.Parser.TXorNode | undefined = PQP.Parser.NodeIdMapUtils.maybeInvokeExpressionIdentifier(

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeList.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeList.ts
@@ -5,10 +5,7 @@ import * as PQP from "@microsoft/powerquery-parser";
 
 import { InspectTypeState, inspectXor } from "./common";
 
-export function inspectTypeList<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    state: InspectTypeState<S>,
-    xorNode: PQP.Parser.TXorNode,
-): PQP.Language.Type.DefinedList {
+export function inspectTypeList(state: InspectTypeState, xorNode: PQP.Parser.TXorNode): PQP.Language.Type.DefinedList {
     state.settings.maybeCancellationToken?.throwIfCancelled();
     const items: ReadonlyArray<PQP.Parser.TXorNode> = PQP.Parser.NodeIdMapIterator.iterListItems(
         state.nodeIdMapCollection,

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeListType.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeListType.ts
@@ -5,8 +5,8 @@ import * as PQP from "@microsoft/powerquery-parser";
 
 import { InspectTypeState, inspectXor } from "./common";
 
-export function inspectTypeListType<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    state: InspectTypeState<S>,
+export function inspectTypeListType(
+    state: InspectTypeState,
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.ListType | PQP.Language.Type.Unknown {
     state.settings.maybeCancellationToken?.throwIfCancelled();

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeNullCoalescingExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeNullCoalescingExpression.ts
@@ -5,8 +5,8 @@ import * as PQP from "@microsoft/powerquery-parser";
 
 import { inspectTypeFromChildAttributeIndex, InspectTypeState } from "./common";
 
-export function inspectTypeNullCoalescingExpression<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    state: InspectTypeState<S>,
+export function inspectTypeNullCoalescingExpression(
+    state: InspectTypeState,
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeParameter.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeParameter.ts
@@ -5,8 +5,8 @@ import * as PQP from "@microsoft/powerquery-parser";
 
 import { inspectTypeFromChildAttributeIndex, InspectTypeState } from "./common";
 
-export function inspectTypeParameter<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    state: InspectTypeState<S>,
+export function inspectTypeParameter(
+    state: InspectTypeState,
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRangeExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRangeExpression.ts
@@ -5,8 +5,8 @@ import * as PQP from "@microsoft/powerquery-parser";
 
 import { inspectTypeFromChildAttributeIndex, InspectTypeState } from "./common";
 
-export function inspectTypeRangeExpression<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    state: InspectTypeState<S>,
+export function inspectTypeRangeExpression(
+    state: InspectTypeState,
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRecord.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRecord.ts
@@ -5,8 +5,8 @@ import * as PQP from "@microsoft/powerquery-parser";
 
 import { InspectTypeState, inspectXor } from "./common";
 
-export function inspectTypeRecord<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    state: InspectTypeState<S>,
+export function inspectTypeRecord(
+    state: InspectTypeState,
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.DefinedRecord {
     state.settings.maybeCancellationToken?.throwIfCancelled();

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRecordType.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRecordType.ts
@@ -6,8 +6,8 @@ import * as PQP from "@microsoft/powerquery-parser";
 import { InspectTypeState } from "./common";
 import { examineFieldSpecificationList } from "./examineFieldSpecificationList";
 
-export function inspectTypeRecordType<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    state: InspectTypeState<S>,
+export function inspectTypeRecordType(
+    state: InspectTypeState,
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.RecordType | PQP.Language.Type.Unknown {
     state.settings.maybeCancellationToken?.throwIfCancelled();

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRecursivePrimaryExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRecursivePrimaryExpression.ts
@@ -5,8 +5,8 @@ import * as PQP from "@microsoft/powerquery-parser";
 
 import { inspectTypeFromChildAttributeIndex, InspectTypeState, inspectXor } from "./common";
 
-export function inspectTypeRecursivePrimaryExpression<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    state: InspectTypeState<S>,
+export function inspectTypeRecursivePrimaryExpression(
+    state: InspectTypeState,
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeTBinOpExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeTBinOpExpression.ts
@@ -13,8 +13,8 @@ type TRecordOrTable =
     | PQP.Language.Type.DefinedRecord
     | PQP.Language.Type.DefinedTable;
 
-export function inspectTypeTBinOpExpression<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    state: InspectTypeState<S>,
+export function inspectTypeTBinOpExpression(
+    state: InspectTypeState,
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeTableType.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeTableType.ts
@@ -6,8 +6,8 @@ import * as PQP from "@microsoft/powerquery-parser";
 import { InspectTypeState, inspectXor } from "./common";
 import { examineFieldSpecificationList } from "./examineFieldSpecificationList";
 
-export function inspectTypeTableType<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    state: InspectTypeState<S>,
+export function inspectTypeTableType(
+    state: InspectTypeState,
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TableType | PQP.Language.Type.TableTypePrimaryExpression | PQP.Language.Type.Unknown {
     state.settings.maybeCancellationToken?.throwIfCancelled();

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeUnaryExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeUnaryExpression.ts
@@ -7,8 +7,8 @@ import { Assert } from "@microsoft/powerquery-parser";
 
 import { InspectTypeState, inspectXor } from "./common";
 
-export function inspectTypeUnaryExpression<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    state: InspectTypeState<S>,
+export function inspectTypeUnaryExpression(
+    state: InspectTypeState,
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
@@ -51,8 +51,8 @@ type NumberUnaryNodeOperator = PQP.Language.Ast.IConstant<
 >;
 type LogicalUnaryNodeOperator = PQP.Language.Ast.IConstant<PQP.Language.Constant.UnaryOperatorKind.Not>;
 
-function inspectTypeUnaryNumber<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    state: InspectTypeState<S>,
+function inspectTypeUnaryNumber(
+    state: InspectTypeState,
     unaryExpressionType: PQP.Language.Type.TNumber,
     unaryOperatorWrapperId: number,
 ): PQP.Language.Type.TNumber | PQP.Language.Type.None {
@@ -96,8 +96,8 @@ function inspectTypeUnaryNumber<S extends PQP.Parser.IParseState = PQP.Parser.IP
     }
 }
 
-function inspectTypeUnaryLogical<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    state: InspectTypeState<S>,
+function inspectTypeUnaryLogical(
+    state: InspectTypeState,
     unaryExpressionType: PQP.Language.Type.TLogical,
     unaryOperatorWrapperId: number,
 ): PQP.Language.Type.TLogical | PQP.Language.Type.None {

--- a/src/powerquery-language-services/inspection/type/task.ts
+++ b/src/powerquery-language-services/inspection/type/task.ts
@@ -15,15 +15,15 @@ export type TriedScopeType = PQP.Result<ScopeTypeByKey, PQP.CommonError.CommonEr
 
 export type TriedType = PQP.Result<PQP.Language.Type.TPowerQueryType, PQP.CommonError.CommonError>;
 
-export function tryScopeType<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    settings: InspectionSettings<S>,
+export function tryScopeType(
+    settings: InspectionSettings,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
     nodeId: number,
     // If a TypeCache is given, then potentially add to its values and include it as part of the return,
     // Else create a new TypeCache and include it in the return.
     typeCache: TypeCache = TypeCacheUtils.createEmptyCache(),
 ): TriedScopeType {
-    const state: InspectTypeState<S> = {
+    const state: InspectTypeState = {
         settings,
         givenTypeById: typeCache.typeById,
         deltaTypeById: new Map(),
@@ -34,13 +34,13 @@ export function tryScopeType<S extends PQP.Parser.IParseState = PQP.Parser.IPars
     return PQP.ResultUtils.ensureResult(settings.locale, () => inspectScopeType(state, nodeId));
 }
 
-export function tryType<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    settings: InspectionSettings<S>,
+export function tryType(
+    settings: InspectionSettings,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
     nodeId: number,
     typeCache: TypeCache = TypeCacheUtils.createEmptyCache(),
 ): TriedType {
-    const state: InspectTypeState<S> = {
+    const state: InspectTypeState = {
         settings,
         givenTypeById: typeCache.typeById,
         deltaTypeById: new Map(),
@@ -53,10 +53,7 @@ export function tryType<S extends PQP.Parser.IParseState = PQP.Parser.IParseStat
     );
 }
 
-function inspectScopeType<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    state: InspectTypeState<S>,
-    nodeId: number,
-): ScopeTypeByKey {
+function inspectScopeType(state: InspectTypeState, nodeId: number): ScopeTypeByKey {
     const nodeScope: NodeScope = assertGetOrCreateNodeScope(state, nodeId);
 
     for (const scopeItem of nodeScope.values()) {

--- a/src/powerquery-language-services/inspectionSettings.ts
+++ b/src/powerquery-language-services/inspectionSettings.ts
@@ -5,6 +5,6 @@ import * as PQP from "@microsoft/powerquery-parser";
 
 import { ExternalType } from "./inspection/externalType";
 
-export interface InspectionSettings<S extends PQP.Parser.IParseState = PQP.Parser.IParseState> extends PQP.Settings<S> {
+export interface InspectionSettings extends PQP.Settings {
     readonly maybeExternalTypeResolver: ExternalType.TExternalTypeResolverFn | undefined;
 }

--- a/src/powerquery-language-services/inspectionUtils.ts
+++ b/src/powerquery-language-services/inspectionUtils.ts
@@ -11,10 +11,10 @@ import { ExternalType } from "./inspection/externalType";
 import { InspectionSettings } from "./inspectionSettings";
 import { AutocompleteItemProviderContext, SignatureProviderContext } from "./providers/commonTypes";
 
-export function createInspectionSettings<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    settings: PQP.Settings<S>,
+export function createInspectionSettings(
+    settings: PQP.Settings,
     maybeExternalTypeResolver: ExternalType.TExternalTypeResolverFn | undefined,
-): InspectionSettings<S> {
+): InspectionSettings {
     return {
         ...settings,
         maybeExternalTypeResolver,

--- a/src/powerquery-language-services/providers/localDocumentSymbolProvider.ts
+++ b/src/powerquery-language-services/providers/localDocumentSymbolProvider.ts
@@ -8,6 +8,7 @@ import { Hover, MarkupKind, SignatureHelp } from "vscode-languageserver-types";
 import * as InspectionUtils from "../inspectionUtils";
 
 import { Inspection, Library } from "..";
+import { EmptyHover } from "../commonTypes";
 import { InspectionSettings } from "../inspectionSettings";
 import { WorkspaceCache, WorkspaceCacheUtils } from "../workspaceCache";
 import {
@@ -44,144 +45,41 @@ export class LocalDocumentSymbolProvider implements ISymbolProvider {
         ];
     }
 
-    // We might be hovering over the key in a key-value-pair (eg. an entry in a record).
-    // In that case then get the hover details for the value instead of the key.
-    public async getHoverForIdentifierPairedExpression(
-        inspectionTask: WorkspaceCache.InspectionTask,
-        activeNode: Inspection.ActiveNode,
-    ): Promise<Hover | null> {
-        const parseState: PQP.Parser.ParseState = inspectionTask.parseState;
-        const ancestry: ReadonlyArray<PQP.Parser.TXorNode> = activeNode.ancestry;
-        const maybeLeaf: PQP.Parser.TXorNode | undefined = ancestry[0];
-
-        if (!maybeLeaf || maybeLeaf.node.kind !== PQP.Language.Ast.NodeKind.Identifier) {
-            return null;
-        }
-
-        const maybeIdentifierPairedExpression:
-            | PQP.Parser.TXorNode
-            | undefined = PQP.Parser.AncestryUtils.maybeNthXor(activeNode.ancestry, 1, [
-            PQP.Language.Ast.NodeKind.IdentifierPairedExpression,
-        ]);
-
-        // We're on an identifier in some other context which we don't support.
-        if (maybeIdentifierPairedExpression === undefined) {
-            return null;
-        }
-
-        const maybeExpression:
-            | PQP.Parser.TXorNode
-            | undefined = PQP.Parser.NodeIdMapUtils.maybeChildXorByAttributeIndex(
-            parseState.contextState.nodeIdMapCollection,
-            maybeIdentifierPairedExpression.node.id,
-            2,
-            undefined,
-        );
-
-        // We're on an identifier in some other context which we don't support.
-        if (maybeExpression === undefined) {
-            return null;
-        }
-
-        Inspection.tryType();
-    }
-
     public async getHover(context: HoverProviderContext): Promise<Hover | null> {
         if (!WorkspaceCacheUtils.isInspectionTask(this.maybeTriedInspection)) {
+            // tslint:disable-next-line: no-null-keyword
             return null;
         }
 
         const activeNode: Inspection.TMaybeActiveNode = this.maybeTriedInspection.maybeActiveNode;
         if (!Inspection.ActiveNodeUtils.isPositionInBounds(activeNode)) {
+            // tslint:disable-next-line: no-null-keyword
             return null;
         }
+        const inspection: WorkspaceCache.InspectionCacheItem = this.maybeTriedInspection;
 
-        const parseState: PQP.Parser.ParseState = this.maybeTriedInspection.parseState;
-        const ancestry: ReadonlyArray<PQP.Parser.TXorNode> = activeNode.ancestry;
-        const maybeLeaf: PQP.Parser.TXorNode | undefined = ancestry[0];
+        let maybeHover: Hover | undefined = await LocalDocumentSymbolProvider.getHoverForIdentifierPairedExpression(
+            context,
+            this.createInspectionSettingsFn(),
+            this.maybeTriedInspection,
+            activeNode,
+        );
 
-        // We might be hovering over the key in a key-value-pair (eg. an entry in a record).
-        // In that case then get the hover details for the value instead of the key.
-        if (maybeLeaf?.node.kind === PQP.Language.Ast.NodeKind.Identifier) {
-            const maybeIdentifierPairedExpression:
-                | PQP.Parser.TXorNode
-                | undefined = PQP.Parser.AncestryUtils.maybeNthXor(activeNode.ancestry, 1, [
-                PQP.Language.Ast.NodeKind.IdentifierPairedExpression,
-            ]);
-
-            // We're on an identifier in some other context which we don't support.
-            if (maybeIdentifierPairedExpression === undefined) {
-                return null;
-            }
-
-            const maybeExpression:
-                | PQP.Parser.TXorNode
-                | undefined = PQP.Parser.NodeIdMapUtils.maybeChildXorByAttributeIndex(
-                parseState.contextState.nodeIdMapCollection,
-                maybeIdentifierPairedExpression.node.id,
-                2,
-                undefined,
-            );
-
-            // We're on an identifier in some other context which we don't support.
-            if (maybeExpression === undefined) {
-                return null;
-            }
-
-            if (maybeIdentifierPairedExpression !== undefined) {
-            }
+        if (maybeHover !== undefined) {
+            return maybeHover;
         }
 
-        // const maybeNodeScope: Inspection.NodeScope | undefined = this.maybeNodeScope();
-        // if (maybeNodeScope === undefined) {
-        //     // tslint:disable-next-line: no-null-keyword
-        //     return null;
-        // }
-
-        // const maybeInspection: Inspection.Inspection | undefined = this.getMaybeInspection();
-        // if (!maybeInspection || !Inspection.ActiveNodeUtils.isPositionInBounds(maybeInspection.maybeActiveNode)) {
-        //     // tslint:disable-next-line: no-null-keyword
-        //     return null;
-        // }
-        // const activeNode: Inspection.ActiveNode = maybeInspection.maybeActiveNode;
-
-        // const maybeNodeScope: Inspection.NodeScope | undefined = this.maybeNodeScope();
-        // if (maybeNodeScope === undefined) {
-        //     // tslint:disable-next-line: no-null-keyword
-        //     return null;
-        // }
-
-        // const identifierLiteral: string = context.identifier;
-        // const maybeScopeItem: Inspection.TScopeItem | undefined = maybeNodeScope.get(identifierLiteral);
-        // if (maybeScopeItem === undefined || maybeScopeItem.kind === Inspection.ScopeItemKind.Undefined) {
-        //     // tslint:disable-next-line: no-null-keyword
-        //     return null;
-        // }
-
-        // const scopeItemText: string = InspectionUtils.getScopeItemKindText(maybeScopeItem.kind);
-
-        // const maybeScopeItemType: PQP.Language.Type.TPowerQueryType | undefined = this.maybeTypeFromIdentifier(
-        //     identifierLiteral,
-        // );
-        // const scopeItemTypeText: string =
-        //     maybeScopeItemType !== undefined ? PQP.Language.TypeUtils.nameOf(maybeScopeItemType) : "unknown";
-
-        return {
-            contents: {
-                kind: MarkupKind.PlainText,
-                language: "powerquery",
-                value: `[${scopeItemText}] ${identifierLiteral}: ${scopeItemTypeText}`,
-            },
-            range: undefined,
-        };
-    }
-
-    public getHoverTarget(): PQP.Parser.TXorNode | undefined {
-        const maybeInspection: Inspection.Inspection | undefined = this.getMaybeInspection();
-        if (!maybeInspection || !Inspection.ActiveNodeUtils.isPositionInBounds(maybeInspection.maybeActiveNode)) {
-            return undefined;
+        if (!PQP.ResultUtils.isOk(inspection.triedNodeScope) || !PQP.ResultUtils.isOk(inspection.triedScopeType)) {
+            return EmptyHover;
         }
-        const activeNode: Inspection.ActiveNode = maybeInspection.maybeActiveNode;
+
+        maybeHover = await LocalDocumentSymbolProvider.getHoverForScopeItem(
+            context,
+            inspection.triedNodeScope.value,
+            inspection.triedScopeType.value,
+        );
+
+        return maybeHover ?? EmptyHover;
     }
 
     public async getSignatureHelp(context: SignatureProviderContext): Promise<SignatureHelp | null> {
@@ -202,6 +100,128 @@ export class LocalDocumentSymbolProvider implements ISymbolProvider {
         return InspectionUtils.getMaybeSignatureHelp(context);
     }
 
+    // When hovering over a key it should show the type for the value.
+    // Covers:
+    //  * GeneralizedIdentifierPairedAnyLiteral
+    //  * GeneralizedIdentifierPairedExpression
+    //  * IdentifierPairedExpression
+    protected static async getHoverForIdentifierPairedExpression(
+        context: HoverProviderContext,
+        inspectionSettings: InspectionSettings,
+        inspectionTask: WorkspaceCache.InspectionTask,
+        activeNode: Inspection.ActiveNode,
+    ): Promise<Hover | undefined> {
+        const parseState: PQP.Parser.ParseState = inspectionTask.parseState;
+        const ancestry: ReadonlyArray<PQP.Parser.TXorNode> = activeNode.ancestry;
+        const maybeLeafKind: PQP.Language.Ast.NodeKind | undefined = ancestry[0]?.node.kind;
+
+        const isValidLeafNodeKind: boolean = [
+            PQP.Language.Ast.NodeKind.GeneralizedIdentifier,
+            PQP.Language.Ast.NodeKind.Identifier,
+        ].includes(maybeLeafKind);
+
+        if (!isValidLeafNodeKind) {
+            return undefined;
+        }
+
+        const maybeIdentifierPairedExpression:
+            | PQP.Parser.TXorNode
+            | undefined = PQP.Parser.AncestryUtils.maybeNthXor(activeNode.ancestry, 1, [
+            PQP.Language.Ast.NodeKind.GeneralizedIdentifierPairedAnyLiteral,
+            PQP.Language.Ast.NodeKind.GeneralizedIdentifierPairedExpression,
+            PQP.Language.Ast.NodeKind.IdentifierPairedExpression,
+        ]);
+
+        // We're on an identifier in some other context which we don't support.
+        if (maybeIdentifierPairedExpression === undefined) {
+            return undefined;
+        }
+
+        const maybeExpression:
+            | PQP.Parser.TXorNode
+            | undefined = PQP.Parser.NodeIdMapUtils.maybeChildXorByAttributeIndex(
+            parseState.contextState.nodeIdMapCollection,
+            maybeIdentifierPairedExpression.node.id,
+            2,
+            undefined,
+        );
+
+        // We're on an identifier in some other context which we don't support.
+        if (maybeExpression === undefined) {
+            return undefined;
+        }
+
+        const triedExpressionType: Inspection.TriedType = Inspection.tryType(
+            inspectionSettings,
+            parseState.contextState.nodeIdMapCollection,
+            maybeExpression.node.id,
+            inspectionTask.typeCache,
+        );
+
+        // TODO handle error
+        if (PQP.ResultUtils.isError(triedExpressionType)) {
+            return undefined;
+        }
+
+        let scopeItemText: string = "unknown";
+        // If it's a SectionMember
+        const maybeThirdNodeKind: PQP.Language.Ast.NodeKind = ancestry[2]?.node.kind;
+        if (maybeThirdNodeKind === PQP.Language.Ast.NodeKind.SectionMember) {
+            scopeItemText = InspectionUtils.getScopeItemKindText(Inspection.ScopeItemKind.SectionMember);
+        }
+
+        // Else if it's RecordExpression or RecordLiteral
+        const maybeFifthNodeKind: PQP.Language.Ast.NodeKind = ancestry[4]?.node.kind;
+        const isRecordNodeKind: boolean = [
+            PQP.Language.Ast.NodeKind.RecordExpression,
+            PQP.Language.Ast.NodeKind.RecordLiteral,
+        ].includes(maybeFifthNodeKind);
+
+        if (isRecordNodeKind) {
+            scopeItemText = InspectionUtils.getScopeItemKindText(Inspection.ScopeItemKind.RecordField);
+        } else if (maybeFifthNodeKind === PQP.Language.Ast.NodeKind.LetExpression) {
+            scopeItemText = InspectionUtils.getScopeItemKindText(Inspection.ScopeItemKind.LetVariable);
+        }
+
+        const nameOfExpressionType: string = PQP.Language.TypeUtils.nameOf(triedExpressionType.value);
+
+        return {
+            contents: {
+                kind: MarkupKind.PlainText,
+                language: "powerquery",
+                value: `[${scopeItemText}] ${context.identifier}: ${nameOfExpressionType}`,
+            },
+            range: undefined,
+        };
+    }
+
+    protected static async getHoverForScopeItem(
+        context: HoverProviderContext,
+        nodeScope: Inspection.NodeScope,
+        scopeType: Inspection.ScopeTypeByKey,
+    ): Promise<Hover | undefined> {
+        const identifierLiteral: string = context.identifier;
+        const maybeScopeItem: Inspection.TScopeItem | undefined = nodeScope.get(identifierLiteral);
+        if (maybeScopeItem === undefined || maybeScopeItem.kind === Inspection.ScopeItemKind.Undefined) {
+            return undefined;
+        }
+
+        const scopeItemText: string = InspectionUtils.getScopeItemKindText(maybeScopeItem.kind);
+
+        const maybeScopeItemType: PQP.Language.Type.TPowerQueryType | undefined = scopeType.get(identifierLiteral);
+        const scopeItemTypeText: string =
+            maybeScopeItemType !== undefined ? PQP.Language.TypeUtils.nameOf(maybeScopeItemType) : "unknown";
+
+        return {
+            contents: {
+                kind: MarkupKind.PlainText,
+                language: "powerquery",
+                value: `[${scopeItemText}] ${identifierLiteral}: ${scopeItemTypeText}`,
+            },
+            range: undefined,
+        };
+    }
+
     private getMaybeInspection(): Inspection.Inspection | undefined {
         const inspectionCacheItem: WorkspaceCache.InspectionCacheItem = this.maybeTriedInspection;
 
@@ -217,22 +237,6 @@ export class LocalDocumentSymbolProvider implements ISymbolProvider {
 
         return maybeInspection !== undefined && PQP.ResultUtils.isOk(maybeInspection.triedCurrentInvokeExpression)
             ? maybeInspection.triedCurrentInvokeExpression.value
-            : undefined;
-    }
-
-    private maybeTypeFromIdentifier(identifier: string): PQP.Language.Type.TPowerQueryType | undefined {
-        const maybeInspection: Inspection.Inspection | undefined = this.getMaybeInspection();
-
-        return maybeInspection !== undefined && PQP.ResultUtils.isOk(maybeInspection.triedScopeType)
-            ? maybeInspection.triedScopeType.value.get(identifier)
-            : undefined;
-    }
-
-    private maybeNodeScope(): Inspection.NodeScope | undefined {
-        const maybeInspection: Inspection.Inspection | undefined = this.getMaybeInspection();
-
-        return maybeInspection !== undefined && PQP.ResultUtils.isOk(maybeInspection.triedNodeScope)
-            ? maybeInspection.triedNodeScope.value
             : undefined;
     }
 

--- a/src/powerquery-language-services/validate/validate.ts
+++ b/src/powerquery-language-services/validate/validate.ts
@@ -13,10 +13,7 @@ import { validateLexAndParse } from "./validateLexAndParse";
 import type { ValidationResult } from "./validationResult";
 import type { ValidationSettings } from "./validationSettings";
 
-export function validate<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    textDocument: TextDocument,
-    validationSettings: ValidationSettings<S>,
-): ValidationResult {
+export function validate(textDocument: TextDocument, validationSettings: ValidationSettings): ValidationResult {
     const cacheItem: WorkspaceCache.ParseCacheItem = WorkspaceCacheUtils.getOrCreateParse(
         textDocument,
         validationSettings,

--- a/src/powerquery-language-services/validate/validateDuplicateIdentifiers.ts
+++ b/src/powerquery-language-services/validate/validateDuplicateIdentifiers.ts
@@ -13,9 +13,9 @@ import { WorkspaceCache, WorkspaceCacheUtils } from "../workspaceCache";
 import { ValidationSettings } from "./validationSettings";
 import { PositionUtils } from "..";
 
-export function validateDuplicateIdentifiers<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
+export function validateDuplicateIdentifiers(
     textDocument: TextDocument,
-    validationSettings: ValidationSettings<S>,
+    validationSettings: ValidationSettings,
 ): ReadonlyArray<Diagnostic> {
     if (!validationSettings.checkForDuplicateIdentifiers) {
         return [];
@@ -46,10 +46,10 @@ export function validateDuplicateIdentifiers<S extends PQP.Parser.IParseState = 
     ];
 }
 
-function validateDuplicateIdentifiersForLetExpresion<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
+function validateDuplicateIdentifiersForLetExpresion(
     documentUri: DocumentUri,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
-    validationSettings: ValidationSettings<S>,
+    validationSettings: ValidationSettings,
 ): ReadonlyArray<Diagnostic> {
     const letIds: ReadonlyArray<number> = [
         ...(nodeIdMapCollection.idsByNodeKind.get(PQP.Language.Ast.NodeKind.LetExpression) ?? []),
@@ -64,10 +64,10 @@ function validateDuplicateIdentifiersForLetExpresion<S extends PQP.Parser.IParse
     );
 }
 
-function validateDuplicateIdentifiersForRecord<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
+function validateDuplicateIdentifiersForRecord(
     documentUri: DocumentUri,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
-    validationSettings: ValidationSettings<S>,
+    validationSettings: ValidationSettings,
 ): ReadonlyArray<Diagnostic> {
     const recordIds: ReadonlyArray<number> = [
         ...(nodeIdMapCollection.idsByNodeKind.get(PQP.Language.Ast.NodeKind.RecordExpression) ?? []),
@@ -84,10 +84,10 @@ function validateDuplicateIdentifiersForRecord<S extends PQP.Parser.IParseState 
     );
 }
 
-function validateDuplicateIdentifiersForSection<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
+function validateDuplicateIdentifiersForSection(
     documentUri: DocumentUri,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
-    validationSettings: ValidationSettings<S>,
+    validationSettings: ValidationSettings,
 ): ReadonlyArray<Diagnostic> {
     const recordIds: ReadonlyArray<number> = [
         ...(nodeIdMapCollection.idsByNodeKind.get(PQP.Language.Ast.NodeKind.Section) ?? []),
@@ -106,7 +106,7 @@ function validateDuplicateIdentifiersForSection<S extends PQP.Parser.IParseState
 //  for node in nodeIds:
 //      for childOfNode in iterNodeFn(node):
 //          ...
-function validateDuplicateIdentifiersForKeyValuePair<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
+function validateDuplicateIdentifiersForKeyValuePair(
     documentUri: DocumentUri,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
     nodeIds: ReadonlyArray<number>,
@@ -114,7 +114,7 @@ function validateDuplicateIdentifiersForKeyValuePair<S extends PQP.Parser.IParse
         nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
         node: PQP.Parser.TXorNode,
     ) => ReadonlyArray<PQP.Parser.NodeIdMapIterator.TKeyValuePair>,
-    validationSettings: ValidationSettings<S>,
+    validationSettings: ValidationSettings,
 ): ReadonlyArray<Diagnostic> {
     if (!nodeIds.length) {
         return [];
@@ -174,10 +174,10 @@ function validateDuplicateIdentifiersForKeyValuePair<S extends PQP.Parser.IParse
     return result;
 }
 
-function createDuplicateIdentifierDiagnostic<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
+function createDuplicateIdentifierDiagnostic(
     keyValuePair: PQP.Parser.NodeIdMapIterator.TKeyValuePair,
     relatedInformation: DiagnosticRelatedInformation[],
-    validationSettings: ValidationSettings<S>,
+    validationSettings: ValidationSettings,
 ): Diagnostic {
     return {
         code: DiagnosticErrorCode.DuplicateIdentifier,
@@ -189,9 +189,9 @@ function createDuplicateIdentifierDiagnostic<S extends PQP.Parser.IParseState = 
     };
 }
 
-function createDuplicateIdentifierDiagnosticMessage<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
+function createDuplicateIdentifierDiagnosticMessage(
     keyValuePair: PQP.Parser.NodeIdMapIterator.TKeyValuePair,
-    validationSettings: ValidationSettings<S>,
+    validationSettings: ValidationSettings,
 ): string {
     return Localization.error_validation_duplicate_identifier(
         LocalizationUtils.getLocalizationTemplates(validationSettings?.locale ?? PQP.DefaultLocale),

--- a/src/powerquery-language-services/validate/validateInvokeExpression.ts
+++ b/src/powerquery-language-services/validate/validateInvokeExpression.ts
@@ -12,8 +12,8 @@ import { Localization, LocalizationUtils } from "../localization";
 import { ILocalizationTemplates } from "../localization/templates";
 import { ValidationSettings } from "./validationSettings";
 
-export function validateInvokeExpression<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    validationSettings: ValidationSettings<S>,
+export function validateInvokeExpression(
+    validationSettings: ValidationSettings,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
     maybeCache?: Inspection.TypeCache,
 ): Diagnostic[] {
@@ -44,8 +44,8 @@ export function validateInvokeExpression<S extends PQP.Parser.IParseState = PQP.
     return result;
 }
 
-function invokeExpressionToDiagnostics<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    valdiationSettings: ValidationSettings<S>,
+function invokeExpressionToDiagnostics(
+    valdiationSettings: ValidationSettings,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
     inspected: Inspection.InvokeExpression,
 ): Diagnostic[] {
@@ -99,8 +99,8 @@ function invokeExpressionToDiagnostics<S extends PQP.Parser.IParseState = PQP.Pa
     return result;
 }
 
-function createDiagnosticForMismatch<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    validationSettings: ValidationSettings<S>,
+function createDiagnosticForMismatch(
+    validationSettings: ValidationSettings,
     mismatch: PQP.Language.TypeUtils.InvocationMismatch,
     maybeFunctionName: string | undefined,
     invokeExpressionRange: Range,

--- a/src/powerquery-language-services/validate/validateLexAndParse.ts
+++ b/src/powerquery-language-services/validate/validateLexAndParse.ts
@@ -11,10 +11,7 @@ import { DiagnosticErrorCode } from "../diagnosticErrorCode";
 import { WorkspaceCache, WorkspaceCacheUtils } from "../workspaceCache";
 import { ValidationSettings } from "./validationSettings";
 
-export function validateLexAndParse<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    textDocument: TextDocument,
-    validationSettings: ValidationSettings<S>,
-): Diagnostic[] {
+export function validateLexAndParse(textDocument: TextDocument, validationSettings: ValidationSettings): Diagnostic[] {
     const cacheItem: WorkspaceCache.ParseCacheItem = WorkspaceCacheUtils.getOrCreateParse(
         textDocument,
         validationSettings,
@@ -29,10 +26,7 @@ export function validateLexAndParse<S extends PQP.Parser.IParseState = PQP.Parse
     }
 }
 
-function validateLex<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    triedLex: PQP.Task.TriedLexTask,
-    validationSettings: ValidationSettings<S>,
-): Diagnostic[] {
+function validateLex(triedLex: PQP.Task.TriedLexTask, validationSettings: ValidationSettings): Diagnostic[] {
     if (PQP.TaskUtils.isOk(triedLex) || !PQP.Lexer.LexError.isLexError(triedLex.error)) {
         return [];
     }
@@ -68,10 +62,7 @@ function validateLex<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
     return diagnostics;
 }
 
-function validateParse<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    triedParse: PQP.Task.TriedParseTask,
-    validationSettings: ValidationSettings<S>,
-): Diagnostic[] {
+function validateParse(triedParse: PQP.Task.TriedParseTask, validationSettings: ValidationSettings): Diagnostic[] {
     if (PQP.TaskUtils.isOk(triedParse) || !PQP.Parser.ParseError.isParseError(triedParse.error)) {
         return [];
     }

--- a/src/powerquery-language-services/validate/validationSettings/validationSettings.ts
+++ b/src/powerquery-language-services/validate/validationSettings/validationSettings.ts
@@ -1,12 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
-
 import { InspectionSettings } from "../../inspectionSettings";
 
-export interface ValidationSettings<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>
-    extends InspectionSettings<S> {
+export interface ValidationSettings extends InspectionSettings {
     readonly source: string;
     readonly checkForDuplicateIdentifiers: boolean;
 }

--- a/src/powerquery-language-services/validate/validationSettings/validationSettingsUtils.ts
+++ b/src/powerquery-language-services/validate/validationSettings/validationSettingsUtils.ts
@@ -1,16 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
-
 import { InspectionSettings } from "../..";
 import { ValidationSettings } from "./validationSettings";
 
-export function createValidationSettings<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    inspectionSettings: InspectionSettings<S>,
+export function createValidationSettings(
+    inspectionSettings: InspectionSettings,
     source: string,
     checkForDuplicateIdentifiers?: boolean,
-): ValidationSettings<S> {
+): ValidationSettings {
     return {
         ...inspectionSettings,
         checkForDuplicateIdentifiers: checkForDuplicateIdentifiers ?? true,

--- a/src/powerquery-language-services/workspaceCache/workspaceCache.ts
+++ b/src/powerquery-language-services/workspaceCache/workspaceCache.ts
@@ -7,29 +7,25 @@ import { Position } from "vscode-languageserver-textdocument";
 
 import { Inspection } from "..";
 
-export type InspectionTask = Inspection.Inspection & { readonly stage: "Inspection"; readonly version: number };
+export type InspectionTask = Inspection.Inspection & {
+    readonly stage: "Inspection";
+    readonly version: number;
+    readonly parseState: PQP.Parser.ParseState;
+};
 
-export type CacheItem<S extends PQP.Parser.IParseState = PQP.Parser.IParseState> =
-    | LexCacheItem
-    | ParseCacheItem<S>
-    | InspectionCacheItem;
+export type CacheItem = LexCacheItem | ParseCacheItem | InspectionCacheItem;
 
 export type LexCacheItem = PQP.Task.TriedLexTask;
 
-export type ParseCacheItem<S extends PQP.Parser.IParseState = PQP.Parser.IParseState> =
-    | LexCacheItem
-    | PQP.Task.TriedParseTask<S>;
+export type ParseCacheItem = LexCacheItem | PQP.Task.TriedParseTask;
 
-export type InspectionCacheItem<S extends PQP.Parser.IParseState = PQP.Parser.IParseState> =
-    | ParseCacheItem<S>
-    | InspectionTask
-    | undefined;
+export type InspectionCacheItem = ParseCacheItem | InspectionTask | undefined;
 
 // A collection for a given TextDocument.uri
-export interface CacheCollection<S extends PQP.Parser.IParseState = PQP.Parser.IParseState> {
+export interface CacheCollection {
     readonly maybeLex: LexCacheItem | undefined;
-    readonly maybeParse: ParseCacheItem<S> | undefined;
-    readonly maybeInspectionByPosition: Map<Position, InspectionCacheItem<S>> | undefined;
+    readonly maybeParse: ParseCacheItem | undefined;
+    readonly maybeInspectionByPosition: Map<Position, InspectionCacheItem> | undefined;
     readonly typeCache: Inspection.TypeCache;
     readonly version: number;
 }

--- a/src/test/inspection/autocomplete/autocompleteFieldAccess.ts
+++ b/src/test/inspection/autocomplete/autocompleteFieldAccess.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
-
 import { Assert } from "@microsoft/powerquery-parser";
 import "mocha";
 import type { Position } from "vscode-languageserver-types";
@@ -10,8 +8,8 @@ import type { Position } from "vscode-languageserver-types";
 import { TestConstants, TestUtils } from "../..";
 import { Inspection, InspectionSettings } from "../../../powerquery-language-services";
 
-function assertGetFieldAccessAutocomplete<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    settings: InspectionSettings<S>,
+function assertGetFieldAccessAutocomplete(
+    settings: InspectionSettings,
     text: string,
     position: Position,
 ): ReadonlyArray<Inspection.AutocompleteItem> {

--- a/src/test/inspection/autocomplete/autocompleteLanguageConstant.ts
+++ b/src/test/inspection/autocomplete/autocompleteLanguageConstant.ts
@@ -12,8 +12,8 @@ import { TestConstants, TestUtils } from "../..";
 import { Inspection, InspectionSettings } from "../../../powerquery-language-services";
 import { AbridgedAutocompleteItem, createAbridgedAutocompleteItem } from "./common";
 
-function assertGetLanguageConstantAutocomplete<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    settings: InspectionSettings<S>,
+function assertGetLanguageConstantAutocomplete(
+    settings: InspectionSettings,
     text: string,
     position: Position,
 ): AbridgedAutocompleteItem | undefined {

--- a/src/test/inspection/autocomplete/autocompletePrimitiveType.ts
+++ b/src/test/inspection/autocomplete/autocompletePrimitiveType.ts
@@ -10,8 +10,8 @@ import type { Position } from "vscode-languageserver-types";
 import { TestConstants, TestUtils } from "../..";
 import { Inspection, InspectionSettings } from "../../../powerquery-language-services";
 
-function assertGetPrimitiveTypeAutocompleteOk<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    settings: InspectionSettings<S>,
+function assertGetPrimitiveTypeAutocompleteOk(
+    settings: InspectionSettings,
     text: string,
     position: Position,
 ): ReadonlyArray<Inspection.AutocompleteItem> {

--- a/src/test/inspection/currentInvokeExpression.ts
+++ b/src/test/inspection/currentInvokeExpression.ts
@@ -12,8 +12,8 @@ import { Inspection, InspectionSettings } from "../../powerquery-language-servic
 import { TestConstants, TestUtils } from "..";
 import { CurrentInvokeExpressionArguments } from "../../powerquery-language-services/inspection";
 
-function assertInvokeExpressionOk<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    settings: InspectionSettings<S>,
+function assertInvokeExpressionOk(
+    settings: InspectionSettings,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
     position: Position,
 ): Inspection.CurrentInvokeExpression | undefined {
@@ -31,8 +31,8 @@ function assertInvokeExpressionOk<S extends PQP.Parser.IParseState = PQP.Parser.
     return triedInspect.value;
 }
 
-function assertParseOkInvokeExpressionOk<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    settings: InspectionSettings<S>,
+function assertParseOkInvokeExpressionOk(
+    settings: InspectionSettings,
     text: string,
     position: Position,
 ): Inspection.CurrentInvokeExpression | undefined {
@@ -40,8 +40,8 @@ function assertParseOkInvokeExpressionOk<S extends PQP.Parser.IParseState = PQP.
     return assertInvokeExpressionOk(settings, parseOk.nodeIdMapCollection, position);
 }
 
-function assertParseErrInvokeExpressionOk<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    settings: InspectionSettings<S>,
+function assertParseErrInvokeExpressionOk(
+    settings: InspectionSettings,
     text: string,
     position: Position,
 ): Inspection.CurrentInvokeExpression | undefined {

--- a/src/test/inspection/scope.ts
+++ b/src/test/inspection/scope.ts
@@ -160,7 +160,7 @@ function assertNodeScopeOk(
 }
 
 export function assertGetParseOkScopeOk(
-    settings: PQP.LexSettings & PQP.ParseSettings<PQP.Parser.IParseState>,
+    settings: PQP.LexSettings & PQP.ParseSettings,
     text: string,
     position: Position,
 ): Inspection.NodeScope {
@@ -169,7 +169,7 @@ export function assertGetParseOkScopeOk(
 }
 
 export function assertGetParseErrScopeOk(
-    settings: PQP.LexSettings & PQP.ParseSettings<PQP.Parser.IParseState>,
+    settings: PQP.LexSettings & PQP.ParseSettings,
     text: string,
     position: Position,
 ): Inspection.NodeScope {

--- a/src/test/inspection/type.ts
+++ b/src/test/inspection/type.ts
@@ -36,8 +36,8 @@ const TestSettings: PQP.Settings & InspectionSettings = {
     maybeExternalTypeResolver: ExternalTypeResolver,
 };
 
-function assertParseOkNodeTypeEqual<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    settings: InspectionSettings<S>,
+function assertParseOkNodeTypeEqual(
+    settings: InspectionSettings,
     text: string,
     expected: PQP.Language.Type.TPowerQueryType,
 ): void {
@@ -64,8 +64,8 @@ function assertParseErrNodeTypeEqual(text: string, expected: PQP.Language.Type.T
     expect(actual).deep.equal(expected);
 }
 
-function assertGetParseNodeOk<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    settings: InspectionSettings<S>,
+function assertGetParseNodeOk(
+    settings: InspectionSettings,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
@@ -75,8 +75,8 @@ function assertGetParseNodeOk<S extends PQP.Parser.IParseState = PQP.Parser.IPar
     return triedType.value;
 }
 
-function assertParseOkScopeTypeEqual<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    settings: InspectionSettings<S>,
+function assertParseOkScopeTypeEqual(
+    settings: InspectionSettings,
     textWithPipe: string,
     expected: Inspection.ScopeTypeByKey,
 ): void {
@@ -92,8 +92,8 @@ function assertParseOkScopeTypeEqual<S extends PQP.Parser.IParseState = PQP.Pars
     expect(actual).deep.equal(expected);
 }
 
-function assertGetParseOkScopeTypeOk<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    settings: InspectionSettings<S>,
+function assertGetParseOkScopeTypeOk(
+    settings: InspectionSettings,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
     position: Position,
 ): Inspection.ScopeTypeByKey {

--- a/src/test/providers/localDocumentSymbolProvider.ts
+++ b/src/test/providers/localDocumentSymbolProvider.ts
@@ -225,9 +225,24 @@ describe(`SimpleLocalDocumentSymbolProvider`, async () => {
         });
 
         describe(`hover the value when over key`, () => {
-            it(`WIP let-variable`, async () => {
+            it(`let-variable`, async () => {
                 const hover: Hover = await createHover("let foo| = 1 in foo");
                 TestUtils.assertHover("[let-variable] foo: 1", hover);
+            });
+
+            it(`record-field expression`, async () => {
+                const hover: Hover = await createHover("[foo| = 1]");
+                TestUtils.assertHover("[record-field] foo: 1", hover);
+            });
+
+            it(`record-field literal`, async () => {
+                const hover: Hover = await createHover("[foo| = 1] section; bar = 1;");
+                TestUtils.assertHover("[record-field] foo: 1", hover);
+            });
+
+            it(`section-member`, async () => {
+                const hover: Hover = await createHover("section; foo| = 1;");
+                TestUtils.assertHover("[section-member] foo: 1", hover);
             });
         });
     });

--- a/src/test/providers/localDocumentSymbolProvider.ts
+++ b/src/test/providers/localDocumentSymbolProvider.ts
@@ -192,29 +192,43 @@ describe(`SimpleLocalDocumentSymbolProvider`, async () => {
     });
 
     describe(`getHover`, async () => {
-        it(`let-variable`, async () => {
-            const hover: Hover = await createHover("let x = 1 in x|");
-            TestUtils.assertHover("[let-variable] x: 1", hover);
+        describe(`simple`, async () => {
+            it(`let-variable`, async () => {
+                const hover: Hover = await createHover("let x = 1 in x|");
+                TestUtils.assertHover("[let-variable] x: 1", hover);
+            });
+
+            it(`parameter`, async () => {
+                const hover: Hover = await createHover("(x as number) => x|");
+                TestUtils.assertHover("[parameter] x: number", hover);
+            });
+
+            it(`record-field`, async () => {
+                const hover: Hover = await createHover("[x = 1, y = x|]");
+                TestUtils.assertHover("[record-field] x: 1", hover);
+            });
+
+            it(`section-member`, async () => {
+                const hover: Hover = await createHover("section; x = 1; y = x|;");
+                TestUtils.assertHover("[section-member] x: 1", hover);
+            });
+
+            it(`undefined`, async () => {
+                const hover: Hover = await createHover("x|");
+                expect(hover).to.equal(EmptyHover);
+            });
         });
 
-        it(`parameter`, async () => {
-            const hover: Hover = await createHover("(x as number) => x|");
-            TestUtils.assertHover("[parameter] x: number", hover);
+        it(`null on parameter hover`, async () => {
+            const hover: Hover = await createHover("let foo = 10, bar = (foo| as number) => foo in foo");
+            expect(hover).to.deep.equal(EmptyHover);
         });
 
-        it(`record-field`, async () => {
-            const hover: Hover = await createHover("[x = 1, y = x|]");
-            TestUtils.assertHover("[record-field] x: 1", hover);
-        });
-
-        it(`section-member`, async () => {
-            const hover: Hover = await createHover("section; x = 1; y = x|;");
-            TestUtils.assertHover("[section-member] x: 1", hover);
-        });
-
-        it(`undefined`, async () => {
-            const hover: Hover = await createHover("x|");
-            expect(hover).to.equal(EmptyHover);
+        describe(`hover the value when over key`, () => {
+            it(`WIP let-variable`, async () => {
+                const hover: Hover = await createHover("let foo| = 1 in foo");
+                TestUtils.assertHover("[let-variable] foo: 1", hover);
+            });
         });
     });
 

--- a/src/test/testConstants.ts
+++ b/src/test/testConstants.ts
@@ -242,8 +242,9 @@ export const SimpleLibraryAnalysisSettings: AnalysisSettings = {
     maybeCreateLibrarySymbolProviderFn: (library: Library.ILibrary) => new LibrarySymbolProvider(library),
     maybeCreateLocalDocumentSymbolProviderFn: (
         library: Library.ILibrary,
-        maybeTriedInspection: WorkspaceCache.InspectionCacheItem | undefined,
-    ) => new LocalDocumentSymbolProvider(library, maybeTriedInspection),
+        maybeTriedInspection: WorkspaceCache.CacheItem | undefined,
+        createInspectionSettingsFn: () => InspectionSettings,
+    ) => new LocalDocumentSymbolProvider(library, maybeTriedInspection, createInspectionSettingsFn),
 };
 
 export const enum TestLibraryName {

--- a/src/test/testUtils/assert.ts
+++ b/src/test/testUtils/assert.ts
@@ -30,12 +30,12 @@ export function assertAsMarkupContent(value: Hover["contents"]): MarkupContent {
     return value;
 }
 
-export function assertGetAutocomplete<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    settings: InspectionSettings<S>,
+export function assertGetAutocomplete(
+    settings: InspectionSettings,
     text: string,
     position: Position,
 ): Inspection.Autocomplete {
-    const triedLexParseTask: PQP.Task.TriedLexParseTask<S> = PQP.TaskUtils.tryLexParse(settings, text);
+    const triedLexParseTask: PQP.Task.TriedLexParseTask = PQP.TaskUtils.tryLexParse(settings, text);
     TaskUtils.assertIsParseStage(triedLexParseTask);
 
     if (PQP.TaskUtils.isParseStageOk(triedLexParseTask)) {
@@ -51,7 +51,7 @@ export function assertGetAutocomplete<S extends PQP.Parser.IParseState = PQP.Par
             throw triedLexParseTask.error;
         }
 
-        return Inspection.autocomplete<S>(
+        return Inspection.autocomplete(
             settings,
             triedLexParseTask.parseState,
             TypeCacheUtils.createEmptyCache(),
@@ -90,21 +90,15 @@ export function assertGetInspectionCacheItem(document: MockDocument, position: P
     return cacheItem;
 }
 
-export function assertGetLexParseOk<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    settings: PQP.Settings<S>,
-    text: string,
-): PQP.Task.ParseTaskOk<S> {
-    const triedLexParseTask: PQP.Task.TriedLexParseTask<S> = PQP.TaskUtils.tryLexParse(settings, text);
+export function assertGetLexParseOk(settings: PQP.Settings, text: string): PQP.Task.ParseTaskOk {
+    const triedLexParseTask: PQP.Task.TriedLexParseTask = PQP.TaskUtils.tryLexParse(settings, text);
     TaskUtils.assertIsParseStageOk(triedLexParseTask);
 
     return triedLexParseTask;
 }
 
-export function assertGetLexParseError<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
-    settings: PQP.Settings<S>,
-    text: string,
-): PQP.Task.ParseTaskParseError<S> {
-    const triedLexParseTask: PQP.Task.TriedLexParseTask<S> = PQP.TaskUtils.tryLexParse(settings, text);
+export function assertGetLexParseError(settings: PQP.Settings, text: string): PQP.Task.ParseTaskParseError {
+    const triedLexParseTask: PQP.Task.TriedLexParseTask = PQP.TaskUtils.tryLexParse(settings, text);
     TaskUtils.assertIsParseStageParseError(triedLexParseTask);
 
     return triedLexParseTask;


### PR DESCRIPTION
* updated to use the new parser library, which mostly removes IParserState nonsense. This is the majority of the changes.
* getHover works on the keys for key-value-pairs. This required a new factory function, createInspectionSettingsFn, in order to do evaluate the value's type
* added the typeCache used in an inspection as a part of its return