### PR TITLE
Fix onHover not always populating for library references

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.2.9",
+    "version": "0.2.10",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.2.9",
+    "version": "0.2.10",
     "author": "Microsoft",
     "license": "MIT",
     "scripts": {

--- a/src/powerquery-language-services/providers/localDocumentSymbolProvider.ts
+++ b/src/powerquery-language-services/providers/localDocumentSymbolProvider.ts
@@ -8,7 +8,6 @@ import { Hover, MarkupKind, SignatureHelp } from "vscode-languageserver-types";
 import * as InspectionUtils from "../inspectionUtils";
 
 import { Inspection, Library } from "..";
-import { EmptyHover } from "../commonTypes";
 import { InspectionSettings } from "../inspectionSettings";
 import { WorkspaceCache, WorkspaceCacheUtils } from "../workspaceCache";
 import {
@@ -70,7 +69,8 @@ export class LocalDocumentSymbolProvider implements ISymbolProvider {
         }
 
         if (!PQP.ResultUtils.isOk(inspection.triedNodeScope) || !PQP.ResultUtils.isOk(inspection.triedScopeType)) {
-            return EmptyHover;
+            // tslint:disable-next-line: no-null-keyword
+            return null;
         }
 
         maybeHover = await LocalDocumentSymbolProvider.getHoverForScopeItem(
@@ -79,7 +79,8 @@ export class LocalDocumentSymbolProvider implements ISymbolProvider {
             inspection.triedScopeType.value,
         );
 
-        return maybeHover ?? EmptyHover;
+        // tslint:disable-next-line: no-null-keyword
+        return maybeHover ?? null;
     }
 
     public async getSignatureHelp(context: SignatureProviderContext): Promise<SignatureHelp | null> {

--- a/src/test/providers/multipleProviders.ts
+++ b/src/test/providers/multipleProviders.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import "mocha";
+
+import { TestConstants, TestUtils } from "..";
+import { Hover } from "../../powerquery-language-services";
+
+async function createHover(text: string): Promise<Hover> {
+    return TestUtils.createHover(text, TestConstants.SimpleLibraryAnalysisSettings);
+}
+describe(`Multiple providers (TestConstants.SimpleLibraryAnalysisSettings)`, async () => {
+    it(`getHover value in key-value-pair`, async () => {
+        const hover: Hover = await createHover(`let foobar = ${TestConstants.TestLibraryName.SquareIfNumber}|`);
+        TestUtils.assertHover("[library function] Test.SquareIfNumber: (x: any) => any", hover);
+    });
+});


### PR DESCRIPTION
Cases like `let foobar = Table.AddColumn|` failed to provide onHover details. This is because I returned EmptyHover in localDocumentSymbolProvider instead of the expected null value. It got by the existing tests as I was only testing providers in isolation.