### PR TITLE
Integrate new parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,17 +31,17 @@
             }
         },
         "@microsoft/powerquery-formatter": {
-            "version": "0.0.37",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.0.37.tgz",
-            "integrity": "sha512-+JOt+ZRUm72FEBU/7qgSJH/adnmuJo3wGF3gilCIDYkgi9l/CwstQ8EMIThfTvN35415TdlnpxizFIyhB7f4HA==",
+            "version": "0.0.39",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.0.39.tgz",
+            "integrity": "sha512-MJqg9c1L9XZku+ZzKy8lHe/DaKx+TtbEvRFzl/0AAh9YRh+VmRFyysPn6VuAZ9b0D5rgdcqhmuTR9PDNNHWBCQ==",
             "requires": {
-                "@microsoft/powerquery-parser": "0.4.10"
+                "@microsoft/powerquery-parser": "0.4.15"
             }
         },
         "@microsoft/powerquery-parser": {
-            "version": "0.4.10",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.4.10.tgz",
-            "integrity": "sha512-KspLLMML+LIl8RoCaHGS9dVmOxiVZM4OECUwx2lN6dh9Z+eCeTx6r6LtPd5wE7sS7fazY2y5KKjddoPEs4kgYg==",
+            "version": "0.4.15",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.4.15.tgz",
+            "integrity": "sha512-MARY4OLTPx2Zd5zGaNcMonu4MAY9VKNykE4b9R6MNrxbg2V3ic+M0GMtlp42h5s3laLftVpJo5VlkekW51w5+g==",
             "requires": {
                 "grapheme-splitter": "^1.0.4"
             }

--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
         "typescript": "^4.3.5"
     },
     "dependencies": {
-        "@microsoft/powerquery-formatter": "0.0.37",
-        "@microsoft/powerquery-parser": "0.4.10",
+        "@microsoft/powerquery-formatter": "0.0.39",
+        "@microsoft/powerquery-parser": "0.4.15",
         "vscode-languageserver-textdocument": "1.0.1",
         "vscode-languageserver-types": "3.15.1"
     },

--- a/src/powerquery-language-services/commonTypesUtils.ts
+++ b/src/powerquery-language-services/commonTypesUtils.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import * as PQP from "@microsoft/powerquery-parser";
+
 import { Position, Range } from "./commonTypes";
 
 export function rangeFromTokenRange(tokenRange: PQP.Language.Token.TokenRange): Range {

--- a/src/powerquery-language-services/documentSymbols.ts
+++ b/src/powerquery-language-services/documentSymbols.ts
@@ -49,15 +49,20 @@ function addIdentifierPairedExpressionSymbols(
     );
 
     for (const xorNode of identifierPairedExpressionsXorNodes) {
-        if (!PQP.Parser.XorNodeUtils.isAst(xorNode)) {
+        if (
+            !PQP.Parser.XorNodeUtils.isAstXor<PQP.Language.Ast.IdentifierPairedExpression>(
+                xorNode,
+                PQP.Language.Ast.NodeKind.IdentifierPairedExpression,
+            )
+        ) {
             continue;
         }
 
-        const asAst: PQP.Language.Ast.IdentifierPairedExpression = xorNode.node as PQP.Language.Ast.IdentifierPairedExpression;
-        const asDocumentSymbol: DocumentSymbol = InspectionUtils.getSymbolForIdentifierPairedExpression(asAst);
+        const nodeId: number = xorNode.node.id;
+        const documentSymbol: DocumentSymbol = InspectionUtils.getSymbolForIdentifierPairedExpression(xorNode.node);
 
-        addDocumentSymbols(nodeIdMapCollection, parentSymbolById, asAst.id, currentSymbols, asDocumentSymbol);
-        parentSymbolById.set(asAst.id, asDocumentSymbol);
+        addDocumentSymbols(nodeIdMapCollection, parentSymbolById, nodeId, currentSymbols, documentSymbol);
+        parentSymbolById.set(nodeId, documentSymbol);
     }
 }
 
@@ -76,7 +81,7 @@ function addRecordSymbols(
     );
 
     for (const xorNode of recordXorNodes) {
-        if (!PQP.Parser.XorNodeUtils.isAst(xorNode)) {
+        if (!PQP.Parser.XorNodeUtils.isAstXor(xorNode)) {
             continue;
         }
 

--- a/src/powerquery-language-services/documentSymbols.ts
+++ b/src/powerquery-language-services/documentSymbols.ts
@@ -50,7 +50,7 @@ function addIdentifierPairedExpressionSymbols(
 
     for (const xorNode of identifierPairedExpressionsXorNodes) {
         if (
-            !PQP.Parser.XorNodeUtils.isAstXor<PQP.Language.Ast.IdentifierPairedExpression>(
+            !PQP.Parser.XorNodeUtils.isAstXorChecked<PQP.Language.Ast.IdentifierPairedExpression>(
                 xorNode,
                 PQP.Language.Ast.NodeKind.IdentifierPairedExpression,
             )

--- a/src/powerquery-language-services/formatter.ts
+++ b/src/powerquery-language-services/formatter.ts
@@ -4,6 +4,7 @@
 import * as PQF from "@microsoft/powerquery-formatter";
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { ResultUtils } from "@microsoft/powerquery-parser";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { FormattingOptions, Range, TextEdit } from "vscode-languageserver-types";
 
@@ -22,7 +23,7 @@ export function tryFormat(document: TextDocument, formattingOptions: FormattingO
     };
     const triedFormat: PQF.TriedFormat = PQF.tryFormat(formatSettings, document.getText());
 
-    if (PQP.ResultUtils.isOk(triedFormat)) {
+    if (ResultUtils.isOk(triedFormat)) {
         return [TextEdit.replace(fullDocumentRange(document), triedFormat.value)];
     }
     // If an unhandled exception was returned.

--- a/src/powerquery-language-services/inspection/activeNode/activeNode.ts
+++ b/src/powerquery-language-services/inspection/activeNode/activeNode.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
+import { Ast } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { TXorNode } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
 import type { Position } from "vscode-languageserver-types";
 
@@ -29,12 +30,9 @@ export interface ActiveNode extends IActiveNode {
     // A full parental ancestry of the starting node.
     // [starting node, parent of starting node, parent of parent of starting node, ...].
     // Must contain at least one element, otherwise it should be an OutOfBoundPosition.
-    readonly ancestry: ReadonlyArray<PQP.Parser.TXorNode>;
+    readonly ancestry: ReadonlyArray<TXorNode>;
     // A conditional indirection to the leaf if it's an Ast identifier.
-    readonly maybeIdentifierUnderPosition:
-        | PQP.Language.Ast.Identifier
-        | PQP.Language.Ast.GeneralizedIdentifier
-        | undefined;
+    readonly maybeIdentifierUnderPosition: Ast.Identifier | Ast.GeneralizedIdentifier | undefined;
 }
 
 export interface OutOfBoundPosition extends IActiveNode {

--- a/src/powerquery-language-services/inspection/activeNode/activeNodeUtils.ts
+++ b/src/powerquery-language-services/inspection/activeNode/activeNodeUtils.ts
@@ -250,7 +250,12 @@ function maybeFindAstNodes(nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
                 maybeBestAfter.constantKind,
             )
         ) {
-            const parent: PQP.Language.Ast.TNode = PQP.Parser.NodeIdMapUtils.assertGetParentAst(
+            const parent:
+                | PQP.Language.Ast.RecordExpression
+                | PQP.Language.Ast.RecordLiteral
+                | PQP.Language.Ast.ListExpression
+                | PQP.Language.Ast.ListLiteral
+                | PQP.Language.Ast.InvokeExpression = PQP.Parser.NodeIdMapUtils.assertUnwrapParentAst(
                 nodeIdMapCollection,
                 currentOnOrBefore.id,
                 [
@@ -261,11 +266,11 @@ function maybeFindAstNodes(nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
                     PQP.Language.Ast.NodeKind.InvokeExpression,
                 ],
             );
-            const arrayWrapper: PQP.Language.Ast.TNode = PQP.Parser.NodeIdMapUtils.assertGetChildAstByAttributeIndex(
+            const arrayWrapper: PQP.Language.Ast.TArrayWrapper = PQP.Parser.NodeIdMapUtils.assertUnwrapNthChildAsAst(
                 nodeIdMapCollection,
                 parent.id,
                 1,
-                [PQP.Language.Ast.NodeKind.ArrayWrapper],
+                PQP.Language.Ast.NodeKind.ArrayWrapper,
             );
             maybeShiftedRightNode = arrayWrapper;
         }
@@ -317,7 +322,7 @@ function findIdentifierUnderPosition(
     position: Position,
     leaf: PQP.Parser.TXorNode,
 ): PQP.Language.Ast.Identifier | PQP.Language.Ast.GeneralizedIdentifier | undefined {
-    if (PQP.Parser.XorNodeUtils.isContext(leaf)) {
+    if (PQP.Parser.XorNodeUtils.isContextXor(leaf)) {
         return undefined;
     }
 
@@ -334,7 +339,7 @@ function findIdentifierUnderPosition(
         }
         const parentId: number = maybeParentId;
 
-        const parent: PQP.Language.Ast.TNode = PQP.Parser.NodeIdMapUtils.assertGetAst(
+        const parent: PQP.Language.Ast.TNode = PQP.Parser.NodeIdMapUtils.assertUnwrapAst(
             nodeIdMapCollection.astNodeById,
             parentId,
         );

--- a/src/powerquery-language-services/inspection/activeNode/activeNodeUtils.ts
+++ b/src/powerquery-language-services/inspection/activeNode/activeNodeUtils.ts
@@ -3,12 +3,21 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { Ast, Constant } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import {
+    AncestryUtils,
+    NodeIdMap,
+    NodeIdMapUtils,
+    TXorNode,
+    XorNode,
+    XorNodeUtils,
+} from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 import type { Position } from "vscode-languageserver-types";
 
 import { PositionUtils } from "../..";
 import { ActiveNode, ActiveNodeKind, ActiveNodeLeafKind, OutOfBoundPosition, TMaybeActiveNode } from "./activeNode";
 
-// Searches all leaf PQP.Language.Ast.TNodes and all Context nodes to find the "active" node.
+// Searches all leaf Ast.TNodes and all Context nodes to find the "active" node.
 // ' 1 + |' -> the second operand, a Context node, in an ArithmeticExpression.
 // 'let x=|1 in x' -> the value part of the key-value-pair.
 // 'foo(|)' -> the zero length ArrayWrapper of an InvokeExpression
@@ -17,18 +26,15 @@ import { ActiveNode, ActiveNodeKind, ActiveNodeLeafKind, OutOfBoundPosition, TMa
 // This approach breaks under several edge cases.
 //
 // Take a look at the ArithmeticExpression example above,
-// it doesn't make sense for the ActiveNode to be the '+' PQP.Language.constant.
-// When the position is on a constant the selected PQP.Language.Ast.TNode might need to be shifted one to the right.
+// it doesn't make sense for the ActiveNode to be the '+' Constant.
+// When the position is on a constant the selected Ast.TNode might need to be shifted one to the right.
 // This happens with atomic constants such as '+', '=>', '[', '(' etc.
 // However if you shifted right on '(' for 'foo(|)' then the ActiveNode would be ')' instead of the ArrayWrapper.
 //
 // Sometimes we don't want to shift at all.
 // Nodes that prevent shifting are called anchor nodes.
-// '[foo = bar|' should be anchored on the identifier 'bar' and not the context node for the ']' PQP.Language.constant.
-export function maybeActiveNode(
-    nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
-    position: Position,
-): TMaybeActiveNode {
+// '[foo = bar|' should be anchored on the identifier 'bar' and not the context node for the ']' Constant.
+export function maybeActiveNode(nodeIdMapCollection: NodeIdMap.Collection, position: Position): TMaybeActiveNode {
     // Search for the closest Ast node on or to the left of Position, as well as the closest shifted right Ast node.
     const astSearch: AstNodeSearch = maybeFindAstNodes(nodeIdMapCollection, position);
     // Search for the closest Context node on or to the right of the closest Ast node.
@@ -37,7 +43,7 @@ export function maybeActiveNode(
         astSearch,
     );
 
-    let maybeLeaf: PQP.Parser.TXorNode | undefined;
+    let maybeLeaf: TXorNode | undefined;
     let leafKind: ActiveNodeLeafKind;
     // Order of node priority:
     //  * shifted
@@ -45,19 +51,19 @@ export function maybeActiveNode(
     //  * Context
     //  * Ast
     if (astSearch.maybeShiftedRightNode !== undefined) {
-        maybeLeaf = PQP.Parser.XorNodeUtils.createAstNode(astSearch.maybeShiftedRightNode);
+        maybeLeaf = XorNodeUtils.boxAst(astSearch.maybeShiftedRightNode);
         leafKind = ActiveNodeLeafKind.ShiftedRight;
     } else if (
         astSearch.maybeBestOnOrBeforeNode !== undefined &&
         isAnchorNode(position, astSearch.maybeBestOnOrBeforeNode)
     ) {
-        maybeLeaf = PQP.Parser.XorNodeUtils.createAstNode(astSearch.maybeBestOnOrBeforeNode);
+        maybeLeaf = XorNodeUtils.boxAst(astSearch.maybeBestOnOrBeforeNode);
         leafKind = ActiveNodeLeafKind.Anchored;
     } else if (maybeContextNode !== undefined) {
-        maybeLeaf = PQP.Parser.XorNodeUtils.createContextNode(maybeContextNode);
+        maybeLeaf = XorNodeUtils.boxContext(maybeContextNode);
         leafKind = ActiveNodeLeafKind.ContextNode;
     } else if (astSearch.maybeBestOnOrBeforeNode !== undefined) {
-        maybeLeaf = PQP.Parser.XorNodeUtils.createAstNode(astSearch.maybeBestOnOrBeforeNode);
+        maybeLeaf = XorNodeUtils.boxAst(astSearch.maybeBestOnOrBeforeNode);
         leafKind = PositionUtils.isAfterAst(position, astSearch.maybeBestOnOrBeforeNode, false)
             ? ActiveNodeLeafKind.AfterAstNode
             : ActiveNodeLeafKind.OnAstNode;
@@ -65,12 +71,12 @@ export function maybeActiveNode(
         return createOutOfBoundPosition(position);
     }
 
-    const leaf: PQP.Parser.TXorNode = maybeLeaf;
+    const leaf: TXorNode = maybeLeaf;
 
     return createActiveNode(
         leafKind,
         position,
-        PQP.Parser.AncestryUtils.assertGetAncestry(nodeIdMapCollection, leaf.node.id),
+        AncestryUtils.assertGetAncestry(nodeIdMapCollection, leaf.node.id),
         findIdentifierUnderPosition(nodeIdMapCollection, position, leaf),
     );
 }
@@ -78,8 +84,8 @@ export function maybeActiveNode(
 export function createActiveNode(
     leafKind: ActiveNodeLeafKind,
     position: Position,
-    ancestry: ReadonlyArray<PQP.Parser.TXorNode>,
-    maybeIdentifierUnderPosition: PQP.Language.Ast.Identifier | PQP.Language.Ast.GeneralizedIdentifier | undefined,
+    ancestry: ReadonlyArray<TXorNode>,
+    maybeIdentifierUnderPosition: Ast.Identifier | Ast.GeneralizedIdentifier | undefined,
 ): ActiveNode {
     return {
         kind: ActiveNodeKind.ActiveNode,
@@ -97,14 +103,14 @@ export function createOutOfBoundPosition(position: Position): OutOfBoundPosition
     };
 }
 
-export function assertActiveNode(nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection, position: Position): ActiveNode {
+export function assertActiveNode(nodeIdMapCollection: NodeIdMap.Collection, position: Position): ActiveNode {
     const maybeValue: TMaybeActiveNode = maybeActiveNode(nodeIdMapCollection, position);
     assertPositionInBounds(maybeValue);
     return maybeValue;
 }
 
-export function assertGetLeaf(activeNode: ActiveNode): PQP.Parser.TXorNode {
-    return PQP.Parser.AncestryUtils.assertGetLeaf(activeNode.ancestry);
+export function assertGetLeaf(activeNode: ActiveNode): TXorNode {
+    return AncestryUtils.assertGetLeaf(activeNode.ancestry);
 }
 
 export function assertPositionInBounds(maybeValue: TMaybeActiveNode): asserts maybeValue is ActiveNode {
@@ -117,69 +123,63 @@ export function isPositionInBounds(maybeValue: TMaybeActiveNode): maybeValue is 
     return maybeValue.kind === ActiveNodeKind.ActiveNode;
 }
 
-export function maybeFirstXorOfNodeKind<T extends PQP.Language.Ast.TNode>(
+export function maybeFirstXorOfNodeKind<T extends Ast.TNode>(
     activeNode: ActiveNode,
     nodeKind: T["kind"],
-): PQP.Parser.XorNode<T> | undefined {
-    return PQP.Parser.AncestryUtils.maybeFirstXorOfNodeKind(activeNode.ancestry, nodeKind);
+): XorNode<T> | undefined {
+    return AncestryUtils.maybeFirstXorOfNodeKind(activeNode.ancestry, nodeKind);
 }
 
 interface AstNodeSearch {
-    readonly maybeBestOnOrBeforeNode: PQP.Language.Ast.TNode | undefined;
-    readonly maybeShiftedRightNode: PQP.Language.Ast.TNode | undefined;
+    readonly maybeBestOnOrBeforeNode: Ast.TNode | undefined;
+    readonly maybeShiftedRightNode: Ast.TNode | undefined;
 }
 
 const DrilldownConstantKind: ReadonlyArray<string> = [
-    PQP.Language.Constant.WrapperConstantKind.LeftBrace,
-    PQP.Language.Constant.WrapperConstantKind.LeftBracket,
-    PQP.Language.Constant.WrapperConstantKind.LeftParenthesis,
+    Constant.WrapperConstantKind.LeftBrace,
+    Constant.WrapperConstantKind.LeftBracket,
+    Constant.WrapperConstantKind.LeftParenthesis,
 ];
 
 const ShiftRightConstantKinds: ReadonlyArray<string> = [
-    PQP.Language.Constant.MiscConstantKind.Comma,
-    PQP.Language.Constant.MiscConstantKind.Equal,
-    PQP.Language.Constant.MiscConstantKind.FatArrow,
-    PQP.Language.Constant.WrapperConstantKind.RightBrace,
-    PQP.Language.Constant.WrapperConstantKind.RightBracket,
-    PQP.Language.Constant.WrapperConstantKind.RightParenthesis,
-    PQP.Language.Constant.MiscConstantKind.Semicolon,
+    Constant.MiscConstantKind.Comma,
+    Constant.MiscConstantKind.Equal,
+    Constant.MiscConstantKind.FatArrow,
+    Constant.WrapperConstantKind.RightBrace,
+    Constant.WrapperConstantKind.RightBracket,
+    Constant.WrapperConstantKind.RightParenthesis,
+    Constant.MiscConstantKind.Semicolon,
     ...DrilldownConstantKind,
 ];
 
-function isAnchorNode(position: Position, astNode: PQP.Language.Ast.TNode): boolean {
+function isAnchorNode(position: Position, astNode: Ast.TNode): boolean {
     if (!PositionUtils.isInAst(position, astNode, true, true)) {
         return false;
     }
 
-    if (
-        astNode.kind === PQP.Language.Ast.NodeKind.Identifier ||
-        astNode.kind === PQP.Language.Ast.NodeKind.GeneralizedIdentifier
-    ) {
+    if (astNode.kind === Ast.NodeKind.Identifier || astNode.kind === Ast.NodeKind.GeneralizedIdentifier) {
         return true;
-    } else if (
-        astNode.kind === PQP.Language.Ast.NodeKind.LiteralExpression &&
-        astNode.literalKind === PQP.Language.Ast.LiteralKind.Numeric
-    ) {
+    } else if (astNode.kind === Ast.NodeKind.LiteralExpression && astNode.literalKind === Ast.LiteralKind.Numeric) {
         return true;
-    } else if (astNode.kind === PQP.Language.Ast.NodeKind.Constant) {
+    } else if (astNode.kind === Ast.NodeKind.Constant) {
         switch (astNode.constantKind) {
-            case PQP.Language.Constant.KeywordConstantKind.As:
-            case PQP.Language.Constant.KeywordConstantKind.Each:
-            case PQP.Language.Constant.KeywordConstantKind.Else:
-            case PQP.Language.Constant.KeywordConstantKind.Error:
-            case PQP.Language.Constant.KeywordConstantKind.If:
-            case PQP.Language.Constant.KeywordConstantKind.In:
-            case PQP.Language.Constant.KeywordConstantKind.Is:
-            case PQP.Language.Constant.KeywordConstantKind.Section:
-            case PQP.Language.Constant.KeywordConstantKind.Shared:
-            case PQP.Language.Constant.KeywordConstantKind.Let:
-            case PQP.Language.Constant.KeywordConstantKind.Meta:
-            case PQP.Language.Constant.KeywordConstantKind.Otherwise:
-            case PQP.Language.Constant.KeywordConstantKind.Then:
-            case PQP.Language.Constant.KeywordConstantKind.Try:
-            case PQP.Language.Constant.KeywordConstantKind.Type:
+            case Constant.KeywordConstantKind.As:
+            case Constant.KeywordConstantKind.Each:
+            case Constant.KeywordConstantKind.Else:
+            case Constant.KeywordConstantKind.Error:
+            case Constant.KeywordConstantKind.If:
+            case Constant.KeywordConstantKind.In:
+            case Constant.KeywordConstantKind.Is:
+            case Constant.KeywordConstantKind.Section:
+            case Constant.KeywordConstantKind.Shared:
+            case Constant.KeywordConstantKind.Let:
+            case Constant.KeywordConstantKind.Meta:
+            case Constant.KeywordConstantKind.Otherwise:
+            case Constant.KeywordConstantKind.Then:
+            case Constant.KeywordConstantKind.Try:
+            case Constant.KeywordConstantKind.Type:
 
-            case PQP.Language.Constant.PrimitiveTypeConstantKind.Null:
+            case Constant.PrimitiveTypeConstantKind.Null:
                 return true;
 
             default:
@@ -190,29 +190,29 @@ function isAnchorNode(position: Position, astNode: PQP.Language.Ast.TNode): bool
     }
 }
 
-function maybeFindAstNodes(nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection, position: Position): AstNodeSearch {
+function maybeFindAstNodes(nodeIdMapCollection: NodeIdMap.Collection, position: Position): AstNodeSearch {
     const astNodeById: PQP.Parser.NodeIdMap.AstNodeById = nodeIdMapCollection.astNodeById;
-    let maybeBestOnOrBeforeNode: PQP.Language.Ast.TNode | undefined;
-    let maybeBestAfter: PQP.Language.Ast.TNode | undefined;
-    let maybeShiftedRightNode: PQP.Language.Ast.TNode | undefined;
+    let maybeBestOnOrBeforeNode: Ast.TNode | undefined;
+    let maybeBestAfter: Ast.TNode | undefined;
+    let maybeShiftedRightNode: Ast.TNode | undefined;
 
     // Find:
     //  the closest leaf to the left or on position.
     //  the closest leaf to the right of position.
     for (const nodeId of nodeIdMapCollection.leafIds) {
-        const maybeCandidate: PQP.Language.Ast.TNode | undefined = astNodeById.get(nodeId);
+        const maybeCandidate: Ast.TNode | undefined = astNodeById.get(nodeId);
         if (maybeCandidate === undefined) {
             continue;
         }
-        const candidate: PQP.Language.Ast.TNode = maybeCandidate;
+        const candidate: Ast.TNode = maybeCandidate;
 
         let isBoundIncluded: boolean;
         if (
             // let x|=1
-            (candidate.kind === PQP.Language.Ast.NodeKind.Constant &&
+            (candidate.kind === Ast.NodeKind.Constant &&
                 ShiftRightConstantKinds.indexOf(candidate.constantKind) !== -1) ||
             // let x=|1
-            (maybeBestOnOrBeforeNode?.kind === PQP.Language.Ast.NodeKind.Constant &&
+            (maybeBestOnOrBeforeNode?.kind === Ast.NodeKind.Constant &&
                 ShiftRightConstantKinds.indexOf(maybeBestOnOrBeforeNode.constantKind) !== -1)
         ) {
             isBoundIncluded = false;
@@ -238,35 +238,35 @@ function maybeFindAstNodes(nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
     }
 
     // Might need to shift.
-    if (maybeBestOnOrBeforeNode?.kind === PQP.Language.Ast.NodeKind.Constant) {
-        const currentOnOrBefore: PQP.Language.Ast.TConstant = maybeBestOnOrBeforeNode;
+    if (maybeBestOnOrBeforeNode?.kind === Ast.NodeKind.Constant) {
+        const currentOnOrBefore: Ast.TConstant = maybeBestOnOrBeforeNode;
 
         // Requires a shift into an empty ArrayWrapper.
         if (
             DrilldownConstantKind.indexOf(maybeBestOnOrBeforeNode.constantKind) !== -1 &&
-            maybeBestAfter?.kind === PQP.Language.Ast.NodeKind.Constant &&
+            maybeBestAfter?.kind === Ast.NodeKind.Constant &&
             PQP.Language.ConstantUtils.isPairedWrapperConstantKinds(
                 maybeBestOnOrBeforeNode.constantKind,
                 maybeBestAfter.constantKind,
             )
         ) {
             const parent:
-                | PQP.Language.Ast.RecordExpression
-                | PQP.Language.Ast.RecordLiteral
-                | PQP.Language.Ast.ListExpression
-                | PQP.Language.Ast.ListLiteral
-                | PQP.Language.Ast.InvokeExpression = PQP.Parser.NodeIdMapUtils.assertUnwrapParentAstChecked(
+                | Ast.RecordExpression
+                | Ast.RecordLiteral
+                | Ast.ListExpression
+                | Ast.ListLiteral
+                | Ast.InvokeExpression = NodeIdMapUtils.assertUnboxParentAstChecked(
                 nodeIdMapCollection,
                 currentOnOrBefore.id,
                 [
-                    PQP.Language.Ast.NodeKind.RecordExpression,
-                    PQP.Language.Ast.NodeKind.RecordLiteral,
-                    PQP.Language.Ast.NodeKind.ListExpression,
-                    PQP.Language.Ast.NodeKind.ListLiteral,
-                    PQP.Language.Ast.NodeKind.InvokeExpression,
+                    Ast.NodeKind.RecordExpression,
+                    Ast.NodeKind.RecordLiteral,
+                    Ast.NodeKind.ListExpression,
+                    Ast.NodeKind.ListLiteral,
+                    Ast.NodeKind.InvokeExpression,
                 ],
             );
-            const arrayWrapper: PQP.Language.Ast.TArrayWrapper = PQP.Parser.NodeIdMapUtils.assertUnwrapArrayWrapperAst(
+            const arrayWrapper: Ast.TArrayWrapper = NodeIdMapUtils.assertUnboxArrayWrapperAst(
                 nodeIdMapCollection,
                 parent.id,
             );
@@ -291,7 +291,7 @@ function maybeFindAstNodes(nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
 }
 
 function maybeFindContext(
-    nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
+    nodeIdMapCollection: NodeIdMap.Collection,
     astNodeSearch: AstNodeSearch,
 ): PQP.Parser.ParseContext.TNode | undefined {
     if (astNodeSearch.maybeBestOnOrBeforeNode === undefined) {
@@ -316,39 +316,30 @@ function maybeFindContext(
 }
 
 function findIdentifierUnderPosition(
-    nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
+    nodeIdMapCollection: NodeIdMap.Collection,
     position: Position,
-    leaf: PQP.Parser.TXorNode,
-): PQP.Language.Ast.Identifier | PQP.Language.Ast.GeneralizedIdentifier | undefined {
-    if (PQP.Parser.XorNodeUtils.isContextXor(leaf)) {
+    leaf: TXorNode,
+): Ast.Identifier | Ast.GeneralizedIdentifier | undefined {
+    if (XorNodeUtils.isContextXor(leaf)) {
         return undefined;
     }
 
-    let identifier: PQP.Language.Ast.Identifier | PQP.Language.Ast.GeneralizedIdentifier;
+    let identifier: Ast.Identifier | Ast.GeneralizedIdentifier;
 
     // If closestLeaf is '@', then check if it's part of an IdentifierExpression.
-    if (
-        leaf.node.kind === PQP.Language.Ast.NodeKind.Constant &&
-        leaf.node.constantKind === PQP.Language.Constant.MiscConstantKind.AtSign
-    ) {
+    if (leaf.node.kind === Ast.NodeKind.Constant && leaf.node.constantKind === Constant.MiscConstantKind.AtSign) {
         const maybeParentId: number | undefined = nodeIdMapCollection.parentIdById.get(leaf.node.id);
         if (maybeParentId === undefined) {
             return undefined;
         }
         const parentId: number = maybeParentId;
 
-        const parent: PQP.Language.Ast.TNode = PQP.Parser.NodeIdMapUtils.assertUnwrapAst(
-            nodeIdMapCollection.astNodeById,
-            parentId,
-        );
-        if (parent.kind !== PQP.Language.Ast.NodeKind.IdentifierExpression) {
+        const parent: Ast.TNode = NodeIdMapUtils.assertUnboxAst(nodeIdMapCollection.astNodeById, parentId);
+        if (parent.kind !== Ast.NodeKind.IdentifierExpression) {
             return undefined;
         }
         identifier = parent.identifier;
-    } else if (
-        leaf.node.kind === PQP.Language.Ast.NodeKind.Identifier ||
-        leaf.node.kind === PQP.Language.Ast.NodeKind.GeneralizedIdentifier
-    ) {
+    } else if (leaf.node.kind === Ast.NodeKind.Identifier || leaf.node.kind === Ast.NodeKind.GeneralizedIdentifier) {
         identifier = leaf.node;
     } else {
         return undefined;

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteFieldAccess.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteFieldAccess.ts
@@ -217,9 +217,10 @@ function inspectFieldSelector(
     }
 
     const generalizedIdentifierId: number = childIds[1];
-    const generalizedIdentifierXor: PQP.Parser.TXorNode = PQP.Parser.NodeIdMapUtils.assertGetXor(
+    const generalizedIdentifierXor: PQP.Parser.XorNode<PQP.Language.Ast.GeneralizedIdentifier> = PQP.Parser.NodeIdMapUtils.assertGetXor(
         nodeIdMapCollection,
         generalizedIdentifierId,
+        PQP.Language.Ast.NodeKind.GeneralizedIdentifier,
     );
     Assert.isTrue(
         generalizedIdentifierXor.node.kind === PQP.Language.Ast.NodeKind.GeneralizedIdentifier,
@@ -228,7 +229,7 @@ function inspectFieldSelector(
 
     switch (generalizedIdentifierXor.kind) {
         case PQP.Parser.XorNodeKind.Ast: {
-            const generalizedIdentifier: PQP.Language.Ast.GeneralizedIdentifier = generalizedIdentifierXor.node as PQP.Language.Ast.GeneralizedIdentifier;
+            const generalizedIdentifier: PQP.Language.Ast.GeneralizedIdentifier = generalizedIdentifierXor.node;
             const isPositionInIdentifier: boolean = PositionUtils.isInAst(position, generalizedIdentifier, true, true);
             return {
                 isAutocompleteAllowed: isPositionInIdentifier,
@@ -241,11 +242,11 @@ function inspectFieldSelector(
             // TODO [Autocomplete]:
             // This doesn't take into account of generalized identifiers consisting of multiple tokens.
             // Eg. `foo[bar baz]` or `foo[#"bar baz"].
-            const openBracketConstant: PQP.Language.Ast.TNode = PQP.Parser.NodeIdMapUtils.assertGetChildAstByAttributeIndex(
+            const openBracketConstant: PQP.Language.Ast.TConstant = PQP.Parser.NodeIdMapUtils.assertUnwrapNthChildAsAst(
                 nodeIdMapCollection,
                 fieldSelector.node.id,
                 0,
-                [PQP.Language.Ast.NodeKind.Constant],
+                PQP.Language.Ast.NodeKind.Constant,
             );
             const maybeNextTokenPosition: PQP.Language.Token.TokenPosition =
                 lexerSnapshot.tokens[openBracketConstant.tokenRange.tokenIndexEnd + 1]?.positionStart;

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteFieldAccess.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteFieldAccess.ts
@@ -217,7 +217,7 @@ function inspectFieldSelector(
     }
 
     const generalizedIdentifierId: number = childIds[1];
-    const generalizedIdentifierXor: PQP.Parser.XorNode<PQP.Language.Ast.GeneralizedIdentifier> = PQP.Parser.NodeIdMapUtils.assertGetXor(
+    const generalizedIdentifierXor: PQP.Parser.XorNode<PQP.Language.Ast.GeneralizedIdentifier> = PQP.Parser.NodeIdMapUtils.assertGetXorChecked(
         nodeIdMapCollection,
         generalizedIdentifierId,
         PQP.Language.Ast.NodeKind.GeneralizedIdentifier,
@@ -242,7 +242,7 @@ function inspectFieldSelector(
             // TODO [Autocomplete]:
             // This doesn't take into account of generalized identifiers consisting of multiple tokens.
             // Eg. `foo[bar baz]` or `foo[#"bar baz"].
-            const openBracketConstant: PQP.Language.Ast.TConstant = PQP.Parser.NodeIdMapUtils.assertUnwrapNthChildAsAst(
+            const openBracketConstant: PQP.Language.Ast.TConstant = PQP.Parser.NodeIdMapUtils.assertUnwrapNthChildAsAstChecked(
                 nodeIdMapCollection,
                 fieldSelector.node.id,
                 0,

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteFieldAccess.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteFieldAccess.ts
@@ -3,7 +3,18 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
-import { Assert } from "@microsoft/powerquery-parser";
+import { Assert, ResultUtils } from "@microsoft/powerquery-parser";
+import { Ast, Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import {
+    AncestryUtils,
+    NodeIdMap,
+    NodeIdMapIterator,
+    NodeIdMapUtils,
+    TXorNode,
+    XorNode,
+    XorNodeUtils,
+} from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
+
 import type { Position } from "vscode-languageserver-types";
 
 import { PositionUtils } from "../..";
@@ -21,24 +32,21 @@ export function tryAutocompleteFieldAccess(
     typeCache: TypeCache,
 ): TriedAutocompleteFieldAccess {
     if (!ActiveNodeUtils.isPositionInBounds(maybeActiveNode)) {
-        return PQP.ResultUtils.createOk(undefined);
+        return ResultUtils.boxOk(undefined);
     }
 
-    return PQP.ResultUtils.ensureResult(settings.locale, () => {
+    return ResultUtils.ensureResult(settings.locale, () => {
         return autocompleteFieldAccess(settings, parseState, maybeActiveNode, typeCache);
     });
 }
 
-const AllowedExtendedTypeKindsForFieldEntries: ReadonlyArray<PQP.Language.Type.ExtendedTypeKind> = [
-    PQP.Language.Type.ExtendedTypeKind.AnyUnion,
-    PQP.Language.Type.ExtendedTypeKind.DefinedRecord,
-    PQP.Language.Type.ExtendedTypeKind.DefinedTable,
+const AllowedExtendedTypeKindsForFieldEntries: ReadonlyArray<Type.ExtendedTypeKind> = [
+    Type.ExtendedTypeKind.AnyUnion,
+    Type.ExtendedTypeKind.DefinedRecord,
+    Type.ExtendedTypeKind.DefinedTable,
 ];
 
-const FieldAccessNodeKinds: ReadonlyArray<PQP.Language.Ast.NodeKind> = [
-    PQP.Language.Ast.NodeKind.FieldSelector,
-    PQP.Language.Ast.NodeKind.FieldProjection,
-];
+const FieldAccessNodeKinds: ReadonlyArray<Ast.NodeKind> = [Ast.NodeKind.FieldSelector, Ast.NodeKind.FieldProjection];
 
 function autocompleteFieldAccess(
     settings: InspectionSettings,
@@ -49,7 +57,7 @@ function autocompleteFieldAccess(
     let maybeInspectedFieldAccess: InspectedFieldAccess | undefined = undefined;
 
     // Option 1: Find a field access node in the ancestry.
-    let maybeFieldAccessAncestor: PQP.Parser.TXorNode | undefined;
+    let maybeFieldAccessAncestor: TXorNode | undefined;
     for (const ancestor of activeNode.ancestry) {
         if (FieldAccessNodeKinds.includes(ancestor.node.kind)) {
             maybeFieldAccessAncestor = ancestor;
@@ -77,26 +85,24 @@ function autocompleteFieldAccess(
         return undefined;
     }
 
-    // After a field access was found then find the field it's accessing and inspect the field's PQP.Language.type.
+    // After a field access was found then find the field it's accessing and inspect the field's Type.
     // This is delayed until after the field access because running static type analysis on an
     // arbitrary field could be costly.
-    const nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection = parseState.contextState.nodeIdMapCollection;
-    const maybeField: PQP.Parser.TXorNode | undefined = maybeTypablePrimaryExpression(nodeIdMapCollection, activeNode);
+    const nodeIdMapCollection: NodeIdMap.Collection = parseState.contextState.nodeIdMapCollection;
+    const maybeField: TXorNode | undefined = maybeTypablePrimaryExpression(nodeIdMapCollection, activeNode);
     if (maybeField === undefined) {
         return undefined;
     }
-    const field: PQP.Parser.TXorNode = maybeField;
+    const field: TXorNode = maybeField;
 
     const triedFieldType: TriedType = tryType(settings, nodeIdMapCollection, field.node.id, typeCache);
-    if (PQP.ResultUtils.isError(triedFieldType)) {
+    if (ResultUtils.isError(triedFieldType)) {
         throw triedFieldType.error;
     }
-    const fieldType: PQP.Language.Type.TPowerQueryType = triedFieldType.value;
+    const fieldType: Type.TPowerQueryType = triedFieldType.value;
 
     // We can only autocomplete a field access if we know what fields are present.
-    const fieldEntries: ReadonlyArray<[string, PQP.Language.Type.TPowerQueryType]> = fieldEntriesFromFieldType(
-        fieldType,
-    );
+    const fieldEntries: ReadonlyArray<[string, Type.TPowerQueryType]> = fieldEntriesFromFieldType(fieldType);
     if (fieldEntries.length === 0) {
         return undefined;
     }
@@ -109,12 +115,10 @@ function autocompleteFieldAccess(
     };
 }
 
-function fieldEntriesFromFieldType(
-    type: PQP.Language.Type.TPowerQueryType,
-): ReadonlyArray<[string, PQP.Language.Type.TPowerQueryType]> {
+function fieldEntriesFromFieldType(type: Type.TPowerQueryType): ReadonlyArray<[string, Type.TPowerQueryType]> {
     switch (type.maybeExtendedKind) {
-        case PQP.Language.Type.ExtendedTypeKind.AnyUnion: {
-            let fields: [string, PQP.Language.Type.TPowerQueryType][] = [];
+        case Type.ExtendedTypeKind.AnyUnion: {
+            let fields: [string, Type.TPowerQueryType][] = [];
             for (const field of type.unionedTypePairs) {
                 if (
                     field.maybeExtendedKind &&
@@ -127,8 +131,8 @@ function fieldEntriesFromFieldType(
             return fields;
         }
 
-        case PQP.Language.Type.ExtendedTypeKind.DefinedRecord:
-        case PQP.Language.Type.ExtendedTypeKind.DefinedTable:
+        case Type.ExtendedTypeKind.DefinedRecord:
+        case Type.ExtendedTypeKind.DefinedTable:
             return [...type.fields.entries()];
 
         default:
@@ -138,15 +142,15 @@ function fieldEntriesFromFieldType(
 
 function inspectFieldAccess(
     lexerSnapshot: PQP.Lexer.LexerSnapshot,
-    nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
+    nodeIdMapCollection: NodeIdMap.Collection,
     position: Position,
-    fieldAccess: PQP.Parser.TXorNode,
+    fieldAccess: TXorNode,
 ): InspectedFieldAccess {
     switch (fieldAccess.node.kind) {
-        case PQP.Language.Ast.NodeKind.FieldProjection:
+        case Ast.NodeKind.FieldProjection:
             return inspectFieldProjection(lexerSnapshot, nodeIdMapCollection, position, fieldAccess);
 
-        case PQP.Language.Ast.NodeKind.FieldSelector:
+        case Ast.NodeKind.FieldSelector:
             return inspectFieldSelector(lexerSnapshot, nodeIdMapCollection, position, fieldAccess);
 
         default:
@@ -155,7 +159,7 @@ function inspectFieldAccess(
                 nodeKind: fieldAccess.node.kind,
             };
             throw new PQP.CommonError.InvariantError(
-                `fieldAccess should be either ${PQP.Language.Ast.NodeKind.FieldProjection} or ${PQP.Language.Ast.NodeKind.FieldSelector}`,
+                `fieldAccess should be either ${Ast.NodeKind.FieldProjection} or ${Ast.NodeKind.FieldSelector}`,
                 details,
             );
     }
@@ -163,18 +167,15 @@ function inspectFieldAccess(
 
 function inspectFieldProjection(
     lexerSnapshot: PQP.Lexer.LexerSnapshot,
-    nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
+    nodeIdMapCollection: NodeIdMap.Collection,
     position: Position,
-    fieldProjection: PQP.Parser.TXorNode,
+    fieldProjection: TXorNode,
 ): InspectedFieldAccess {
     let isAutocompleteAllowed: boolean = false;
-    let maybeIdentifierUnderPosition: PQP.Language.Ast.GeneralizedIdentifier | undefined;
+    let maybeIdentifierUnderPosition: Ast.GeneralizedIdentifier | undefined;
     const fieldNames: string[] = [];
 
-    for (const fieldSelector of PQP.Parser.NodeIdMapIterator.iterFieldProjection(
-        nodeIdMapCollection,
-        fieldProjection,
-    )) {
+    for (const fieldSelector of NodeIdMapIterator.iterFieldProjection(nodeIdMapCollection, fieldProjection)) {
         const inspectedFieldSelector: InspectedFieldAccess = inspectFieldSelector(
             lexerSnapshot,
             nodeIdMapCollection,
@@ -205,9 +206,9 @@ function createInspectedFieldAccess(isAutocompleteAllowed: boolean): InspectedFi
 
 function inspectFieldSelector(
     lexerSnapshot: PQP.Lexer.LexerSnapshot,
-    nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
+    nodeIdMapCollection: NodeIdMap.Collection,
     position: Position,
-    fieldSelector: PQP.Parser.TXorNode,
+    fieldSelector: TXorNode,
 ): InspectedFieldAccess {
     const childIds: ReadonlyArray<number> | undefined = nodeIdMapCollection.childIdsById.get(fieldSelector.node.id);
     if (childIds === undefined) {
@@ -217,19 +218,19 @@ function inspectFieldSelector(
     }
 
     const generalizedIdentifierId: number = childIds[1];
-    const generalizedIdentifierXor: PQP.Parser.XorNode<PQP.Language.Ast.GeneralizedIdentifier> = PQP.Parser.NodeIdMapUtils.assertGetXorChecked(
+    const generalizedIdentifierXor: XorNode<Ast.GeneralizedIdentifier> = NodeIdMapUtils.assertGetXorChecked(
         nodeIdMapCollection,
         generalizedIdentifierId,
-        PQP.Language.Ast.NodeKind.GeneralizedIdentifier,
+        Ast.NodeKind.GeneralizedIdentifier,
     );
     Assert.isTrue(
-        generalizedIdentifierXor.node.kind === PQP.Language.Ast.NodeKind.GeneralizedIdentifier,
-        "generalizedIdentifier.node.kind === PQP.Language.Ast.NodeKind.GeneralizedIdentifier",
+        generalizedIdentifierXor.node.kind === Ast.NodeKind.GeneralizedIdentifier,
+        "generalizedIdentifier.node.kind === Ast.NodeKind.GeneralizedIdentifier",
     );
 
     switch (generalizedIdentifierXor.kind) {
         case PQP.Parser.XorNodeKind.Ast: {
-            const generalizedIdentifier: PQP.Language.Ast.GeneralizedIdentifier = generalizedIdentifierXor.node;
+            const generalizedIdentifier: Ast.GeneralizedIdentifier = generalizedIdentifierXor.node;
             const isPositionInIdentifier: boolean = PositionUtils.isInAst(position, generalizedIdentifier, true, true);
             return {
                 isAutocompleteAllowed: isPositionInIdentifier,
@@ -242,11 +243,11 @@ function inspectFieldSelector(
             // TODO [Autocomplete]:
             // This doesn't take into account of generalized identifiers consisting of multiple tokens.
             // Eg. `foo[bar baz]` or `foo[#"bar baz"].
-            const openBracketConstant: PQP.Language.Ast.TConstant = PQP.Parser.NodeIdMapUtils.assertUnwrapNthChildAsAstChecked(
+            const openBracketConstant: Ast.TConstant = NodeIdMapUtils.assertUnboxNthChildAsAstChecked(
                 nodeIdMapCollection,
                 fieldSelector.node.id,
                 0,
-                PQP.Language.Ast.NodeKind.Constant,
+                Ast.NodeKind.Constant,
             );
             const maybeNextTokenPosition: PQP.Language.Token.TokenPosition =
                 lexerSnapshot.tokens[openBracketConstant.tokenRange.tokenIndexEnd + 1]?.positionStart;
@@ -265,12 +266,12 @@ function inspectFieldSelector(
         }
 
         default:
-            throw PQP.Assert.isNever(generalizedIdentifierXor);
+            throw Assert.isNever(generalizedIdentifierXor);
     }
 }
 
 function createAutocompleteItems(
-    fieldEntries: ReadonlyArray<[string, PQP.Language.Type.TPowerQueryType]>,
+    fieldEntries: ReadonlyArray<[string, Type.TPowerQueryType]>,
     inspectedFieldAccess: InspectedFieldAccess,
 ): ReadonlyArray<AutocompleteItem> {
     const fieldAccessNames: ReadonlyArray<string> = inspectedFieldAccess.fieldNames;
@@ -292,23 +293,20 @@ function createAutocompleteItems(
 }
 
 function maybeTypablePrimaryExpression(
-    nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
+    nodeIdMapCollection: NodeIdMap.Collection,
     activeNode: ActiveNode,
-): PQP.Parser.TXorNode | undefined {
-    const ancestry: ReadonlyArray<PQP.Parser.TXorNode> = activeNode.ancestry;
+): TXorNode | undefined {
+    const ancestry: ReadonlyArray<TXorNode> = activeNode.ancestry;
     const numAncestors: number = ancestry.length;
 
-    let maybeContiguousPrimaryExpression: PQP.Parser.TXorNode | undefined;
+    let maybeContiguousPrimaryExpression: TXorNode | undefined;
     let matchingContiguousPrimaryExpression: boolean = true;
     for (let index: number = 0; index < numAncestors; index += 1) {
-        const xorNode: PQP.Parser.TXorNode = ancestry[index];
+        const xorNode: TXorNode = ancestry[index];
 
-        if (xorNode.node.kind === PQP.Language.Ast.NodeKind.RecursivePrimaryExpression) {
+        if (xorNode.node.kind === Ast.NodeKind.RecursivePrimaryExpression) {
             // The previous ancestor must be an attribute of Rpe, which is either its head or ArrrayWrapper.
-            const xorNodeBeforeRpe: PQP.Parser.TXorNode = PQP.Parser.AncestryUtils.assertGetNthPreviousXor(
-                ancestry,
-                index,
-            );
+            const xorNodeBeforeRpe: TXorNode = AncestryUtils.assertGetNthPreviousXor(ancestry, index);
 
             // If we're coming from the head node,
             // then return undefined as there can be no nodes before the head ode.
@@ -318,25 +316,21 @@ function maybeTypablePrimaryExpression(
             // Else if we're coming from the ArrayWrapper,
             // then grab the previous sibling.
             else if (xorNodeBeforeRpe.node.maybeAttributeIndex === 1) {
-                const rpeChild: PQP.Parser.TXorNode = PQP.Parser.AncestryUtils.assertGetNthPreviousXor(
-                    ancestry,
-                    index,
-                    2,
-                );
-                return PQP.Parser.NodeIdMapUtils.assertGetRecursiveExpressionPreviousSibling(
+                const rpeChild: TXorNode = AncestryUtils.assertGetNthPreviousXor(ancestry, index, 2);
+                return NodeIdMapUtils.assertGetRecursiveExpressionPreviousSibling(
                     nodeIdMapCollection,
                     rpeChild.node.id,
                 );
             } else {
                 throw new PQP.CommonError.InvariantError(
-                    `the child of a ${PQP.Language.Ast.NodeKind.RecursivePrimaryExpression} should have an attribute index of either 1 or 2`,
+                    `the child of a ${Ast.NodeKind.RecursivePrimaryExpression} should have an attribute index of either 1 or 2`,
                     {
                         parentId: xorNode.node.id,
                         childId: xorNodeBeforeRpe.node.id,
                     },
                 );
             }
-        } else if (matchingContiguousPrimaryExpression && PQP.Parser.XorNodeUtils.isTPrimaryExpression(xorNode)) {
+        } else if (matchingContiguousPrimaryExpression && XorNodeUtils.isTPrimaryExpression(xorNode)) {
             maybeContiguousPrimaryExpression = xorNode;
         } else {
             matchingContiguousPrimaryExpression = false;

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteItem/autocompleteItem.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteItem/autocompleteItem.ts
@@ -1,11 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
-
+import { Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 import { CompletionItem } from "vscode-languageserver-types";
 
 export interface AutocompleteItem extends CompletionItem {
     readonly jaroWinklerScore: number;
-    readonly powerQueryType: PQP.Language.Type.TPowerQueryType;
+    readonly powerQueryType: Type.TPowerQueryType;
 }

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteItem/autocompleteItemUtils.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteItem/autocompleteItemUtils.ts
@@ -3,6 +3,9 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { Assert } from "@microsoft/powerquery-parser";
+import { Constant, Keyword, Type, TypeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { XorNodeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 import { CompletionItemKind } from "vscode-languageserver-types";
 
 import { Inspection } from "../../..";
@@ -12,7 +15,7 @@ import type { AutocompleteItem } from "./autocompleteItem";
 
 export function createFromFieldAccess(
     label: string,
-    powerQueryType: PQP.Language.Type.TPowerQueryType,
+    powerQueryType: Type.TPowerQueryType,
     maybeOther?: string,
 ): AutocompleteItem {
     const jaroWinklerScore: number = maybeOther !== undefined ? calculateJaroWinkler(label, maybeOther) : 1;
@@ -30,19 +33,19 @@ export function createFromFieldAccess(
     };
 }
 
-export function createFromKeywordKind(label: PQP.Language.Keyword.KeywordKind, maybeOther?: string): AutocompleteItem {
+export function createFromKeywordKind(label: Keyword.KeywordKind, maybeOther?: string): AutocompleteItem {
     const jaroWinklerScore: number = maybeOther !== undefined ? calculateJaroWinkler(label, maybeOther) : 1;
 
     return {
         jaroWinklerScore,
         kind: CompletionItemKind.Keyword,
         label,
-        powerQueryType: PQP.Language.Type.NotApplicableInstance,
+        powerQueryType: Type.NotApplicableInstance,
     };
 }
 
 export function createFromLanguageConstantKind(
-    label: PQP.Language.Constant.LanguageConstantKind,
+    label: Constant.LanguageConstantKind,
     maybeOther?: string,
 ): AutocompleteItem {
     const jaroWinklerScore: number = maybeOther !== undefined ? calculateJaroWinkler(label, maybeOther) : 1;
@@ -51,7 +54,7 @@ export function createFromLanguageConstantKind(
         jaroWinklerScore,
         kind: CompletionItemKind.Keyword,
         label,
-        powerQueryType: PQP.Language.Type.NotApplicableInstance,
+        powerQueryType: Type.NotApplicableInstance,
     };
 }
 
@@ -71,7 +74,7 @@ export function createFromLibraryDefinition(
 }
 
 export function createFromPrimitiveTypeConstantKind(
-    label: PQP.Language.Constant.PrimitiveTypeConstantKind,
+    label: Constant.PrimitiveTypeConstantKind,
     maybeOther?: string,
 ): AutocompleteItem {
     const jaroWinklerScore: number = maybeOther !== undefined ? calculateJaroWinkler(label, maybeOther) : 1;
@@ -80,9 +83,9 @@ export function createFromPrimitiveTypeConstantKind(
         jaroWinklerScore,
         kind: CompletionItemKind.Keyword,
         label,
-        powerQueryType: PQP.Language.TypeUtils.createPrimitiveType(
-            label === PQP.Language.Constant.PrimitiveTypeConstantKind.Null,
-            PQP.Language.TypeUtils.typeKindFromPrimitiveTypeConstantKind(label),
+        powerQueryType: TypeUtils.createPrimitiveType(
+            label === Constant.PrimitiveTypeConstantKind.Null,
+            TypeUtils.typeKindFromPrimitiveTypeConstantKind(label),
         ),
     };
 }
@@ -90,7 +93,7 @@ export function createFromPrimitiveTypeConstantKind(
 export function maybeCreateFromScopeItem(
     label: string,
     scopeItem: Inspection.TScopeItem,
-    powerQueryType: PQP.Language.Type.TPowerQueryType,
+    powerQueryType: Type.TPowerQueryType,
     maybeOther?: string,
 ): AutocompleteItem | undefined {
     switch (scopeItem.kind) {
@@ -113,7 +116,7 @@ export function maybeCreateFromScopeItem(
         }
 
         case Inspection.ScopeItemKind.Undefined: {
-            if (scopeItem.xorNode.kind !== PQP.Parser.XorNodeKind.Ast) {
+            if (XorNodeUtils.isContextXor(scopeItem.xorNode)) {
                 return undefined;
             }
 
@@ -121,7 +124,7 @@ export function maybeCreateFromScopeItem(
         }
 
         default:
-            throw PQP.Assert.isNever(scopeItem);
+            throw Assert.isNever(scopeItem);
     }
 
     const jaroWinklerScore: number = maybeOther !== undefined ? calculateJaroWinkler(label, maybeOther) : 1;

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordDefault.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordDefault.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
+import { Ast, Keyword } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { TXorNode, XorNodeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
 import { PositionUtils } from "../../..";
 import { ActiveNode, ActiveNodeLeafKind } from "../../activeNode";
@@ -9,15 +10,15 @@ import { InspectAutocompleteKeywordState } from "./commonTypes";
 
 export function autocompleteKeywordDefault(
     state: InspectAutocompleteKeywordState,
-): ReadonlyArray<PQP.Language.Keyword.KeywordKind> | undefined {
+): ReadonlyArray<Keyword.KeywordKind> | undefined {
     const activeNode: ActiveNode = state.activeNode;
-    const child: PQP.Parser.TXorNode = state.child;
+    const child: TXorNode = state.child;
     const key: string = createMapKey(state.parent.node.kind, child.node.maybeAttributeIndex);
 
     if (AutocompleteExpressionKeys.indexOf(key) !== -1) {
         return autocompleteDefaultExpression(state);
     } else {
-        const maybeMappedKeywordKind: PQP.Language.Keyword.KeywordKind | undefined = AutocompleteConstantMap.get(key);
+        const maybeMappedKeywordKind: Keyword.KeywordKind | undefined = AutocompleteConstantMap.get(key);
         return maybeMappedKeywordKind !== undefined
             ? autocompleteKeywordConstant(activeNode, child, maybeMappedKeywordKind)
             : undefined;
@@ -25,75 +26,71 @@ export function autocompleteKeywordDefault(
 }
 
 const AutocompleteExpressionKeys: ReadonlyArray<string> = [
-    createMapKey(PQP.Language.Ast.NodeKind.ErrorRaisingExpression, 1),
-    createMapKey(PQP.Language.Ast.NodeKind.GeneralizedIdentifierPairedExpression, 2),
-    createMapKey(PQP.Language.Ast.NodeKind.FunctionExpression, 3),
-    createMapKey(PQP.Language.Ast.NodeKind.IdentifierPairedExpression, 2),
-    createMapKey(PQP.Language.Ast.NodeKind.IfExpression, 1),
-    createMapKey(PQP.Language.Ast.NodeKind.IfExpression, 3),
-    createMapKey(PQP.Language.Ast.NodeKind.IfExpression, 5),
-    createMapKey(PQP.Language.Ast.NodeKind.InvokeExpression, 1),
-    createMapKey(PQP.Language.Ast.NodeKind.LetExpression, 3),
-    createMapKey(PQP.Language.Ast.NodeKind.ListExpression, 1),
-    createMapKey(PQP.Language.Ast.NodeKind.OtherwiseExpression, 1),
-    createMapKey(PQP.Language.Ast.NodeKind.ParenthesizedExpression, 1),
+    createMapKey(Ast.NodeKind.ErrorRaisingExpression, 1),
+    createMapKey(Ast.NodeKind.GeneralizedIdentifierPairedExpression, 2),
+    createMapKey(Ast.NodeKind.FunctionExpression, 3),
+    createMapKey(Ast.NodeKind.IdentifierPairedExpression, 2),
+    createMapKey(Ast.NodeKind.IfExpression, 1),
+    createMapKey(Ast.NodeKind.IfExpression, 3),
+    createMapKey(Ast.NodeKind.IfExpression, 5),
+    createMapKey(Ast.NodeKind.InvokeExpression, 1),
+    createMapKey(Ast.NodeKind.LetExpression, 3),
+    createMapKey(Ast.NodeKind.ListExpression, 1),
+    createMapKey(Ast.NodeKind.OtherwiseExpression, 1),
+    createMapKey(Ast.NodeKind.ParenthesizedExpression, 1),
 ];
 
 // If we're coming from a constant then we can quickly evaluate using a map.
 // This is possible because reading a Constant is binary.
 // Either the Constant was read and you're in the next context, or you didn't and you're in the constant's context.
-const AutocompleteConstantMap: Map<string, PQP.Language.Keyword.KeywordKind> = new Map<
-    string,
-    PQP.Language.Keyword.KeywordKind
->([
+const AutocompleteConstantMap: Map<string, Keyword.KeywordKind> = new Map<string, Keyword.KeywordKind>([
     // Ast.NodeKind.ErrorRaisingExpression
-    [createMapKey(PQP.Language.Ast.NodeKind.ErrorRaisingExpression, 0), PQP.Language.Keyword.KeywordKind.Error],
+    [createMapKey(Ast.NodeKind.ErrorRaisingExpression, 0), Keyword.KeywordKind.Error],
 
     // Ast.NodeKind.IfExpression
-    [createMapKey(PQP.Language.Ast.NodeKind.IfExpression, 0), PQP.Language.Keyword.KeywordKind.If],
-    [createMapKey(PQP.Language.Ast.NodeKind.IfExpression, 2), PQP.Language.Keyword.KeywordKind.Then],
-    [createMapKey(PQP.Language.Ast.NodeKind.IfExpression, 4), PQP.Language.Keyword.KeywordKind.Else],
+    [createMapKey(Ast.NodeKind.IfExpression, 0), Keyword.KeywordKind.If],
+    [createMapKey(Ast.NodeKind.IfExpression, 2), Keyword.KeywordKind.Then],
+    [createMapKey(Ast.NodeKind.IfExpression, 4), Keyword.KeywordKind.Else],
 
     // Ast.NodeKind.LetExpression
-    [createMapKey(PQP.Language.Ast.NodeKind.LetExpression, 2), PQP.Language.Keyword.KeywordKind.In],
+    [createMapKey(Ast.NodeKind.LetExpression, 2), Keyword.KeywordKind.In],
 
     // Ast.NodeKind.OtherwiseExpression
-    [createMapKey(PQP.Language.Ast.NodeKind.OtherwiseExpression, 0), PQP.Language.Keyword.KeywordKind.Otherwise],
+    [createMapKey(Ast.NodeKind.OtherwiseExpression, 0), Keyword.KeywordKind.Otherwise],
 
     // Ast.NodeKind.Section
-    [createMapKey(PQP.Language.Ast.NodeKind.Section, 1), PQP.Language.Keyword.KeywordKind.Section],
+    [createMapKey(Ast.NodeKind.Section, 1), Keyword.KeywordKind.Section],
 ]);
 
 function autocompleteDefaultExpression(
     state: InspectAutocompleteKeywordState,
-): ReadonlyArray<PQP.Language.Keyword.KeywordKind> | undefined {
+): ReadonlyArray<Keyword.KeywordKind> | undefined {
     const activeNode: ActiveNode = state.activeNode;
-    const child: PQP.Parser.TXorNode = state.child;
+    const child: TXorNode = state.child;
 
     // '[x=|1]
     if (activeNode.leafKind === ActiveNodeLeafKind.ShiftedRight) {
-        return PQP.Language.Keyword.ExpressionKeywordKinds;
+        return Keyword.ExpressionKeywordKinds;
     }
     // `if 1|`
     else if (
-        child.kind === PQP.Parser.XorNodeKind.Ast &&
-        child.node.kind === PQP.Language.Ast.NodeKind.LiteralExpression &&
-        child.node.literalKind === PQP.Language.Ast.LiteralKind.Numeric
+        XorNodeUtils.isAstXorChecked<Ast.LiteralExpression>(child, Ast.NodeKind.LiteralExpression) &&
+        child.node.literalKind === Ast.LiteralKind.Numeric
     ) {
         return [];
     }
 
-    return PQP.Language.Keyword.ExpressionKeywordKinds;
+    return Keyword.ExpressionKeywordKinds;
 }
 
 function autocompleteKeywordConstant(
     activeNode: ActiveNode,
-    child: PQP.Parser.TXorNode,
-    keywordKind: PQP.Language.Keyword.KeywordKind,
-): ReadonlyArray<PQP.Language.Keyword.KeywordKind> | undefined {
+    child: TXorNode,
+    keywordKind: Keyword.KeywordKind,
+): ReadonlyArray<Keyword.KeywordKind> | undefined {
     if (PositionUtils.isBeforeXor(activeNode.position, child, false)) {
         return undefined;
-    } else if (child.kind === PQP.Parser.XorNodeKind.Ast) {
+    } else if (XorNodeUtils.isAstXor(child)) {
         // So long as you're inside of an Ast Constant there's nothing that can be recommended other than the constant.
         // Note that we previously checked isBeforeXorNode so we can use the quicker isOnAstNodeEnd to check
         // if we're inside of the Ast node.
@@ -106,6 +103,6 @@ function autocompleteKeywordConstant(
 // A tuple can't easily be used as a Map key as it does a shallow comparison.
 // The work around is to stringify the tuple key, even though we lose typing by doing so.
 // [parent XorNode.node.kind, child XorNode.node.maybeAttributeIndex].join(",")
-function createMapKey(nodeKind: PQP.Language.Ast.NodeKind, maybeAttributeIndex: number | undefined): string {
+function createMapKey(nodeKind: Ast.NodeKind, maybeAttributeIndex: number | undefined): string {
     return [nodeKind, maybeAttributeIndex].join(",");
 }

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordErrorHandlingExpression.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordErrorHandlingExpression.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
+import { Keyword, Token } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { TXorNode, XorNodeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
 import type { Position } from "vscode-languageserver-types";
 
@@ -11,14 +12,14 @@ import { InspectAutocompleteKeywordState } from "./commonTypes";
 
 export function autocompleteKeywordErrorHandlingExpression(
     state: InspectAutocompleteKeywordState,
-): ReadonlyArray<PQP.Language.Keyword.KeywordKind> | undefined {
+): ReadonlyArray<Keyword.KeywordKind> | undefined {
     const position: Position = state.activeNode.position;
-    const child: PQP.Parser.TXorNode = state.child;
+    const child: TXorNode = state.child;
     const maybeTrailingText: TrailingToken | undefined = state.maybeTrailingToken;
 
     const maybeChildAttributeIndex: number | undefined = child.node.maybeAttributeIndex;
     if (maybeChildAttributeIndex === 0) {
-        return [PQP.Language.Keyword.KeywordKind.Try];
+        return [Keyword.KeywordKind.Try];
     } else if (maybeChildAttributeIndex === 1) {
         // 'try true o|' creates a ParseError.
         // It's ambiguous if the next token should be either 'otherwise' or 'or'.
@@ -27,21 +28,21 @@ export function autocompleteKeywordErrorHandlingExpression(
 
             // First we test if we can autocomplete using the error token.
             if (
-                trailingToken.kind === PQP.Language.Token.TokenKind.Identifier &&
+                trailingToken.kind === Token.TokenKind.Identifier &&
                 PositionUtils.isInToken(position, trailingToken, false, true)
             ) {
                 const tokenData: string = maybeTrailingText.data;
 
                 // If we can exclude 'or' then the only thing we can autocomplete is 'otherwise'.
-                if (tokenData.length > 1 && PQP.Language.Keyword.KeywordKind.Otherwise.startsWith(tokenData)) {
-                    return [PQP.Language.Keyword.KeywordKind.Otherwise];
+                if (tokenData.length > 1 && Keyword.KeywordKind.Otherwise.startsWith(tokenData)) {
+                    return [Keyword.KeywordKind.Otherwise];
                 }
                 // In the ambiguous case we don't know what they're typing yet, so we suggest both.
                 // In the case of an identifier that doesn't match a 'or' or 'otherwise'
                 // we still suggest the only valid keywords allowed.
                 // In both cases the return is the same.
                 else {
-                    return [PQP.Language.Keyword.KeywordKind.Or, PQP.Language.Keyword.KeywordKind.Otherwise];
+                    return [Keyword.KeywordKind.Or, Keyword.KeywordKind.Otherwise];
                 }
             }
 
@@ -49,10 +50,10 @@ export function autocompleteKeywordErrorHandlingExpression(
             else {
                 return undefined;
             }
-        } else if (child.kind === PQP.Parser.XorNodeKind.Ast && PositionUtils.isAfterAst(position, child.node, true)) {
-            return [PQP.Language.Keyword.KeywordKind.Otherwise];
+        } else if (XorNodeUtils.isAstXor(child) && PositionUtils.isAfterAst(position, child.node, true)) {
+            return [Keyword.KeywordKind.Otherwise];
         } else {
-            return PQP.Language.Keyword.ExpressionKeywordKinds;
+            return Keyword.ExpressionKeywordKinds;
         }
     } else {
         return undefined;

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordIdentifierPairedExpression.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordIdentifierPairedExpression.ts
@@ -15,9 +15,11 @@ export function autocompleteKeywordIdentifierPairedExpression(
     // `section; [] |`
     if (
         childAttributeIndex === 0 &&
-        PQP.Parser.AncestryUtils.maybeNextXor(state.activeNode.ancestry, state.ancestryIndex, [
+        PQP.Parser.AncestryUtils.maybeNextXorChecked(
+            state.activeNode.ancestry,
+            state.ancestryIndex,
             PQP.Language.Ast.NodeKind.SectionMember,
-        ])
+        )
     ) {
         return [PQP.Language.Keyword.KeywordKind.Shared];
     } else if (childAttributeIndex !== 2) {

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordIdentifierPairedExpression.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordIdentifierPairedExpression.ts
@@ -1,38 +1,35 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
+import { Ast, Keyword } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { AncestryUtils, NodeIdMapUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
 import { PositionUtils } from "../../..";
 import { InspectAutocompleteKeywordState } from "./commonTypes";
 
 export function autocompleteKeywordIdentifierPairedExpression(
     state: InspectAutocompleteKeywordState,
-): ReadonlyArray<PQP.Language.Keyword.KeywordKind> | undefined {
+): ReadonlyArray<Keyword.KeywordKind> | undefined {
     const childAttributeIndex: number | undefined = state.child.node.maybeAttributeIndex;
 
     // `section; s|`
     // `section; [] |`
     if (
         childAttributeIndex === 0 &&
-        PQP.Parser.AncestryUtils.maybeNextXorChecked(
-            state.activeNode.ancestry,
-            state.ancestryIndex,
-            PQP.Language.Ast.NodeKind.SectionMember,
-        )
+        AncestryUtils.maybeNextXorChecked(state.activeNode.ancestry, state.ancestryIndex, Ast.NodeKind.SectionMember)
     ) {
-        return [PQP.Language.Keyword.KeywordKind.Shared];
+        return [Keyword.KeywordKind.Shared];
     } else if (childAttributeIndex !== 2) {
         return [];
     }
-    const maybeLeaf: PQP.Language.Ast.TNode | undefined = PQP.Parser.NodeIdMapUtils.maybeLeftMostLeaf(
+    const maybeLeaf: Ast.TNode | undefined = NodeIdMapUtils.maybeLeftMostLeaf(
         state.nodeIdMapCollection,
         state.child.node.id,
     );
     // `x = |`
     // `x = |1`
     if (maybeLeaf === undefined || PositionUtils.isBeforeAst(state.activeNode.position, maybeLeaf, false)) {
-        return PQP.Language.Keyword.ExpressionKeywordKinds;
+        return Keyword.ExpressionKeywordKinds;
     } else {
         return undefined;
     }

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordLetExpression.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordLetExpression.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
+import { Keyword } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { NodeIdMapIterator, TXorNode, XorNodeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
 import { PositionUtils } from "../../..";
 import { autocompleteKeywordDefault } from "./autocompleteKeywordDefault";
@@ -11,25 +12,28 @@ import { InspectAutocompleteKeywordState } from "./commonTypes";
 
 export function autocompleteKeywordLetExpression(
     state: InspectAutocompleteKeywordState,
-): ReadonlyArray<PQP.Language.Keyword.KeywordKind> | undefined {
+): ReadonlyArray<Keyword.KeywordKind> | undefined {
     // LetExpressions can trigger another inspection which will always hit the same LetExpression.
     // Make sure that it doesn't trigger an infinite recursive call.
-    const child: PQP.Parser.TXorNode = state.child;
-    let maybeInspected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> | undefined;
+    const child: TXorNode = state.child;
+    let maybeInspected: ReadonlyArray<Keyword.KeywordKind> | undefined;
 
     // Might be either `in` or whatever the autocomplete is for the the last child of the variableList.
     // `let x = 1 |`
-    if (child.node.maybeAttributeIndex === 2 && child.kind === PQP.Parser.XorNodeKind.Context) {
+    if (child.node.maybeAttributeIndex === 2 && XorNodeUtils.isContextXor(child)) {
         maybeInspected = autocompleteLastKeyValuePair(
             state,
-            PQP.Parser.NodeIdMapIterator.iterLetExpression(state.nodeIdMapCollection, state.parent),
+            NodeIdMapIterator.iterLetExpression(
+                state.nodeIdMapCollection,
+                XorNodeUtils.assertAsLetExpression(state.parent),
+            ),
         );
         if (state.maybeTrailingToken !== undefined) {
             if (state.maybeTrailingToken.isInOrOnPosition === true) {
                 // We don't want maybeInspected to be zero legnth.
                 // It's either undefined or non-zero length.
                 maybeInspected = autocompleteKeywordTrailingText(maybeInspected ?? [], state.maybeTrailingToken, [
-                    PQP.Language.Keyword.KeywordKind.In,
+                    Keyword.KeywordKind.In,
                 ]);
                 return maybeInspected.length ? maybeInspected : undefined;
             } else if (
@@ -39,14 +43,12 @@ export function autocompleteKeywordLetExpression(
                     true,
                 )
             ) {
-                return maybeInspected !== undefined
-                    ? [...maybeInspected, PQP.Language.Keyword.KeywordKind.In]
-                    : maybeInspected;
+                return maybeInspected !== undefined ? [...maybeInspected, Keyword.KeywordKind.In] : maybeInspected;
             }
         } else {
             return maybeInspected !== undefined
-                ? [...maybeInspected, PQP.Language.Keyword.KeywordKind.In]
-                : [PQP.Language.Keyword.KeywordKind.In];
+                ? [...maybeInspected, Keyword.KeywordKind.In]
+                : [Keyword.KeywordKind.In];
         }
     }
 
@@ -55,14 +57,14 @@ export function autocompleteKeywordLetExpression(
 
 function autocompleteLastKeyValuePair(
     state: InspectAutocompleteKeywordState,
-    keyValuePairs: ReadonlyArray<PQP.Parser.NodeIdMapIterator.TKeyValuePair>,
-): ReadonlyArray<PQP.Language.Keyword.KeywordKind> | undefined {
+    keyValuePairs: ReadonlyArray<NodeIdMapIterator.TKeyValuePair>,
+): ReadonlyArray<Keyword.KeywordKind> | undefined {
     if (keyValuePairs.length === 0) {
         return undefined;
     }
 
     // Grab the last value (if one exists)
-    const maybeLastValue: PQP.Parser.TXorNode | undefined = keyValuePairs[keyValuePairs.length - 1].maybeValue;
+    const maybeLastValue: TXorNode | undefined = keyValuePairs[keyValuePairs.length - 1].maybeValue;
     if (maybeLastValue === undefined) {
         return undefined;
     }

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordListExpression.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordListExpression.ts
@@ -30,7 +30,6 @@ export function autocompleteKeywordListExpression(
         activeNode.ancestry,
         ancestryIndex,
         3,
-        undefined,
     );
     if (nodeOrComma.node.maybeAttributeIndex !== 0) {
         return undefined;
@@ -40,7 +39,7 @@ export function autocompleteKeywordListExpression(
     // but we have to drill down one more level if it's a RangeExpression.
     const itemNode: PQP.Parser.TXorNode =
         nodeOrComma.node.kind === PQP.Language.Ast.NodeKind.RangeExpression
-            ? PQP.Parser.AncestryUtils.assertGetNthPreviousXor(activeNode.ancestry, ancestryIndex, 4, undefined)
+            ? PQP.Parser.AncestryUtils.assertGetNthPreviousXor(activeNode.ancestry, ancestryIndex, 4)
             : nodeOrComma;
 
     if (

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordSectionMember.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordSectionMember.ts
@@ -1,27 +1,29 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
+import { Ast, Keyword } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import {
+    AncestryUtils,
+    NodeIdMapUtils,
+    TXorNode,
+    XorNode,
+    XorNodeKind,
+} from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
 import { autocompleteKeywordRightMostLeaf } from "./common";
 import { InspectAutocompleteKeywordState } from "./commonTypes";
 
 export function autocompleteKeywordSectionMember(
     state: InspectAutocompleteKeywordState,
-): ReadonlyArray<PQP.Language.Keyword.KeywordKind> | undefined {
+): ReadonlyArray<Keyword.KeywordKind> | undefined {
     const maybeChildAttributeIndex: number | undefined = state.child.node.maybeAttributeIndex;
 
     // SectionMember.namePairedExpression
     if (maybeChildAttributeIndex === 2) {
         // A test for 'shared', which as we're on namePairedExpression we either parsed it or skipped it.
-        const maybeSharedConstant:
-            | PQP.Parser.XorNode<PQP.Language.Ast.TConstant>
-            | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChildChecked<PQP.Language.Ast.TConstant>(
-            state.nodeIdMapCollection,
-            state.parent.node.id,
-            1,
-            PQP.Language.Ast.NodeKind.Constant,
-        );
+        const maybeSharedConstant: XorNode<Ast.TConstant> | undefined = NodeIdMapUtils.maybeNthChildChecked<
+            Ast.TConstant
+        >(state.nodeIdMapCollection, state.parent.node.id, 1, Ast.NodeKind.Constant);
 
         // 'shared' was parsed so we can exit.
         if (maybeSharedConstant !== undefined) {
@@ -29,33 +31,33 @@ export function autocompleteKeywordSectionMember(
         }
 
         // SectionMember -> IdentifierPairedExpression -> Identifier
-        const maybeName: PQP.Parser.TXorNode | undefined = PQP.Parser.AncestryUtils.maybeNthPreviousXorChecked(
+        const maybeName: TXorNode | undefined = AncestryUtils.maybeNthPreviousXorChecked(
             state.activeNode.ancestry,
             state.ancestryIndex,
             2,
-            [PQP.Language.Ast.NodeKind.IdentifierPairedExpression, PQP.Language.Ast.NodeKind.Identifier],
+            [Ast.NodeKind.IdentifierPairedExpression, Ast.NodeKind.Identifier],
         );
 
         // Name hasn't been parsed yet so we can exit.
-        if (maybeName?.kind !== PQP.Parser.XorNodeKind.Ast) {
+        if (maybeName?.kind !== XorNodeKind.Ast) {
             return undefined;
         }
 
-        const name: PQP.Language.Ast.Identifier = maybeName.node as PQP.Language.Ast.Identifier;
-        if (PQP.Language.Keyword.KeywordKind.Shared.startsWith(name.literal)) {
-            return [PQP.Language.Keyword.KeywordKind.Shared];
+        const name: Ast.Identifier = maybeName.node as Ast.Identifier;
+        if (Keyword.KeywordKind.Shared.startsWith(name.literal)) {
+            return [Keyword.KeywordKind.Shared];
         }
 
         return undefined;
     }
     // `section foo; bar = 1 |` would be expecting a semicolon.
     // The autocomplete should be for the IdentifierPairedExpression found on the previous child index.
-    else if (maybeChildAttributeIndex === 3 && state.child.kind === PQP.Parser.XorNodeKind.Context) {
-        const identifierPairedExpression: PQP.Language.Ast.IdentifierPairedExpression = PQP.Parser.NodeIdMapUtils.assertUnwrapNthChildAsAstChecked(
+    else if (maybeChildAttributeIndex === 3 && state.child.kind === XorNodeKind.Context) {
+        const identifierPairedExpression: Ast.IdentifierPairedExpression = NodeIdMapUtils.assertUnboxNthChildAsAstChecked(
             state.nodeIdMapCollection,
             state.parent.node.id,
             2,
-            PQP.Language.Ast.NodeKind.IdentifierPairedExpression,
+            Ast.NodeKind.IdentifierPairedExpression,
         );
         return autocompleteKeywordRightMostLeaf(state, identifierPairedExpression.id);
     } else {

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordSectionMember.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordSectionMember.ts
@@ -15,12 +15,12 @@ export function autocompleteKeywordSectionMember(
     if (maybeChildAttributeIndex === 2) {
         // A test for 'shared', which as we're on namePairedExpression we either parsed it or skipped it.
         const maybeSharedConstant:
-            | PQP.Parser.TXorNode
-            | undefined = PQP.Parser.NodeIdMapUtils.maybeChildXorByAttributeIndex(
+            | PQP.Parser.XorNode<PQP.Language.Ast.TConstant>
+            | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChild(
             state.nodeIdMapCollection,
             state.parent.node.id,
             1,
-            [PQP.Language.Ast.NodeKind.Constant],
+            PQP.Language.Ast.NodeKind.Constant,
         );
 
         // 'shared' was parsed so we can exit.
@@ -51,11 +51,11 @@ export function autocompleteKeywordSectionMember(
     // `section foo; bar = 1 |` would be expecting a semicolon.
     // The autocomplete should be for the IdentifierPairedExpression found on the previous child index.
     else if (maybeChildAttributeIndex === 3 && state.child.kind === PQP.Parser.XorNodeKind.Context) {
-        const identifierPairedExpression: PQP.Language.Ast.TNode = PQP.Parser.NodeIdMapUtils.assertGetChildAstByAttributeIndex(
+        const identifierPairedExpression: PQP.Language.Ast.IdentifierPairedExpression = PQP.Parser.NodeIdMapUtils.assertUnwrapNthChildAsAst(
             state.nodeIdMapCollection,
             state.parent.node.id,
             2,
-            [PQP.Language.Ast.NodeKind.IdentifierPairedExpression],
+            PQP.Language.Ast.NodeKind.IdentifierPairedExpression,
         );
         return autocompleteKeywordRightMostLeaf(state, identifierPairedExpression.id);
     } else {

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordSectionMember.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordSectionMember.ts
@@ -16,7 +16,7 @@ export function autocompleteKeywordSectionMember(
         // A test for 'shared', which as we're on namePairedExpression we either parsed it or skipped it.
         const maybeSharedConstant:
             | PQP.Parser.XorNode<PQP.Language.Ast.TConstant>
-            | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChild(
+            | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChildChecked<PQP.Language.Ast.TConstant>(
             state.nodeIdMapCollection,
             state.parent.node.id,
             1,
@@ -29,7 +29,7 @@ export function autocompleteKeywordSectionMember(
         }
 
         // SectionMember -> IdentifierPairedExpression -> Identifier
-        const maybeName: PQP.Parser.TXorNode | undefined = PQP.Parser.AncestryUtils.maybeNthPreviousXor(
+        const maybeName: PQP.Parser.TXorNode | undefined = PQP.Parser.AncestryUtils.maybeNthPreviousXorChecked(
             state.activeNode.ancestry,
             state.ancestryIndex,
             2,
@@ -51,7 +51,7 @@ export function autocompleteKeywordSectionMember(
     // `section foo; bar = 1 |` would be expecting a semicolon.
     // The autocomplete should be for the IdentifierPairedExpression found on the previous child index.
     else if (maybeChildAttributeIndex === 3 && state.child.kind === PQP.Parser.XorNodeKind.Context) {
-        const identifierPairedExpression: PQP.Language.Ast.IdentifierPairedExpression = PQP.Parser.NodeIdMapUtils.assertUnwrapNthChildAsAst(
+        const identifierPairedExpression: PQP.Language.Ast.IdentifierPairedExpression = PQP.Parser.NodeIdMapUtils.assertUnwrapNthChildAsAstChecked(
             state.nodeIdMapCollection,
             state.parent.node.id,
             2,

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordTrailingText.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordTrailingText.ts
@@ -4,14 +4,15 @@
 import * as PQP from "@microsoft/powerquery-parser";
 
 import { Assert } from "@microsoft/powerquery-parser";
+import { Keyword } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 
 import { TrailingToken } from "../commonTypes";
 
 export function autocompleteKeywordTrailingText(
-    inspected: ReadonlyArray<PQP.Language.Keyword.KeywordKind>,
+    inspected: ReadonlyArray<Keyword.KeywordKind>,
     trailingToken: TrailingToken,
-    maybeAllowedKeywords: ReadonlyArray<PQP.Language.Keyword.KeywordKind> | undefined,
-): ReadonlyArray<PQP.Language.Keyword.KeywordKind> {
+    maybeAllowedKeywords: ReadonlyArray<Keyword.KeywordKind> | undefined,
+): ReadonlyArray<Keyword.KeywordKind> {
     if (trailingToken.isInOrOnPosition === false) {
         return inspected;
     }
@@ -23,7 +24,7 @@ export function autocompleteKeywordTrailingText(
     if (maybeAllowedKeywords !== undefined) {
         return PQP.ArrayUtils.concatUnique(
             inspected,
-            maybeAllowedKeywords.filter((keyword: PQP.Language.Keyword.KeywordKind) => keyword.startsWith(token.data)),
+            maybeAllowedKeywords.filter((keyword: Keyword.KeywordKind) => keyword.startsWith(token.data)),
         );
     } else {
         return inspected;
@@ -32,12 +33,12 @@ export function autocompleteKeywordTrailingText(
 
 // Used with maybeParseError to see if a user could be typing a conjunctive keyword such as 'or'. Eg.
 // 'Details[UserName] <> "" o|'
-const PartialConjunctionKeywordAutocompleteMap: Map<string, ReadonlyArray<PQP.Language.Keyword.KeywordKind>> = new Map<
+const PartialConjunctionKeywordAutocompleteMap: Map<string, ReadonlyArray<Keyword.KeywordKind>> = new Map<
     string,
-    ReadonlyArray<PQP.Language.Keyword.KeywordKind>
+    ReadonlyArray<Keyword.KeywordKind>
 >([
-    ["a", [PQP.Language.Keyword.KeywordKind.And, PQP.Language.Keyword.KeywordKind.As]],
-    ["i", [PQP.Language.Keyword.KeywordKind.Is]],
-    ["m", [PQP.Language.Keyword.KeywordKind.Meta]],
-    ["o", [PQP.Language.Keyword.KeywordKind.Or]],
+    ["a", [Keyword.KeywordKind.And, Keyword.KeywordKind.As]],
+    ["i", [Keyword.KeywordKind.Is]],
+    ["m", [Keyword.KeywordKind.Meta]],
+    ["o", [Keyword.KeywordKind.Or]],
 ]);

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/common.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/common.ts
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
+import { Assert } from "@microsoft/powerquery-parser";
+import { Ast, Keyword, KeywordUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { AncestryUtils, NodeIdMapUtils, TXorNode } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
-import { Assert, CommonError } from "@microsoft/powerquery-parser";
+import { CommonError } from "@microsoft/powerquery-parser";
 
 import { ActiveNode } from "../../activeNode";
 import { AutocompleteItem } from "../autocompleteItem";
@@ -13,17 +15,19 @@ import { InspectAutocompleteKeywordState } from "./commonTypes";
 export function autocompleteKeywordRightMostLeaf(
     state: InspectAutocompleteKeywordState,
     xorNodeId: number,
-): ReadonlyArray<PQP.Language.Keyword.KeywordKind> | undefined {
+): ReadonlyArray<Keyword.KeywordKind> | undefined {
     // Grab the right-most Ast node in the last value.
-    const maybeRightMostAstLeafForLastValue:
-        | PQP.Language.Ast.TNode
-        | undefined = PQP.Parser.NodeIdMapUtils.maybeRightMostLeaf(state.nodeIdMapCollection, xorNodeId, undefined);
+    const maybeRightMostAstLeafForLastValue: Ast.TNode | undefined = NodeIdMapUtils.maybeRightMostLeaf(
+        state.nodeIdMapCollection,
+        xorNodeId,
+        undefined,
+    );
     if (maybeRightMostAstLeafForLastValue === undefined) {
         return undefined;
     }
 
     // Start a new autocomplete inspection where the ActiveNode's ancestry is the right-most Ast node in the last value.
-    const shiftedAncestry: ReadonlyArray<PQP.Parser.TXorNode> = PQP.Parser.AncestryUtils.assertGetAncestry(
+    const shiftedAncestry: ReadonlyArray<TXorNode> = AncestryUtils.assertGetAncestry(
         state.nodeIdMapCollection,
         maybeRightMostAstLeafForLastValue.id,
     );
@@ -40,7 +44,7 @@ export function autocompleteKeywordRightMostLeaf(
     );
 
     return inspected.map((autocompleteItem: AutocompleteItem) => {
-        if (!PQP.Language.KeywordUtils.isKeyword(autocompleteItem.label)) {
+        if (!KeywordUtils.isKeyword(autocompleteItem.label)) {
             throw new CommonError.InvariantError(
                 `expected ${autocompleteKeyword.name} to return only with KeywordKind values for AutocompleteItem.label`,
             );

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/commonTypes.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/commonTypes.ts
@@ -1,16 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
+import { NodeIdMap, TXorNode } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
 import { ActiveNode } from "../../activeNode";
 import { TrailingToken } from "../commonTypes";
 
 export interface InspectAutocompleteKeywordState {
-    readonly nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection;
+    readonly nodeIdMapCollection: NodeIdMap.Collection;
     readonly activeNode: ActiveNode;
     readonly maybeTrailingToken: TrailingToken | undefined;
-    parent: PQP.Parser.TXorNode;
-    child: PQP.Parser.TXorNode;
+    parent: TXorNode;
+    child: TXorNode;
     ancestryIndex: number;
 }

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteLanguageConstant.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteLanguageConstant.ts
@@ -126,10 +126,13 @@ function isOptionalAllowed(activeNode: ActiveNode): boolean {
 
     // FunctionExpression -> IParenthesisWrapped -> ParameterList -> Csv -> Parameter
     const maybeParameter:
-        | PQP.Parser.TXorNode
-        | undefined = PQP.Parser.AncestryUtils.maybeNthPreviousXor(activeNode.ancestry, fnExprAncestryIndex, 4, [
+        | PQP.Parser.XorNode<PQP.Language.Ast.TParameter>
+        | undefined = PQP.Parser.AncestryUtils.maybeNthPreviousXorChecked<PQP.Language.Ast.TParameter>(
+        activeNode.ancestry,
+        fnExprAncestryIndex,
+        4,
         PQP.Language.Ast.NodeKind.Parameter,
-    ]);
+    );
     if (maybeParameter === undefined) {
         return false;
     }

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteLanguageConstant.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteLanguageConstant.ts
@@ -3,6 +3,10 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { Assert, ResultUtils } from "@microsoft/powerquery-parser";
+import { Ast, Constant } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { AncestryUtils, TXorNode, XorNode } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
+
 import type { Position } from "vscode-languageserver-types";
 import { PositionUtils } from "../..";
 import { ActiveNode, ActiveNodeUtils, TMaybeActiveNode } from "../activeNode";
@@ -13,7 +17,7 @@ export function tryAutocompleteLanguageConstant(
     settings: PQP.CommonSettings,
     maybeActiveNode: TMaybeActiveNode,
 ): TriedAutocompleteLanguageConstant {
-    return PQP.ResultUtils.ensureResult(settings.locale, () => {
+    return ResultUtils.ensureResult(settings.locale, () => {
         return autocompleteLanguageConstant(maybeActiveNode);
     });
 }
@@ -25,33 +29,29 @@ function autocompleteLanguageConstant(maybeActiveNode: TMaybeActiveNode): Autoco
     const activeNode: ActiveNode = maybeActiveNode;
 
     if (isNullableAllowed(activeNode)) {
-        return AutocompleteItemUtils.createFromLanguageConstantKind(
-            PQP.Language.Constant.LanguageConstantKind.Nullable,
-        );
+        return AutocompleteItemUtils.createFromLanguageConstantKind(Constant.LanguageConstantKind.Nullable);
     } else if (isOptionalAllowed(activeNode)) {
-        return AutocompleteItemUtils.createFromLanguageConstantKind(
-            PQP.Language.Constant.LanguageConstantKind.Optional,
-        );
+        return AutocompleteItemUtils.createFromLanguageConstantKind(Constant.LanguageConstantKind.Optional);
     } else {
         return undefined;
     }
 }
 
 function isNullableAllowed(activeNode: ActiveNode): boolean {
-    const ancestry: ReadonlyArray<PQP.Parser.TXorNode> = activeNode.ancestry;
+    const ancestry: ReadonlyArray<TXorNode> = activeNode.ancestry;
     const numAncestors: number = ancestry.length;
 
     for (let index: number = 0; index < numAncestors; index += 1) {
-        const xorNode: PQP.Parser.TXorNode = ancestry[index];
+        const xorNode: TXorNode = ancestry[index];
 
         switch (xorNode.node.kind) {
-            case PQP.Language.Ast.NodeKind.AsNullablePrimitiveType:
+            case Ast.NodeKind.AsNullablePrimitiveType:
                 if (isNullableAllowedForAsNullablePrimitiveType(activeNode, index)) {
                     return true;
                 }
                 break;
 
-            case PQP.Language.Ast.NodeKind.PrimitiveType:
+            case Ast.NodeKind.PrimitiveType:
                 if (isNullableAllowedForPrimitiveType(xorNode)) {
                     return true;
                 }
@@ -66,27 +66,21 @@ function isNullableAllowed(activeNode: ActiveNode): boolean {
 }
 
 function isNullableAllowedForAsNullablePrimitiveType(activeNode: ActiveNode, ancestryIndex: number): boolean {
-    const maybeChild: PQP.Parser.TXorNode | undefined = PQP.Parser.AncestryUtils.maybePreviousXor(
-        activeNode.ancestry,
-        ancestryIndex,
-    );
+    const maybeChild: TXorNode | undefined = AncestryUtils.maybePreviousXor(activeNode.ancestry, ancestryIndex);
     if (maybeChild?.node.maybeAttributeIndex !== 1) {
         return false;
     }
-    // PQP.Language.Ast.AsNullablePrimitiveType.paired: PQP.Language.Ast.TNullablePrimitiveType
-    const paired: PQP.Parser.TXorNode = maybeChild;
+    // Ast.AsNullablePrimitiveType.paired: Ast.TNullablePrimitiveType
+    const paired: TXorNode = maybeChild;
     const position: Position = activeNode.position;
 
-    // PQP.Language.Ast.PrimitiveType
-    if (
-        paired.node.kind === PQP.Language.Ast.NodeKind.PrimitiveType &&
-        PositionUtils.isBeforeXor(position, paired, false)
-    ) {
+    // Ast.PrimitiveType
+    if (paired.node.kind === Ast.NodeKind.PrimitiveType && PositionUtils.isBeforeXor(position, paired, false)) {
         return true;
     }
-    // PQP.Language.Ast.NullablePrimitiveType
-    else if (paired.node.kind === PQP.Language.Ast.NodeKind.NullablePrimitiveType) {
-        const maybeGrandchild: PQP.Parser.TXorNode | undefined = PQP.Parser.AncestryUtils.maybeNthPreviousXor(
+    // Ast.NullablePrimitiveType
+    else if (paired.node.kind === Ast.NodeKind.NullablePrimitiveType) {
+        const maybeGrandchild: TXorNode | undefined = AncestryUtils.maybeNthPreviousXor(
             activeNode.ancestry,
             ancestryIndex,
             2,
@@ -94,30 +88,30 @@ function isNullableAllowedForAsNullablePrimitiveType(activeNode: ActiveNode, anc
         if (maybeGrandchild === undefined) {
             return false;
         }
-        // PQP.Language.Ast.Constant || PQP.Language.Ast.PrimitiveType
-        const grandchild: PQP.Parser.TXorNode = maybeGrandchild;
+        // Ast.Constant || Ast.PrimitiveType
+        const grandchild: TXorNode = maybeGrandchild;
 
         return (
-            // PQP.Language.Ast.Constant
-            grandchild.node.kind === PQP.Language.Ast.NodeKind.Constant ||
-            // before PQP.Language.Ast.PrimitiveType
+            // Ast.Constant
+            grandchild.node.kind === Ast.NodeKind.Constant ||
+            // before Ast.PrimitiveType
             PositionUtils.isBeforeXor(position, grandchild, false)
         );
-    } else if (paired.node.kind === PQP.Language.Ast.NodeKind.PrimitiveType) {
+    } else if (paired.node.kind === Ast.NodeKind.PrimitiveType) {
         return isNullableAllowedForPrimitiveType(paired);
     } else {
         return false;
     }
 }
 
-function isNullableAllowedForPrimitiveType(primitiveType: PQP.Parser.TXorNode): boolean {
+function isNullableAllowedForPrimitiveType(primitiveType: TXorNode): boolean {
     return primitiveType.kind === PQP.Parser.XorNodeKind.Context;
 }
 
 function isOptionalAllowed(activeNode: ActiveNode): boolean {
-    const maybeFnExprAncestryIndex: number | undefined = PQP.Parser.AncestryUtils.maybeFirstIndexOfNodeKind(
+    const maybeFnExprAncestryIndex: number | undefined = AncestryUtils.maybeFirstIndexOfNodeKind(
         activeNode.ancestry,
-        PQP.Language.Ast.NodeKind.FunctionExpression,
+        Ast.NodeKind.FunctionExpression,
     );
     if (maybeFnExprAncestryIndex === undefined) {
         return false;
@@ -125,19 +119,14 @@ function isOptionalAllowed(activeNode: ActiveNode): boolean {
     const fnExprAncestryIndex: number = maybeFnExprAncestryIndex;
 
     // FunctionExpression -> IParenthesisWrapped -> ParameterList -> Csv -> Parameter
-    const maybeParameter:
-        | PQP.Parser.XorNode<PQP.Language.Ast.TParameter>
-        | undefined = PQP.Parser.AncestryUtils.maybeNthPreviousXorChecked<PQP.Language.Ast.TParameter>(
-        activeNode.ancestry,
-        fnExprAncestryIndex,
-        4,
-        PQP.Language.Ast.NodeKind.Parameter,
-    );
+    const maybeParameter: XorNode<Ast.TParameter> | undefined = AncestryUtils.maybeNthPreviousXorChecked<
+        Ast.TParameter
+    >(activeNode.ancestry, fnExprAncestryIndex, 4, Ast.NodeKind.Parameter);
     if (maybeParameter === undefined) {
         return false;
     }
 
-    const maybeChildOfParameter: PQP.Parser.TXorNode | undefined = PQP.Parser.AncestryUtils.maybeNthPreviousXor(
+    const maybeChildOfParameter: TXorNode | undefined = AncestryUtils.maybeNthPreviousXor(
         activeNode.ancestry,
         fnExprAncestryIndex,
         5,
@@ -145,7 +134,7 @@ function isOptionalAllowed(activeNode: ActiveNode): boolean {
     if (maybeChildOfParameter === undefined) {
         return true;
     }
-    const childOfParameter: PQP.Parser.TXorNode = maybeChildOfParameter;
+    const childOfParameter: TXorNode = maybeChildOfParameter;
 
     switch (childOfParameter.node.maybeAttributeIndex) {
         // IParameter.maybeOptionalConstant
@@ -156,12 +145,12 @@ function isOptionalAllowed(activeNode: ActiveNode): boolean {
         case 1:
             switch (childOfParameter.kind) {
                 case PQP.Parser.XorNodeKind.Ast: {
-                    const nameAst: PQP.Language.Ast.Identifier = childOfParameter.node as PQP.Language.Ast.Identifier;
+                    const nameAst: Ast.Identifier = childOfParameter.node as Ast.Identifier;
                     const name: string = nameAst.literal;
 
                     return (
-                        PQP.Language.Constant.LanguageConstantKind.Optional.startsWith(name) &&
-                        name !== PQP.Language.Constant.LanguageConstantKind.Optional &&
+                        Constant.LanguageConstantKind.Optional.startsWith(name) &&
+                        name !== Constant.LanguageConstantKind.Optional &&
                         PositionUtils.isInAst(activeNode.position, nameAst, false, true)
                     );
                 }
@@ -170,7 +159,7 @@ function isOptionalAllowed(activeNode: ActiveNode): boolean {
                     return true;
 
                 default:
-                    throw PQP.Assert.isNever(childOfParameter);
+                    throw Assert.isNever(childOfParameter);
             }
 
         default:

--- a/src/powerquery-language-services/inspection/autocomplete/autocompletePrimitiveType.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompletePrimitiveType.ts
@@ -76,16 +76,18 @@ function traverseAncestors(activeNode: ActiveNode): ReadonlyArray<PQP.Language.C
         // If on a FunctionExpression parameter.
         else if (
             parent.node.kind === PQP.Language.Ast.NodeKind.Parameter &&
-            PQP.Parser.AncestryUtils.maybeNthNextXor(ancestry, index, 4, [
+            PQP.Parser.AncestryUtils.maybeNthNextXorChecked(
+                ancestry,
+                index,
+                4,
                 PQP.Language.Ast.NodeKind.FunctionExpression,
-            ]) !== undefined
+            ) !== undefined
         ) {
             // Things get messy when testing if it's on a nullable primitive type OR a primitive type.
             const maybeGrandchild: PQP.Parser.TXorNode | undefined = PQP.Parser.AncestryUtils.maybeNthPreviousXor(
                 ancestry,
                 index,
                 2,
-                undefined,
             );
             if (maybeGrandchild === undefined) {
                 continue;
@@ -105,7 +107,7 @@ function traverseAncestors(activeNode: ActiveNode): ReadonlyArray<PQP.Language.C
             else if (maybeGrandchild.node.kind === PQP.Language.Ast.NodeKind.NullablePrimitiveType) {
                 const maybeGreatGreatGrandchild:
                     | PQP.Parser.TXorNode
-                    | undefined = PQP.Parser.AncestryUtils.maybeNthPreviousXor(ancestry, index, 3, undefined);
+                    | undefined = PQP.Parser.AncestryUtils.maybeNthPreviousXor(ancestry, index, 3);
                 if (maybeGreatGreatGrandchild?.node.kind === PQP.Language.Ast.NodeKind.PrimitiveType) {
                     return PQP.Language.Constant.PrimitiveTypeConstantKinds;
                 }

--- a/src/powerquery-language-services/inspection/autocomplete/autocompletePrimitiveType.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompletePrimitiveType.ts
@@ -3,6 +3,10 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { ResultUtils } from "@microsoft/powerquery-parser";
+import { Ast, Constant } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { AncestryUtils, TXorNode } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
+
 import { PositionUtils } from "../..";
 import { ActiveNode, ActiveNodeUtils, TMaybeActiveNode } from "../activeNode";
 import { AutocompleteItem, AutocompleteItemUtils } from "./autocompleteItem";
@@ -14,10 +18,10 @@ export function tryAutocompletePrimitiveType(
     maybeTrailingToken: TrailingToken | undefined,
 ): TriedAutocompletePrimitiveType {
     if (!ActiveNodeUtils.isPositionInBounds(maybeActiveNode)) {
-        return PQP.ResultUtils.createOk([]);
+        return ResultUtils.boxOk([]);
     }
 
-    return PQP.ResultUtils.ensureResult(settings.locale, () => {
+    return ResultUtils.ensureResult(settings.locale, () => {
         return autocompletePrimitiveType(maybeActiveNode, maybeTrailingToken?.data);
     });
 }
@@ -30,65 +34,52 @@ function autocompletePrimitiveType(
 }
 
 function createAutocompleteItems(
-    primitiveTypeConstantKinds: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind>,
+    primitiveTypeConstantKinds: ReadonlyArray<Constant.PrimitiveTypeConstantKind>,
     maybeTrailingText: string | undefined,
 ): ReadonlyArray<AutocompleteItem> {
-    return primitiveTypeConstantKinds.map(
-        (primitiveTypeConstantKind: PQP.Language.Constant.PrimitiveTypeConstantKind) =>
-            AutocompleteItemUtils.createFromPrimitiveTypeConstantKind(primitiveTypeConstantKind, maybeTrailingText),
+    return primitiveTypeConstantKinds.map((primitiveTypeConstantKind: Constant.PrimitiveTypeConstantKind) =>
+        AutocompleteItemUtils.createFromPrimitiveTypeConstantKind(primitiveTypeConstantKind, maybeTrailingText),
     );
 }
 
-function traverseAncestors(activeNode: ActiveNode): ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> {
+function traverseAncestors(activeNode: ActiveNode): ReadonlyArray<Constant.PrimitiveTypeConstantKind> {
     if (activeNode.ancestry.length === 0) {
         return [];
     }
 
-    const ancestry: ReadonlyArray<PQP.Parser.TXorNode> = activeNode.ancestry;
+    const ancestry: ReadonlyArray<TXorNode> = activeNode.ancestry;
 
     const numAncestors: number = activeNode.ancestry.length;
     for (let index: number = 0; index < numAncestors; index += 1) {
-        const parent: PQP.Parser.TXorNode = ancestry[index];
-        const maybeChild: PQP.Parser.TXorNode | undefined = ancestry[index - 1];
+        const parent: TXorNode = ancestry[index];
+        const maybeChild: TXorNode | undefined = ancestry[index - 1];
 
         // If the node is a context PrimitiveType node,
         // which is created only when a primitive type was expected but there was nothing to parse.
         // `x as |`
-        if (
-            parent.kind === PQP.Parser.XorNodeKind.Context &&
-            parent.node.kind === PQP.Language.Ast.NodeKind.PrimitiveType
-        ) {
-            return PQP.Language.Constant.PrimitiveTypeConstantKinds;
+        if (parent.kind === PQP.Parser.XorNodeKind.Context && parent.node.kind === Ast.NodeKind.PrimitiveType) {
+            return Constant.PrimitiveTypeConstantKinds;
         }
         // If on the second attribute for TypePrimaryType.
         // `type |`
-        else if (parent.node.kind === PQP.Language.Ast.NodeKind.TypePrimaryType) {
+        else if (parent.node.kind === Ast.NodeKind.TypePrimaryType) {
             if (maybeChild === undefined) {
-                return PQP.Language.Constant.PrimitiveTypeConstantKinds;
+                return Constant.PrimitiveTypeConstantKinds;
             } else if (
                 maybeChild.node.maybeAttributeIndex === 0 &&
                 maybeChild.kind === PQP.Parser.XorNodeKind.Ast &&
-                PositionUtils.isAfterAst(activeNode.position, maybeChild.node as PQP.Language.Ast.TNode, true)
+                PositionUtils.isAfterAst(activeNode.position, maybeChild.node as Ast.TNode, true)
             ) {
-                return PQP.Language.Constant.PrimitiveTypeConstantKinds;
+                return Constant.PrimitiveTypeConstantKinds;
             }
         }
         // If on a FunctionExpression parameter.
         else if (
-            parent.node.kind === PQP.Language.Ast.NodeKind.Parameter &&
-            PQP.Parser.AncestryUtils.maybeNthNextXorChecked(
-                ancestry,
-                index,
-                4,
-                PQP.Language.Ast.NodeKind.FunctionExpression,
-            ) !== undefined
+            parent.node.kind === Ast.NodeKind.Parameter &&
+            AncestryUtils.maybeNthNextXorChecked(ancestry, index, 4, Ast.NodeKind.FunctionExpression) !== undefined
         ) {
             // Things get messy when testing if it's on a nullable primitive type OR a primitive type.
-            const maybeGrandchild: PQP.Parser.TXorNode | undefined = PQP.Parser.AncestryUtils.maybeNthPreviousXor(
-                ancestry,
-                index,
-                2,
-            );
+            const maybeGrandchild: TXorNode | undefined = AncestryUtils.maybeNthPreviousXor(ancestry, index, 2);
             if (maybeGrandchild === undefined) {
                 continue;
             }
@@ -96,20 +87,22 @@ function traverseAncestors(activeNode: ActiveNode): ReadonlyArray<PQP.Language.C
             // `(x as |) => 0`
             else if (
                 maybeGrandchild.kind === PQP.Parser.XorNodeKind.Ast &&
-                maybeGrandchild.node.kind === PQP.Language.Ast.NodeKind.Constant &&
-                maybeGrandchild.node.constantKind === PQP.Language.Constant.KeywordConstantKind.As &&
+                maybeGrandchild.node.kind === Ast.NodeKind.Constant &&
+                maybeGrandchild.node.constantKind === Constant.KeywordConstantKind.As &&
                 PositionUtils.isAfterAst(activeNode.position, maybeGrandchild.node, true)
             ) {
-                return PQP.Language.Constant.PrimitiveTypeConstantKinds;
+                return Constant.PrimitiveTypeConstantKinds;
             }
             // On nullable primitive type
             // `(x as nullable |) => 0`
-            else if (maybeGrandchild.node.kind === PQP.Language.Ast.NodeKind.NullablePrimitiveType) {
-                const maybeGreatGreatGrandchild:
-                    | PQP.Parser.TXorNode
-                    | undefined = PQP.Parser.AncestryUtils.maybeNthPreviousXor(ancestry, index, 3);
-                if (maybeGreatGreatGrandchild?.node.kind === PQP.Language.Ast.NodeKind.PrimitiveType) {
-                    return PQP.Language.Constant.PrimitiveTypeConstantKinds;
+            else if (maybeGrandchild.node.kind === Ast.NodeKind.NullablePrimitiveType) {
+                const maybeGreatGreatGrandchild: TXorNode | undefined = AncestryUtils.maybeNthPreviousXor(
+                    ancestry,
+                    index,
+                    3,
+                );
+                if (maybeGreatGreatGrandchild?.node.kind === Ast.NodeKind.PrimitiveType) {
+                    return Constant.PrimitiveTypeConstantKinds;
                 }
             }
         }

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteUtils.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteUtils.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
+import { ResultUtils } from "@microsoft/powerquery-parser";
+
 import { AutocompleteItem } from "./autocompleteItem";
 
 import { Autocomplete } from "./commonTypes";
@@ -9,7 +10,7 @@ import { Autocomplete } from "./commonTypes";
 export function keys(autocomplete: Autocomplete): ReadonlyArray<string> {
     let result: string[] = [];
 
-    if (PQP.ResultUtils.isOk(autocomplete.triedFieldAccess) && autocomplete.triedFieldAccess.value !== undefined) {
+    if (ResultUtils.isOk(autocomplete.triedFieldAccess) && autocomplete.triedFieldAccess.value !== undefined) {
         result = result.concat(
             autocomplete.triedFieldAccess.value.autocompleteItems.map(
                 (autocompleteItem: AutocompleteItem) => autocompleteItem.label,
@@ -17,13 +18,13 @@ export function keys(autocomplete: Autocomplete): ReadonlyArray<string> {
         );
     }
 
-    if (PQP.ResultUtils.isOk(autocomplete.triedKeyword)) {
+    if (ResultUtils.isOk(autocomplete.triedKeyword)) {
         result = result.concat(
             autocomplete.triedKeyword.value.map((autocompleteItem: AutocompleteItem) => autocompleteItem.label),
         );
     }
 
-    if (PQP.ResultUtils.isOk(autocomplete.triedPrimitiveType) && autocomplete.triedPrimitiveType.value !== undefined) {
+    if (ResultUtils.isOk(autocomplete.triedPrimitiveType) && autocomplete.triedPrimitiveType.value !== undefined) {
         result = result.concat(
             autocomplete.triedPrimitiveType.value.map((autocompleteItem: AutocompleteItem) => autocompleteItem.label),
         );

--- a/src/powerquery-language-services/inspection/autocomplete/commonTypes.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/commonTypes.ts
@@ -3,6 +3,9 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { Ast, Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { TXorNode } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
+
 import { AutocompleteItem } from "./autocompleteItem";
 
 export type TriedAutocompleteFieldAccess = PQP.Result<AutocompleteFieldAccess | undefined, PQP.CommonError.CommonError>;
@@ -21,15 +24,15 @@ export interface Autocomplete {
 }
 
 export interface AutocompleteFieldAccess {
-    readonly field: PQP.Parser.TXorNode;
-    readonly fieldType: PQP.Language.Type.TPowerQueryType;
+    readonly field: TXorNode;
+    readonly fieldType: Type.TPowerQueryType;
     readonly inspectedFieldAccess: InspectedFieldAccess;
     readonly autocompleteItems: ReadonlyArray<AutocompleteItem>;
 }
 
 export interface InspectedFieldAccess {
     readonly isAutocompleteAllowed: boolean;
-    readonly maybeIdentifierUnderPosition: PQP.Language.Ast.GeneralizedIdentifier | undefined;
+    readonly maybeIdentifierUnderPosition: Ast.GeneralizedIdentifier | undefined;
     readonly fieldNames: ReadonlyArray<string>;
 }
 

--- a/src/powerquery-language-services/inspection/autocomplete/task.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/task.ts
@@ -2,6 +2,9 @@
 // Licensed under the MIT license.
 
 import * as PQP from "@microsoft/powerquery-parser";
+
+import { NodeIdMap } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
+
 import { InspectionSettings } from "../../inspectionSettings";
 
 import { TMaybeActiveNode } from "../activeNode";
@@ -27,7 +30,7 @@ export function autocomplete(
     maybeActiveNode: TMaybeActiveNode,
     maybeParseError: PQP.Parser.ParseError.ParseError | undefined,
 ): Autocomplete {
-    const nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection = parseState.contextState.nodeIdMapCollection;
+    const nodeIdMapCollection: NodeIdMap.Collection = parseState.contextState.nodeIdMapCollection;
 
     let maybeTrailingToken: TrailingToken | undefined;
     if (maybeParseError !== undefined) {

--- a/src/powerquery-language-services/inspection/expectedType.ts
+++ b/src/powerquery-language-services/inspection/expectedType.ts
@@ -3,42 +3,46 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { Assert, ResultUtils } from "@microsoft/powerquery-parser";
+import { Ast, Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { TXorNode, XorNodeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
+
 import { ActiveNode, ActiveNodeLeafKind, ActiveNodeUtils, TMaybeActiveNode } from "./activeNode";
 
-export type TriedExpectedType = PQP.Result<PQP.Language.Type.TPowerQueryType | undefined, PQP.CommonError.CommonError>;
+export type TriedExpectedType = PQP.Result<Type.TPowerQueryType | undefined, PQP.CommonError.CommonError>;
 
 export function tryExpectedType(settings: PQP.CommonSettings, maybeActiveNode: TMaybeActiveNode): TriedExpectedType {
     if (!ActiveNodeUtils.isPositionInBounds(maybeActiveNode)) {
-        return PQP.ResultUtils.createOk(undefined);
+        return ResultUtils.boxOk(undefined);
     }
 
-    return PQP.ResultUtils.ensureResult(settings.locale, () => maybeExpectedType(maybeActiveNode));
+    return ResultUtils.ensureResult(settings.locale, () => maybeExpectedType(maybeActiveNode));
 }
 
 // Traverse up the ancestry and find what type is expected as the nth child of a node's kind.
 // The last type generated this way should have the widest typing,
 // which then can be used for type hinting.
-export function maybeExpectedType(activeNode: ActiveNode): PQP.Language.Type.TPowerQueryType | undefined {
-    const ancestry: ReadonlyArray<PQP.Parser.TXorNode> = activeNode.ancestry;
+export function maybeExpectedType(activeNode: ActiveNode): Type.TPowerQueryType | undefined {
+    const ancestry: ReadonlyArray<TXorNode> = activeNode.ancestry;
     const upperBound: number = ancestry.length - 1;
-    let bestMatch: PQP.Language.Type.TPowerQueryType | undefined;
+    let bestMatch: Type.TPowerQueryType | undefined;
 
     for (let index: number = 0; index < upperBound; index += 1) {
-        const parent: PQP.Parser.TXorNode = ancestry[index + 1];
-        const child: PQP.Parser.TXorNode = ancestry[index];
-        const childAttributeIndex: number = PQP.Assert.asDefined(
+        const parent: TXorNode = ancestry[index + 1];
+        const child: TXorNode = ancestry[index];
+        const childAttributeIndex: number = Assert.asDefined(
             child.node.maybeAttributeIndex,
             `Expected child to have an attribute index.`,
             { childId: child.node.id },
         );
 
         const attributeIndex: number =
-            parent.kind === PQP.Parser.XorNodeKind.Ast && activeNode.leafKind === ActiveNodeLeafKind.AfterAstNode
+            XorNodeUtils.isAstXor(parent) && activeNode.leafKind === ActiveNodeLeafKind.AfterAstNode
                 ? childAttributeIndex + 1
                 : childAttributeIndex;
 
-        const allowedType: PQP.Language.Type.TPowerQueryType = expectedType(parent, attributeIndex);
-        if (allowedType.kind !== PQP.Language.Type.TypeKind.NotApplicable) {
+        const allowedType: Type.TPowerQueryType = expectedType(parent, attributeIndex);
+        if (allowedType.kind !== Type.TypeKind.NotApplicable) {
             bestMatch = allowedType;
         }
     }
@@ -47,419 +51,416 @@ export function maybeExpectedType(activeNode: ActiveNode): PQP.Language.Type.TPo
 }
 
 // For a given parent node, what is the expected type for a child at a given index?
-export function expectedType(
-    parentXorNode: PQP.Parser.TXorNode,
-    childIndex: number,
-): PQP.Language.Type.TPowerQueryType {
+export function expectedType(parentXorNode: TXorNode, childIndex: number): Type.TPowerQueryType {
     switch (parentXorNode.node.kind) {
-        case PQP.Language.Ast.NodeKind.ArrayWrapper:
-        case PQP.Language.Ast.NodeKind.Constant:
-        case PQP.Language.Ast.NodeKind.Csv:
-        case PQP.Language.Ast.NodeKind.GeneralizedIdentifier:
-        case PQP.Language.Ast.NodeKind.Identifier:
-        case PQP.Language.Ast.NodeKind.IdentifierExpression:
-        case PQP.Language.Ast.NodeKind.InvokeExpression:
-        case PQP.Language.Ast.NodeKind.FieldProjection:
-        case PQP.Language.Ast.NodeKind.FieldSelector:
-        case PQP.Language.Ast.NodeKind.FieldSpecificationList:
-        case PQP.Language.Ast.NodeKind.ListExpression:
-        case PQP.Language.Ast.NodeKind.ListLiteral:
-        case PQP.Language.Ast.NodeKind.LiteralExpression:
-        case PQP.Language.Ast.NodeKind.RecordLiteral:
-        case PQP.Language.Ast.NodeKind.RecordType:
-        case PQP.Language.Ast.NodeKind.Parameter:
-        case PQP.Language.Ast.NodeKind.ParameterList:
-        case PQP.Language.Ast.NodeKind.PrimitiveType:
-        case PQP.Language.Ast.NodeKind.RecordExpression:
-        case PQP.Language.Ast.NodeKind.RecursivePrimaryExpression:
-            return PQP.Language.Type.NotApplicableInstance;
+        case Ast.NodeKind.ArrayWrapper:
+        case Ast.NodeKind.Constant:
+        case Ast.NodeKind.Csv:
+        case Ast.NodeKind.GeneralizedIdentifier:
+        case Ast.NodeKind.Identifier:
+        case Ast.NodeKind.IdentifierExpression:
+        case Ast.NodeKind.InvokeExpression:
+        case Ast.NodeKind.FieldProjection:
+        case Ast.NodeKind.FieldSelector:
+        case Ast.NodeKind.FieldSpecificationList:
+        case Ast.NodeKind.ListExpression:
+        case Ast.NodeKind.ListLiteral:
+        case Ast.NodeKind.LiteralExpression:
+        case Ast.NodeKind.RecordLiteral:
+        case Ast.NodeKind.RecordType:
+        case Ast.NodeKind.Parameter:
+        case Ast.NodeKind.ParameterList:
+        case Ast.NodeKind.PrimitiveType:
+        case Ast.NodeKind.RecordExpression:
+        case Ast.NodeKind.RecursivePrimaryExpression:
+            return Type.NotApplicableInstance;
 
-        case PQP.Language.Ast.NodeKind.ArithmeticExpression:
-        case PQP.Language.Ast.NodeKind.EqualityExpression:
-        case PQP.Language.Ast.NodeKind.LogicalExpression:
-        case PQP.Language.Ast.NodeKind.RelationalExpression:
+        case Ast.NodeKind.ArithmeticExpression:
+        case Ast.NodeKind.EqualityExpression:
+        case Ast.NodeKind.LogicalExpression:
+        case Ast.NodeKind.RelationalExpression:
             switch (childIndex) {
                 case 0:
                 case 2:
-                    return PQP.Language.Type.TypeExpressionInstance;
+                    return Type.TypeExpressionInstance;
 
                 case 1:
-                    return PQP.Language.Type.NotApplicableInstance;
+                    return Type.NotApplicableInstance;
 
                 default:
                     throw unknownChildIndexError(parentXorNode, childIndex);
             }
 
-        case PQP.Language.Ast.NodeKind.AsExpression:
-        case PQP.Language.Ast.NodeKind.IsExpression:
+        case Ast.NodeKind.AsExpression:
+        case Ast.NodeKind.IsExpression:
             switch (childIndex) {
                 case 0:
-                    return PQP.Language.Type.TypeExpressionInstance;
+                    return Type.TypeExpressionInstance;
 
                 case 1:
-                    return PQP.Language.Type.NotApplicableInstance;
+                    return Type.NotApplicableInstance;
 
                 case 2:
-                    return PQP.Language.Type.NullablePrimitiveInstance;
+                    return Type.NullablePrimitiveInstance;
 
                 default:
                     throw unknownChildIndexError(parentXorNode, childIndex);
             }
 
-        case PQP.Language.Ast.NodeKind.Section:
-        case PQP.Language.Ast.NodeKind.SectionMember:
+        case Ast.NodeKind.Section:
+        case Ast.NodeKind.SectionMember:
             switch (childIndex) {
                 case 0:
-                    return PQP.Language.Type.RecordInstance;
+                    return Type.RecordInstance;
 
                 default:
-                    return PQP.Language.Type.NotApplicableInstance;
+                    return Type.NotApplicableInstance;
             }
 
-        case PQP.Language.Ast.NodeKind.AsType:
+        case Ast.NodeKind.AsType:
             switch (childIndex) {
                 case 0:
-                    return PQP.Language.Type.NotApplicableInstance;
+                    return Type.NotApplicableInstance;
 
                 case 1:
-                    return PQP.Language.Type.TypeProductionInstance;
-
-                default:
-                    throw unknownChildIndexError(parentXorNode, childIndex);
-            }
-
-        case PQP.Language.Ast.NodeKind.AsNullablePrimitiveType:
-            switch (childIndex) {
-                case 0:
-                    return PQP.Language.Type.NotApplicableInstance;
-
-                case 1:
-                    return PQP.Language.Type.NullablePrimitiveInstance;
+                    return Type.TypeProductionInstance;
 
                 default:
                     throw unknownChildIndexError(parentXorNode, childIndex);
             }
 
-        case PQP.Language.Ast.NodeKind.EachExpression:
+        case Ast.NodeKind.AsNullablePrimitiveType:
             switch (childIndex) {
                 case 0:
-                    return PQP.Language.Type.NotApplicableInstance;
+                    return Type.NotApplicableInstance;
 
                 case 1:
-                    return PQP.Language.Type.ExpressionInstance;
+                    return Type.NullablePrimitiveInstance;
 
                 default:
                     throw unknownChildIndexError(parentXorNode, childIndex);
             }
 
-        case PQP.Language.Ast.NodeKind.ErrorHandlingExpression:
+        case Ast.NodeKind.EachExpression:
             switch (childIndex) {
                 case 0:
-                    return PQP.Language.Type.NotApplicableInstance;
+                    return Type.NotApplicableInstance;
 
                 case 1:
-                    return PQP.Language.Type.ExpressionInstance;
+                    return Type.ExpressionInstance;
+
+                default:
+                    throw unknownChildIndexError(parentXorNode, childIndex);
+            }
+
+        case Ast.NodeKind.ErrorHandlingExpression:
+            switch (childIndex) {
+                case 0:
+                    return Type.NotApplicableInstance;
+
+                case 1:
+                    return Type.ExpressionInstance;
 
                 case 2:
-                    return PQP.Language.Type.NotApplicableInstance;
+                    return Type.NotApplicableInstance;
 
                 default:
                     throw unknownChildIndexError(parentXorNode, childIndex);
             }
 
         // TODO: how should error raising be typed?
-        case PQP.Language.Ast.NodeKind.ErrorRaisingExpression:
-            return PQP.Language.Type.NotApplicableInstance;
+        case Ast.NodeKind.ErrorRaisingExpression:
+            return Type.NotApplicableInstance;
 
-        case PQP.Language.Ast.NodeKind.GeneralizedIdentifierPairedAnyLiteral:
+        case Ast.NodeKind.GeneralizedIdentifierPairedAnyLiteral:
             switch (childIndex) {
                 case 0:
                 case 1:
-                    return PQP.Language.Type.NotApplicableInstance;
+                    return Type.NotApplicableInstance;
 
                 case 2:
-                    return PQP.Language.Type.AnyLiteralInstance;
+                    return Type.AnyLiteralInstance;
 
                 default:
                     throw unknownChildIndexError(parentXorNode, childIndex);
             }
 
-        case PQP.Language.Ast.NodeKind.GeneralizedIdentifierPairedExpression:
-        case PQP.Language.Ast.NodeKind.IdentifierPairedExpression:
+        case Ast.NodeKind.GeneralizedIdentifierPairedExpression:
+        case Ast.NodeKind.IdentifierPairedExpression:
             switch (childIndex) {
                 case 0:
                 case 1:
-                    return PQP.Language.Type.NotApplicableInstance;
+                    return Type.NotApplicableInstance;
 
                 case 2:
-                    return PQP.Language.Type.ExpressionInstance;
+                    return Type.ExpressionInstance;
 
                 default:
                     throw unknownChildIndexError(parentXorNode, childIndex);
             }
 
-        case PQP.Language.Ast.NodeKind.FieldSpecification:
+        case Ast.NodeKind.FieldSpecification:
             switch (childIndex) {
                 case 0:
                 case 1:
-                    return PQP.Language.Type.NotApplicableInstance;
+                    return Type.NotApplicableInstance;
 
                 case 2:
-                    return PQP.Language.Type.TypeProductionInstance;
+                    return Type.TypeProductionInstance;
 
                 default:
                     throw unknownChildIndexError(parentXorNode, childIndex);
             }
 
-        case PQP.Language.Ast.NodeKind.FieldTypeSpecification:
+        case Ast.NodeKind.FieldTypeSpecification:
             switch (childIndex) {
                 case 0:
-                    return PQP.Language.Type.NotApplicableInstance;
+                    return Type.NotApplicableInstance;
 
                 case 1:
-                    return PQP.Language.Type.TypeProductionInstance;
+                    return Type.TypeProductionInstance;
 
                 default:
                     throw unknownChildIndexError(parentXorNode, childIndex);
             }
 
-        case PQP.Language.Ast.NodeKind.FunctionExpression:
+        case Ast.NodeKind.FunctionExpression:
             switch (childIndex) {
                 case 0:
                 case 2:
-                    return PQP.Language.Type.NotApplicableInstance;
+                    return Type.NotApplicableInstance;
 
                 case 1:
-                    return PQP.Language.Type.NullablePrimitiveInstance;
+                    return Type.NullablePrimitiveInstance;
 
                 case 3:
-                    return PQP.Language.Type.ExpressionInstance;
+                    return Type.ExpressionInstance;
 
                 default:
                     throw unknownChildIndexError(parentXorNode, childIndex);
             }
 
-        case PQP.Language.Ast.NodeKind.FunctionType:
+        case Ast.NodeKind.FunctionType:
             switch (childIndex) {
                 case 0:
                 case 1:
-                    return PQP.Language.Type.NotApplicableInstance;
+                    return Type.NotApplicableInstance;
 
                 case 2:
-                    return PQP.Language.Type.NullablePrimitiveInstance;
+                    return Type.NullablePrimitiveInstance;
 
                 default:
                     throw unknownChildIndexError(parentXorNode, childIndex);
             }
 
-        case PQP.Language.Ast.NodeKind.IfExpression:
+        case Ast.NodeKind.IfExpression:
             switch (childIndex) {
                 case 0:
                 case 2:
                 case 4:
-                    return PQP.Language.Type.NotApplicableInstance;
+                    return Type.NotApplicableInstance;
 
                 case 1:
-                    return PQP.Language.Type.LogicalInstance;
+                    return Type.LogicalInstance;
 
                 case 3:
                 case 5:
-                    return PQP.Language.Type.ExpressionInstance;
+                    return Type.ExpressionInstance;
 
                 default:
                     throw unknownChildIndexError(parentXorNode, childIndex);
             }
 
-        case PQP.Language.Ast.NodeKind.IsNullablePrimitiveType:
+        case Ast.NodeKind.IsNullablePrimitiveType:
             switch (childIndex) {
                 case 0:
-                    return PQP.Language.Type.NotApplicableInstance;
+                    return Type.NotApplicableInstance;
 
                 case 1:
-                    return PQP.Language.Type.NullablePrimitiveInstance;
+                    return Type.NullablePrimitiveInstance;
 
                 default:
                     throw unknownChildIndexError(parentXorNode, childIndex);
             }
 
-        case PQP.Language.Ast.NodeKind.ItemAccessExpression:
+        case Ast.NodeKind.ItemAccessExpression:
             switch (childIndex) {
                 case 0:
                 case 2:
                 case 3:
-                    return PQP.Language.Type.NotApplicableInstance;
+                    return Type.NotApplicableInstance;
 
                 case 1:
-                    return PQP.Language.Type.ExpressionInstance;
+                    return Type.ExpressionInstance;
 
                 default:
                     throw unknownChildIndexError(parentXorNode, childIndex);
             }
 
-        case PQP.Language.Ast.NodeKind.LetExpression:
+        case Ast.NodeKind.LetExpression:
             switch (childIndex) {
                 case 0:
                 case 1:
                 case 2:
-                    return PQP.Language.Type.NotApplicableInstance;
+                    return Type.NotApplicableInstance;
 
                 case 3:
-                    return PQP.Language.Type.ExpressionInstance;
+                    return Type.ExpressionInstance;
 
                 default:
                     throw unknownChildIndexError(parentXorNode, childIndex);
             }
 
-        case PQP.Language.Ast.NodeKind.ListType:
+        case Ast.NodeKind.ListType:
             switch (childIndex) {
                 case 0:
                 case 2:
-                    return PQP.Language.Type.NotApplicableInstance;
+                    return Type.NotApplicableInstance;
 
                 case 1:
-                    return PQP.Language.Type.TypeProductionInstance;
+                    return Type.TypeProductionInstance;
 
                 default:
                     throw unknownChildIndexError(parentXorNode, childIndex);
             }
 
-        case PQP.Language.Ast.NodeKind.MetadataExpression:
+        case Ast.NodeKind.MetadataExpression:
             switch (childIndex) {
                 case 1:
-                    return PQP.Language.Type.NotApplicableInstance;
+                    return Type.NotApplicableInstance;
 
                 case 0:
                 case 2:
-                    return PQP.Language.Type.TypeExpressionInstance;
+                    return Type.TypeExpressionInstance;
 
                 default:
                     throw unknownChildIndexError(parentXorNode, childIndex);
             }
 
-        case PQP.Language.Ast.NodeKind.NotImplementedExpression:
+        case Ast.NodeKind.NotImplementedExpression:
             switch (childIndex) {
                 case 0:
-                    return PQP.Language.Type.NotApplicableInstance;
+                    return Type.NotApplicableInstance;
 
                 default:
                     throw unknownChildIndexError(parentXorNode, childIndex);
             }
 
-        case PQP.Language.Ast.NodeKind.NullCoalescingExpression:
-            switch (childIndex) {
-                case 0:
-                case 2:
-                    return PQP.Language.Type.ExpressionInstance;
-
-                case 1:
-                    return PQP.Language.Type.NotApplicableInstance;
-
-                default:
-                    throw unknownChildIndexError(parentXorNode, childIndex);
-            }
-
-        case PQP.Language.Ast.NodeKind.NullablePrimitiveType:
-            switch (childIndex) {
-                case 0:
-                    return PQP.Language.Type.NotApplicableInstance;
-
-                case 1:
-                    return PQP.Language.Type.PrimitiveInstance;
-
-                default:
-                    throw unknownChildIndexError(parentXorNode, childIndex);
-            }
-
-        case PQP.Language.Ast.NodeKind.NullableType:
-            switch (childIndex) {
-                case 0:
-                    return PQP.Language.Type.NotApplicableInstance;
-
-                case 1:
-                    return PQP.Language.Type.TypeProductionInstance;
-
-                default:
-                    throw unknownChildIndexError(parentXorNode, childIndex);
-            }
-
-        case PQP.Language.Ast.NodeKind.OtherwiseExpression:
-            switch (childIndex) {
-                case 0:
-                    return PQP.Language.Type.NotApplicableInstance;
-
-                case 1:
-                    return PQP.Language.Type.ExpressionInstance;
-
-                default:
-                    throw unknownChildIndexError(parentXorNode, childIndex);
-            }
-
-        case PQP.Language.Ast.NodeKind.ParenthesizedExpression:
+        case Ast.NodeKind.NullCoalescingExpression:
             switch (childIndex) {
                 case 0:
                 case 2:
-                    return PQP.Language.Type.NotApplicableInstance;
+                    return Type.ExpressionInstance;
 
                 case 1:
-                    return PQP.Language.Type.ExpressionInstance;
+                    return Type.NotApplicableInstance;
 
                 default:
                     throw unknownChildIndexError(parentXorNode, childIndex);
             }
 
-        case PQP.Language.Ast.NodeKind.RangeExpression:
+        case Ast.NodeKind.NullablePrimitiveType:
+            switch (childIndex) {
+                case 0:
+                    return Type.NotApplicableInstance;
+
+                case 1:
+                    return Type.PrimitiveInstance;
+
+                default:
+                    throw unknownChildIndexError(parentXorNode, childIndex);
+            }
+
+        case Ast.NodeKind.NullableType:
+            switch (childIndex) {
+                case 0:
+                    return Type.NotApplicableInstance;
+
+                case 1:
+                    return Type.TypeProductionInstance;
+
+                default:
+                    throw unknownChildIndexError(parentXorNode, childIndex);
+            }
+
+        case Ast.NodeKind.OtherwiseExpression:
+            switch (childIndex) {
+                case 0:
+                    return Type.NotApplicableInstance;
+
+                case 1:
+                    return Type.ExpressionInstance;
+
+                default:
+                    throw unknownChildIndexError(parentXorNode, childIndex);
+            }
+
+        case Ast.NodeKind.ParenthesizedExpression:
             switch (childIndex) {
                 case 0:
                 case 2:
-                    return PQP.Language.Type.ExpressionInstance;
+                    return Type.NotApplicableInstance;
 
                 case 1:
-                    return PQP.Language.Type.NotApplicableInstance;
+                    return Type.ExpressionInstance;
 
                 default:
                     throw unknownChildIndexError(parentXorNode, childIndex);
             }
 
-        case PQP.Language.Ast.NodeKind.TableType:
+        case Ast.NodeKind.RangeExpression:
+            switch (childIndex) {
+                case 0:
+                case 2:
+                    return Type.ExpressionInstance;
+
+                case 1:
+                    return Type.NotApplicableInstance;
+
+                default:
+                    throw unknownChildIndexError(parentXorNode, childIndex);
+            }
+
+        case Ast.NodeKind.TableType:
             switch (childIndex) {
                 case 1:
                 case 2:
-                    return PQP.Language.Type.PrimaryExpressionInstance;
+                    return Type.PrimaryExpressionInstance;
 
                 default:
                     throw unknownChildIndexError(parentXorNode, childIndex);
             }
 
-        case PQP.Language.Ast.NodeKind.TypePrimaryType:
+        case Ast.NodeKind.TypePrimaryType:
             switch (childIndex) {
                 case 0:
-                    return PQP.Language.Type.NotApplicableInstance;
+                    return Type.NotApplicableInstance;
 
                 case 1:
-                    return PQP.Language.Type.PrimaryTypeInstance;
+                    return Type.PrimaryTypeInstance;
 
                 default:
                     throw unknownChildIndexError(parentXorNode, childIndex);
             }
 
-        case PQP.Language.Ast.NodeKind.UnaryExpression:
+        case Ast.NodeKind.UnaryExpression:
             switch (childIndex) {
                 case 0:
-                    return PQP.Language.Type.NotApplicableInstance;
+                    return Type.NotApplicableInstance;
 
                 case 1:
-                    return PQP.Language.Type.TypeExpressionInstance;
+                    return Type.TypeExpressionInstance;
 
                 default:
                     throw unknownChildIndexError(parentXorNode, childIndex);
             }
 
         default:
-            throw PQP.Assert.isNever(parentXorNode.node);
+            throw Assert.isNever(parentXorNode.node);
     }
 }
 
-function unknownChildIndexError(parent: PQP.Parser.TXorNode, childIndex: number): PQP.CommonError.InvariantError {
+function unknownChildIndexError(parent: TXorNode, childIndex: number): PQP.CommonError.InvariantError {
     const details: {} = {
         parentId: parent.node.kind,
         parentNodeKind: parent.node.kind,

--- a/src/powerquery-language-services/inspection/externalType/externalType.ts
+++ b/src/powerquery-language-services/inspection/externalType/externalType.ts
@@ -1,19 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
+import { Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 
 export type TExternalTypeRequest = ExternalValueTypeRequest | ExternalInvocationTypeRequest;
 
-export type TExternalTypeResolverFn = (request: TExternalTypeRequest) => PQP.Language.Type.TPowerQueryType | undefined;
+export type TExternalTypeResolverFn = (request: TExternalTypeRequest) => Type.TPowerQueryType | undefined;
 
 export type TExternalInvocationTypeResolverFn = (
     request: ExternalInvocationTypeRequest,
-) => PQP.Language.Type.TPowerQueryType | undefined;
+) => Type.TPowerQueryType | undefined;
 
-export type TExternalValueTypeResolverFn = (
-    request: ExternalValueTypeRequest,
-) => PQP.Language.Type.TPowerQueryType | undefined;
+export type TExternalValueTypeResolverFn = (request: ExternalValueTypeRequest) => Type.TPowerQueryType | undefined;
 
 export const enum ExternalTypeRequestKind {
     Invocation = "Invocation",
@@ -31,7 +29,7 @@ export interface ExternalValueTypeRequest extends IExternalType {
 
 export interface ExternalInvocationTypeRequest extends IExternalType {
     readonly kind: ExternalTypeRequestKind.Invocation;
-    readonly args: ReadonlyArray<PQP.Language.Type.TPowerQueryType>;
+    readonly args: ReadonlyArray<Type.TPowerQueryType>;
 }
 
 // A null/no-op resolver for when one is required but shouldn't resolve anything, eg. for test mocks.

--- a/src/powerquery-language-services/inspection/externalType/externalTypeUtils.ts
+++ b/src/powerquery-language-services/inspection/externalType/externalTypeUtils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
+import { Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 import { ExternalType } from ".";
 
 export function createValueTypeRequest(identifierLiteral: string): ExternalType.ExternalValueTypeRequest {
@@ -13,7 +13,7 @@ export function createValueTypeRequest(identifierLiteral: string): ExternalType.
 
 export function createInvocationTypeRequest(
     identifierLiteral: string,
-    args: ReadonlyArray<PQP.Language.Type.TPowerQueryType>,
+    args: ReadonlyArray<Type.TPowerQueryType>,
 ): ExternalType.ExternalInvocationTypeRequest {
     return {
         kind: ExternalType.ExternalTypeRequestKind.Invocation,

--- a/src/powerquery-language-services/inspection/invokeExpression/common.ts
+++ b/src/powerquery-language-services/inspection/invokeExpression/common.ts
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
+import { Type, TypeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { TXorNode } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
 export interface IInvokeExpression<T extends InvokeExpressionArguments> {
-    readonly invokeExpressionXorNode: PQP.Parser.TXorNode;
-    readonly functionType: PQP.Language.Type.TPowerQueryType;
+    readonly invokeExpressionXorNode: TXorNode;
+    readonly functionType: Type.TPowerQueryType;
     readonly isNameInLocalScope: boolean;
     readonly maybeName: string | undefined;
     readonly maybeArguments: T | undefined;
@@ -14,7 +15,7 @@ export interface IInvokeExpression<T extends InvokeExpressionArguments> {
 export interface InvokeExpressionArguments {
     readonly numMaxExpectedArguments: number;
     readonly numMinExpectedArguments: number;
-    readonly givenArguments: ReadonlyArray<PQP.Parser.TXorNode>;
-    readonly givenArgumentTypes: ReadonlyArray<PQP.Language.Type.TPowerQueryType>;
-    readonly typeChecked: PQP.Language.TypeUtils.CheckedInvocation;
+    readonly givenArguments: ReadonlyArray<TXorNode>;
+    readonly givenArgumentTypes: ReadonlyArray<Type.TPowerQueryType>;
+    readonly typeChecked: TypeUtils.CheckedInvocation;
 }

--- a/src/powerquery-language-services/inspection/invokeExpression/currentInvokeExpression.ts
+++ b/src/powerquery-language-services/inspection/invokeExpression/currentInvokeExpression.ts
@@ -3,7 +3,6 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
-import { CommonError } from "@microsoft/powerquery-parser";
 import { InspectionSettings } from "../../inspectionSettings";
 
 import { ActiveNode, ActiveNodeUtils, TMaybeActiveNode } from "../activeNode";
@@ -97,16 +96,17 @@ function getArgumentOrdinal(
     invokeExpressionXorNode: PQP.Parser.TXorNode,
 ): number {
     // `foo(1|)
-    const maybeAncestoryCsv:
-        | PQP.Parser.TXorNode
-        | undefined = PQP.Parser.AncestryUtils.maybeNthPreviousXor(activeNode.ancestry, ancestryIndex, 2, [
+    const maybeAncestoryCsv: PQP.Parser.TXorNode | undefined = PQP.Parser.AncestryUtils.maybeNthPreviousXorChecked(
+        activeNode.ancestry,
+        ancestryIndex,
+        2,
         PQP.Language.Ast.NodeKind.Csv,
-    ]);
+    );
     if (maybeAncestoryCsv !== undefined) {
         return maybeAncestoryCsv.node.maybeAttributeIndex ?? 0;
     }
 
-    const maybePreviousXor: PQP.Parser.TXorNode | undefined = PQP.Parser.AncestryUtils.maybePreviousXor(
+    const maybePreviousXor: PQP.Parser.TXorNode | undefined = PQP.Parser.AncestryUtils.maybePreviousXorChecked(
         activeNode.ancestry,
         ancestryIndex,
         [
@@ -120,7 +120,7 @@ function getArgumentOrdinal(
     let arrayWrapperXorNode: PQP.Parser.TXorNode;
     switch (maybePreviousXor?.node.kind) {
         case PQP.Language.Ast.NodeKind.Constant: {
-            arrayWrapperXorNode = PQP.Parser.NodeIdMapUtils.assertGetNthChild(
+            arrayWrapperXorNode = PQP.Parser.NodeIdMapUtils.assertGetNthChildChecked(
                 nodeIdMapCollection,
                 invokeExpressionXorNode.node.id,
                 1,
@@ -137,7 +137,7 @@ function getArgumentOrdinal(
 
         case undefined:
         default:
-            throw new CommonError.InvariantError(`encountered an unknown scenario for getARgumentOrdinal`, {
+            throw new PQP.CommonError.InvariantError(`encountered an unknown scenario for getArgumentOrdinal`, {
                 ancestryIndex,
                 ancestryNodeKinds: activeNode.ancestry.map((xorNode: PQP.Parser.TXorNode) => xorNode.node.kind),
             });

--- a/src/powerquery-language-services/inspection/invokeExpression/currentInvokeExpression.ts
+++ b/src/powerquery-language-services/inspection/invokeExpression/currentInvokeExpression.ts
@@ -120,11 +120,11 @@ function getArgumentOrdinal(
     let arrayWrapperXorNode: PQP.Parser.TXorNode;
     switch (maybePreviousXor?.node.kind) {
         case PQP.Language.Ast.NodeKind.Constant: {
-            arrayWrapperXorNode = PQP.Parser.NodeIdMapUtils.assertGetChildXorByAttributeIndex(
+            arrayWrapperXorNode = PQP.Parser.NodeIdMapUtils.assertGetNthChild(
                 nodeIdMapCollection,
                 invokeExpressionXorNode.node.id,
                 1,
-                [PQP.Language.Ast.NodeKind.ArrayWrapper],
+                PQP.Language.Ast.NodeKind.ArrayWrapper,
             );
 
             break;

--- a/src/powerquery-language-services/inspection/invokeExpression/currentInvokeExpression.ts
+++ b/src/powerquery-language-services/inspection/invokeExpression/currentInvokeExpression.ts
@@ -3,6 +3,15 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { ResultUtils } from "@microsoft/powerquery-parser";
+import { Ast } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import {
+    AncestryUtils,
+    NodeIdMap,
+    NodeIdMapUtils,
+    TXorNode,
+} from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
+
 import { InspectionSettings } from "../../inspectionSettings";
 
 import { ActiveNode, ActiveNodeUtils, TMaybeActiveNode } from "../activeNode";
@@ -22,48 +31,46 @@ export interface CurrentInvokeExpressionArguments extends InvokeExpressionArgume
 
 export function tryCurrentInvokeExpression(
     settings: InspectionSettings,
-    nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
+    nodeIdMapCollection: NodeIdMap.Collection,
     maybeActiveNode: TMaybeActiveNode,
     // If a TypeCache is given, then potentially add to its values and include it as part of the return,
     // Else create a new TypeCache and include it in the return.
     typeCache: TypeCache = TypeCacheUtils.createEmptyCache(),
 ): TriedCurrentInvokeExpression {
     if (!ActiveNodeUtils.isPositionInBounds(maybeActiveNode)) {
-        return PQP.ResultUtils.createOk(undefined);
+        return ResultUtils.boxOk(undefined);
     }
 
-    return PQP.ResultUtils.ensureResult(settings.locale, () =>
+    return ResultUtils.ensureResult(settings.locale, () =>
         inspectInvokeExpression(settings, nodeIdMapCollection, maybeActiveNode, typeCache),
     );
 }
 
 function inspectInvokeExpression(
     settings: InspectionSettings,
-    nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
+    nodeIdMapCollection: NodeIdMap.Collection,
     activeNode: ActiveNode,
     typeCache: TypeCache,
 ): CurrentInvokeExpression | undefined {
-    const ancestry: ReadonlyArray<PQP.Parser.TXorNode> = activeNode.ancestry;
+    const ancestry: ReadonlyArray<TXorNode> = activeNode.ancestry;
 
-    const maybeInvokeExpression:
-        | [PQP.Parser.TXorNode, number]
-        | undefined = PQP.Parser.AncestryUtils.maybeFirstXorAndIndexOfNodeKind(
+    const maybeInvokeExpression: [TXorNode, number] | undefined = AncestryUtils.maybeFirstXorAndIndexOfNodeKind(
         ancestry,
-        PQP.Language.Ast.NodeKind.InvokeExpression,
+        Ast.NodeKind.InvokeExpression,
     );
 
     if (!maybeInvokeExpression) {
         return undefined;
     }
 
-    const [invokeExpressionXorNode, ancestryIndex]: [PQP.Parser.TXorNode, number] = maybeInvokeExpression;
+    const [invokeExpressionXorNode, ancestryIndex]: [TXorNode, number] = maybeInvokeExpression;
     const triedInvokeExpression: TriedInvokeExpression = tryInvokeExpression(
         settings,
         nodeIdMapCollection,
         invokeExpressionXorNode.node.id,
         typeCache,
     );
-    if (PQP.ResultUtils.isError(triedInvokeExpression)) {
+    if (ResultUtils.isError(triedInvokeExpression)) {
         throw triedInvokeExpression;
     }
 
@@ -90,47 +97,47 @@ function inspectInvokeExpression(
 }
 
 function getArgumentOrdinal(
-    nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
+    nodeIdMapCollection: NodeIdMap.Collection,
     activeNode: ActiveNode,
     ancestryIndex: number,
-    invokeExpressionXorNode: PQP.Parser.TXorNode,
+    invokeExpressionXorNode: TXorNode,
 ): number {
     // `foo(1|)
-    const maybeAncestoryCsv: PQP.Parser.TXorNode | undefined = PQP.Parser.AncestryUtils.maybeNthPreviousXorChecked(
+    const maybeAncestoryCsv: TXorNode | undefined = AncestryUtils.maybeNthPreviousXorChecked(
         activeNode.ancestry,
         ancestryIndex,
         2,
-        PQP.Language.Ast.NodeKind.Csv,
+        Ast.NodeKind.Csv,
     );
     if (maybeAncestoryCsv !== undefined) {
         return maybeAncestoryCsv.node.maybeAttributeIndex ?? 0;
     }
 
-    const maybePreviousXor: PQP.Parser.TXorNode | undefined = PQP.Parser.AncestryUtils.maybePreviousXorChecked(
+    const maybePreviousXor: TXorNode | undefined = AncestryUtils.maybePreviousXorChecked(
         activeNode.ancestry,
         ancestryIndex,
         [
             // `foo(|)`
-            PQP.Language.Ast.NodeKind.ArrayWrapper,
+            Ast.NodeKind.ArrayWrapper,
             // `foo(1|`
-            PQP.Language.Ast.NodeKind.Constant,
+            Ast.NodeKind.Constant,
         ],
     );
 
-    let arrayWrapperXorNode: PQP.Parser.TXorNode;
+    let arrayWrapperXorNode: TXorNode;
     switch (maybePreviousXor?.node.kind) {
-        case PQP.Language.Ast.NodeKind.Constant: {
-            arrayWrapperXorNode = PQP.Parser.NodeIdMapUtils.assertGetNthChildChecked(
+        case Ast.NodeKind.Constant: {
+            arrayWrapperXorNode = NodeIdMapUtils.assertGetNthChildChecked(
                 nodeIdMapCollection,
                 invokeExpressionXorNode.node.id,
                 1,
-                PQP.Language.Ast.NodeKind.ArrayWrapper,
+                Ast.NodeKind.ArrayWrapper,
             );
 
             break;
         }
 
-        case PQP.Language.Ast.NodeKind.ArrayWrapper: {
+        case Ast.NodeKind.ArrayWrapper: {
             arrayWrapperXorNode = maybePreviousXor;
             break;
         }
@@ -139,7 +146,7 @@ function getArgumentOrdinal(
         default:
             throw new PQP.CommonError.InvariantError(`encountered an unknown scenario for getArgumentOrdinal`, {
                 ancestryIndex,
-                ancestryNodeKinds: activeNode.ancestry.map((xorNode: PQP.Parser.TXorNode) => xorNode.node.kind),
+                ancestryNodeKinds: activeNode.ancestry.map((xorNode: TXorNode) => xorNode.node.kind),
             });
     }
 

--- a/src/powerquery-language-services/inspection/invokeExpression/invokeExpression.ts
+++ b/src/powerquery-language-services/inspection/invokeExpression/invokeExpression.ts
@@ -4,6 +4,7 @@
 import * as PQP from "@microsoft/powerquery-parser";
 
 import { Assert } from "@microsoft/powerquery-parser";
+import { XorNodeUtils } from "../../../../../powerquery-parser/lib/powerquery-parser/parser";
 
 import { InspectionSettings } from "../../inspectionSettings";
 import { assertGetOrCreateNodeScope, NodeScope, ScopeItemKind, TScopeItem } from "../scope";
@@ -48,7 +49,7 @@ function inspectInvokeExpression(
     }
     const invokeExpressionXorNode: PQP.Parser.TXorNode = maybeInvokeExpressionXorNode;
 
-    PQP.Parser.XorNodeUtils.assertIsNodeKind(invokeExpressionXorNode, PQP.Language.Ast.NodeKind.InvokeExpression);
+    XorNodeUtils.assertIsInvokeExpression(invokeExpressionXorNode);
 
     const previousNode: PQP.Parser.TXorNode = PQP.Parser.NodeIdMapUtils.assertGetRecursiveExpressionPreviousSibling(
         nodeIdMapCollection,

--- a/src/powerquery-language-services/inspection/invokeExpression/invokeExpression.ts
+++ b/src/powerquery-language-services/inspection/invokeExpression/invokeExpression.ts
@@ -48,7 +48,7 @@ function inspectInvokeExpression(
     }
     const invokeExpressionXorNode: PQP.Parser.TXorNode = maybeInvokeExpressionXorNode;
 
-    PQP.Parser.XorNodeUtils.assertAstNodeKind(invokeExpressionXorNode, PQP.Language.Ast.NodeKind.InvokeExpression);
+    PQP.Parser.XorNodeUtils.assertIsNodeKind(invokeExpressionXorNode, PQP.Language.Ast.NodeKind.InvokeExpression);
 
     const previousNode: PQP.Parser.TXorNode = PQP.Parser.NodeIdMapUtils.assertGetRecursiveExpressionPreviousSibling(
         nodeIdMapCollection,

--- a/src/powerquery-language-services/inspection/pseudoFunctionExpressionType.ts
+++ b/src/powerquery-language-services/inspection/pseudoFunctionExpressionType.ts
@@ -94,7 +94,7 @@ function functionParameterXorNodes(
     if (maybeParameterList === undefined) {
         return [];
     }
-    const maybeWrappedContent: TXorNode | undefined = NodeIdMapUtils.maybeWrappedContent(
+    const maybeWrappedContent: TXorNode | undefined = NodeIdMapUtils.maybeUnboxWrappedContent(
         nodeIdMapCollection,
         maybeParameterList.node.id,
     );

--- a/src/powerquery-language-services/inspection/scope/scope.ts
+++ b/src/powerquery-language-services/inspection/scope/scope.ts
@@ -3,8 +3,11 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { Ast, Constant, Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { TXorNode } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
+
 // Keys are identifier literals.
-export type ScopeTypeByKey = Map<string, PQP.Language.Type.TPowerQueryType>;
+export type ScopeTypeByKey = Map<string, Type.TPowerQueryType>;
 
 export type TriedNodeScope = PQP.Result<NodeScope, PQP.CommonError.CommonError>;
 
@@ -44,37 +47,34 @@ export interface IScopeItem {
 }
 
 export interface IKeyValuePairScopeItem<
-    Key extends PQP.Language.Ast.Identifier | PQP.Language.Ast.GeneralizedIdentifier,
+    Key extends Ast.Identifier | Ast.GeneralizedIdentifier,
     Kind extends ScopeItemKind.LetVariable | ScopeItemKind.RecordField | ScopeItemKind.SectionMember
 > extends IScopeItem {
     readonly kind: Kind;
     readonly key: Key;
-    readonly maybeValue: PQP.Parser.TXorNode | undefined;
+    readonly maybeValue: TXorNode | undefined;
 }
 
 export interface EachScopeItem extends IScopeItem {
     readonly kind: ScopeItemKind.Each;
-    readonly eachExpression: PQP.Parser.TXorNode;
+    readonly eachExpression: TXorNode;
 }
 
-export type LetVariableScopeItem = IKeyValuePairScopeItem<PQP.Language.Ast.Identifier, ScopeItemKind.LetVariable>;
+export type LetVariableScopeItem = IKeyValuePairScopeItem<Ast.Identifier, ScopeItemKind.LetVariable>;
 
 export interface ParameterScopeItem extends IScopeItem {
     readonly kind: ScopeItemKind.Parameter;
-    readonly name: PQP.Language.Ast.Identifier;
+    readonly name: Ast.Identifier;
     readonly isOptional: boolean;
     readonly isNullable: boolean;
-    readonly maybeType: PQP.Language.Constant.PrimitiveTypeConstantKind | undefined;
+    readonly maybeType: Constant.PrimitiveTypeConstantKind | undefined;
 }
 
-export type RecordFieldScopeItem = IKeyValuePairScopeItem<
-    PQP.Language.Ast.GeneralizedIdentifier,
-    ScopeItemKind.RecordField
->;
+export type RecordFieldScopeItem = IKeyValuePairScopeItem<Ast.GeneralizedIdentifier, ScopeItemKind.RecordField>;
 
-export type SectionMemberScopeItem = IKeyValuePairScopeItem<PQP.Language.Ast.Identifier, ScopeItemKind.SectionMember>;
+export type SectionMemberScopeItem = IKeyValuePairScopeItem<Ast.Identifier, ScopeItemKind.SectionMember>;
 
 export interface UndefinedScopeItem extends IScopeItem {
     readonly kind: ScopeItemKind.Undefined;
-    readonly xorNode: PQP.Parser.TXorNode;
+    readonly xorNode: TXorNode;
 }

--- a/src/powerquery-language-services/inspection/scope/scopeInspection.ts
+++ b/src/powerquery-language-services/inspection/scope/scopeInspection.ts
@@ -6,6 +6,7 @@ import * as PQP from "@microsoft/powerquery-parser";
 import { Assert } from "@microsoft/powerquery-parser";
 
 import { Inspection } from "../..";
+import { XorNodeUtils } from "../../../../../powerquery-parser/lib/powerquery-parser/parser";
 import {
     PseduoFunctionExpressionType,
     pseudoFunctionExpressionType,
@@ -75,9 +76,9 @@ export function maybeDereferencedIdentifier(
     // Else create a new Map instance and return that instead.
     scopeById: ScopeById = new Map(),
 ): PQP.Result<PQP.Parser.TXorNode | undefined, PQP.CommonError.CommonError> {
-    PQP.Parser.XorNodeUtils.assertIsIdentifier(xorNode);
+    XorNodeUtils.assertIsIdentifier(xorNode);
 
-    if (PQP.Parser.XorNodeUtils.isContextXor(xorNode)) {
+    if (XorNodeUtils.isContextXor(xorNode)) {
         return PQP.ResultUtils.createOk(undefined);
     }
     const identifier: PQP.Language.Ast.Identifier | PQP.Language.Ast.IdentifierExpression = xorNode.node as
@@ -146,7 +147,7 @@ export function maybeDereferencedIdentifier(
     if (maybeNextXorNode === undefined) {
         return PQP.ResultUtils.createOk(xorNode);
     } else if (
-        PQP.Parser.XorNodeUtils.isContextXor(maybeNextXorNode) ||
+        XorNodeUtils.isContextXor(maybeNextXorNode) ||
         (maybeNextXorNode.node.kind !== PQP.Language.Ast.NodeKind.Identifier &&
             maybeNextXorNode.node.kind !== PQP.Language.Ast.NodeKind.IdentifierExpression)
     ) {
@@ -233,7 +234,7 @@ function inspectNode(state: ScopeInspectionState, xorNode: PQP.Parser.TXorNode):
 }
 
 function inspectEachExpression(state: ScopeInspectionState, eachExpr: PQP.Parser.TXorNode): void {
-    PQP.Parser.XorNodeUtils.assertIsNodeKind(eachExpr, PQP.Language.Ast.NodeKind.EachExpression);
+    XorNodeUtils.assertIsNodeKind(eachExpr, PQP.Language.Ast.NodeKind.EachExpression);
     expandChildScope(
         state,
         eachExpr,
@@ -254,7 +255,7 @@ function inspectEachExpression(state: ScopeInspectionState, eachExpr: PQP.Parser
 }
 
 function inspectFunctionExpression(state: ScopeInspectionState, fnExpr: PQP.Parser.TXorNode): void {
-    PQP.Parser.XorNodeUtils.assertIsNodeKind(fnExpr, PQP.Language.Ast.NodeKind.FunctionExpression);
+    XorNodeUtils.assertIsNodeKind(fnExpr, PQP.Language.Ast.NodeKind.FunctionExpression);
 
     // Propegates the parent's scope.
     const nodeScope: NodeScope = localGetOrCreateNodeScope(state, fnExpr.node.id, undefined);
@@ -283,7 +284,7 @@ function inspectFunctionExpression(state: ScopeInspectionState, fnExpr: PQP.Pars
 }
 
 function inspectLetExpression(state: ScopeInspectionState, letExpr: PQP.Parser.TXorNode): void {
-    PQP.Parser.XorNodeUtils.assertIsNodeKind(letExpr, PQP.Language.Ast.NodeKind.LetExpression);
+    XorNodeUtils.assertIsNodeKind<PQP.Language.Ast.LetExpression>(letExpr, PQP.Language.Ast.NodeKind.LetExpression);
 
     // Propegates the parent's scope.
     const nodeScope: NodeScope = localGetOrCreateNodeScope(state, letExpr.node.id, undefined);
@@ -305,7 +306,7 @@ function inspectLetExpression(state: ScopeInspectionState, letExpr: PQP.Parser.T
 }
 
 function inspectRecordExpressionOrRecordLiteral(state: ScopeInspectionState, record: PQP.Parser.TXorNode): void {
-    PQP.Parser.XorNodeUtils.assertIsRecord(record);
+    XorNodeUtils.assertIsRecord(record);
 
     // Propegates the parent's scope.
     const nodeScope: NodeScope = localGetOrCreateNodeScope(state, record.node.id, undefined);
@@ -318,7 +319,7 @@ function inspectRecordExpressionOrRecordLiteral(state: ScopeInspectionState, rec
 }
 
 function inspectSection(state: ScopeInspectionState, section: PQP.Parser.TXorNode): void {
-    PQP.Parser.XorNodeUtils.assertIsNodeKind(section, PQP.Language.Ast.NodeKind.Section);
+    XorNodeUtils.assertIsNodeKind(section, PQP.Language.Ast.NodeKind.Section);
 
     const keyValuePairs: ReadonlyArray<PQP.Parser.NodeIdMapIterator.SectionKeyValuePair> = PQP.Parser.NodeIdMapIterator.iterSection(
         state.nodeIdMapCollection,

--- a/src/powerquery-language-services/inspection/scope/scopeInspection.ts
+++ b/src/powerquery-language-services/inspection/scope/scopeInspection.ts
@@ -77,7 +77,7 @@ export function maybeDereferencedIdentifier(
 ): PQP.Result<PQP.Parser.TXorNode | undefined, PQP.CommonError.CommonError> {
     PQP.Parser.XorNodeUtils.assertIsIdentifier(xorNode);
 
-    if (PQP.Parser.XorNodeUtils.isContext(xorNode)) {
+    if (PQP.Parser.XorNodeUtils.isContextXor(xorNode)) {
         return PQP.ResultUtils.createOk(undefined);
     }
     const identifier: PQP.Language.Ast.Identifier | PQP.Language.Ast.IdentifierExpression = xorNode.node as
@@ -146,7 +146,7 @@ export function maybeDereferencedIdentifier(
     if (maybeNextXorNode === undefined) {
         return PQP.ResultUtils.createOk(xorNode);
     } else if (
-        PQP.Parser.XorNodeUtils.isContext(maybeNextXorNode) ||
+        PQP.Parser.XorNodeUtils.isContextXor(maybeNextXorNode) ||
         (maybeNextXorNode.node.kind !== PQP.Language.Ast.NodeKind.Identifier &&
             maybeNextXorNode.node.kind !== PQP.Language.Ast.NodeKind.IdentifierExpression)
     ) {
@@ -233,7 +233,7 @@ function inspectNode(state: ScopeInspectionState, xorNode: PQP.Parser.TXorNode):
 }
 
 function inspectEachExpression(state: ScopeInspectionState, eachExpr: PQP.Parser.TXorNode): void {
-    PQP.Parser.XorNodeUtils.assertAstNodeKind(eachExpr, PQP.Language.Ast.NodeKind.EachExpression);
+    PQP.Parser.XorNodeUtils.assertIsNodeKind(eachExpr, PQP.Language.Ast.NodeKind.EachExpression);
     expandChildScope(
         state,
         eachExpr,
@@ -254,7 +254,7 @@ function inspectEachExpression(state: ScopeInspectionState, eachExpr: PQP.Parser
 }
 
 function inspectFunctionExpression(state: ScopeInspectionState, fnExpr: PQP.Parser.TXorNode): void {
-    PQP.Parser.XorNodeUtils.assertAstNodeKind(fnExpr, PQP.Language.Ast.NodeKind.FunctionExpression);
+    PQP.Parser.XorNodeUtils.assertIsNodeKind(fnExpr, PQP.Language.Ast.NodeKind.FunctionExpression);
 
     // Propegates the parent's scope.
     const nodeScope: NodeScope = localGetOrCreateNodeScope(state, fnExpr.node.id, undefined);
@@ -283,7 +283,7 @@ function inspectFunctionExpression(state: ScopeInspectionState, fnExpr: PQP.Pars
 }
 
 function inspectLetExpression(state: ScopeInspectionState, letExpr: PQP.Parser.TXorNode): void {
-    PQP.Parser.XorNodeUtils.assertAstNodeKind(letExpr, PQP.Language.Ast.NodeKind.LetExpression);
+    PQP.Parser.XorNodeUtils.assertIsNodeKind(letExpr, PQP.Language.Ast.NodeKind.LetExpression);
 
     // Propegates the parent's scope.
     const nodeScope: NodeScope = localGetOrCreateNodeScope(state, letExpr.node.id, undefined);
@@ -318,7 +318,7 @@ function inspectRecordExpressionOrRecordLiteral(state: ScopeInspectionState, rec
 }
 
 function inspectSection(state: ScopeInspectionState, section: PQP.Parser.TXorNode): void {
-    PQP.Parser.XorNodeUtils.assertAstNodeKind(section, PQP.Language.Ast.NodeKind.Section);
+    PQP.Parser.XorNodeUtils.assertIsNodeKind(section, PQP.Language.Ast.NodeKind.Section);
 
     const keyValuePairs: ReadonlyArray<PQP.Parser.NodeIdMapIterator.SectionKeyValuePair> = PQP.Parser.NodeIdMapIterator.iterSection(
         state.nodeIdMapCollection,
@@ -388,11 +388,10 @@ function expandChildScope(
 
     // TODO: optimize this
     for (const attributeId of childAttributeIds) {
-        const maybeChild: PQP.Parser.TXorNode | undefined = PQP.Parser.NodeIdMapUtils.maybeChildXorByAttributeIndex(
+        const maybeChild: PQP.Parser.TXorNode | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChild(
             nodeIdMapCollection,
             parentId,
             attributeId,
-            undefined,
         );
         if (maybeChild !== undefined) {
             expandScope(state, maybeChild, newEntries, maybeDefaultScope);
@@ -431,7 +430,6 @@ function localGetOrCreateNodeScope(
     const maybeParent: PQP.Parser.TXorNode | undefined = PQP.Parser.NodeIdMapUtils.maybeParentXor(
         state.nodeIdMapCollection,
         nodeId,
-        undefined,
     );
     if (maybeParent !== undefined) {
         const parentNodeId: number = maybeParent.node.id;

--- a/src/powerquery-language-services/inspection/task.ts
+++ b/src/powerquery-language-services/inspection/task.ts
@@ -3,6 +3,7 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { NodeIdMap, TXorNode } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 import type { Position } from "vscode-languageserver-types";
 
 import { InspectionSettings } from "../inspectionSettings";
@@ -25,7 +26,7 @@ export function inspection(
     // Else create a new TypeCache and include it in the return.
     typeCache: TypeCache = TypeCacheUtils.createEmptyCache(),
 ): Inspection {
-    const nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection = parseState.contextState.nodeIdMapCollection;
+    const nodeIdMapCollection: NodeIdMap.Collection = parseState.contextState.nodeIdMapCollection;
 
     // We should only get an undefined for activeNode iff the document is empty
     const maybeActiveNode: TMaybeActiveNode = ActiveNodeUtils.maybeActiveNode(nodeIdMapCollection, position);
@@ -50,14 +51,14 @@ export function inspection(
             typeCache.scopeById,
         );
 
-        const ancestryLeaf: PQP.Parser.TXorNode = PQP.Parser.AncestryUtils.assertGetLeaf(activeNode.ancestry);
+        const ancestryLeaf: TXorNode = PQP.Parser.AncestryUtils.assertGetLeaf(activeNode.ancestry);
         triedScopeType = tryScopeType(settings, nodeIdMapCollection, ancestryLeaf.node.id, typeCache);
 
         triedExpectedType = tryExpectedType(settings, activeNode);
     } else {
-        triedNodeScope = PQP.ResultUtils.createOk(new Map());
-        triedScopeType = PQP.ResultUtils.createOk(new Map());
-        triedExpectedType = PQP.ResultUtils.createOk(undefined);
+        triedNodeScope = PQP.ResultUtils.boxOk(new Map());
+        triedScopeType = PQP.ResultUtils.boxOk(new Map());
+        triedExpectedType = PQP.ResultUtils.boxOk(undefined);
     }
 
     return {

--- a/src/powerquery-language-services/inspection/type/inspectType/common.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/common.ts
@@ -136,11 +136,10 @@ export function inspectTypeFromChildAttributeIndex(
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
 
-    const maybeXorNode: PQP.Parser.TXorNode | undefined = PQP.Parser.NodeIdMapUtils.maybeChildXorByAttributeIndex(
+    const maybeXorNode: PQP.Parser.TXorNode | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChild(
         state.nodeIdMapCollection,
         parentXorNode.node.id,
         attributeIndex,
-        undefined,
     );
     return maybeXorNode !== undefined ? inspectXor(state, maybeXorNode) : PQP.Language.Type.UnknownInstance;
 }

--- a/src/powerquery-language-services/inspection/type/inspectType/common.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/common.ts
@@ -6,6 +6,7 @@ import * as PQP from "@microsoft/powerquery-parser";
 import { Assert } from "@microsoft/powerquery-parser";
 
 import { Inspection } from "../../..";
+import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
 import { InspectionSettings } from "../../../inspectionSettings";
 import { ExternalType, ExternalTypeUtils } from "../../externalType";
 import { NodeScope, ParameterScopeItem, ScopeById, ScopeItemKind, tryNodeScope, TScopeItem } from "../../scope";
@@ -400,7 +401,7 @@ export function recursiveIdentifierDereference(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Parser.TXorNode {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertIsIdentifier(xorNode);
+    XorNodeUtils.assertIsIdentifier(xorNode);
 
     return Assert.asDefined(recursiveIdentifierDereferenceHelper(state, xorNode));
 }
@@ -411,14 +412,12 @@ function recursiveIdentifierDereferenceHelper(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Parser.TXorNode | undefined {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertIsIdentifier(xorNode);
+    XorNodeUtils.assertIsIdentifier(xorNode);
 
     if (xorNode.kind === PQP.Parser.XorNodeKind.Context) {
         return undefined;
     }
-    const identifier: PQP.Language.Ast.Identifier | PQP.Language.Ast.IdentifierExpression = xorNode.node as
-        | PQP.Language.Ast.Identifier
-        | PQP.Language.Ast.IdentifierExpression;
+    const identifier: PQP.Language.Ast.Identifier | PQP.Language.Ast.IdentifierExpression = xorNode.node;
     const identifierId: number = identifier.id;
 
     let identifierLiteral: string;

--- a/src/powerquery-language-services/inspection/type/inspectType/examineFieldSpecificationList.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/examineFieldSpecificationList.ts
@@ -3,6 +3,8 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+
 import { InspectTypeState } from "./common";
 import { inspectTypeFieldSpecification } from "./inspectTypeFieldSpecification";
 
@@ -17,18 +19,18 @@ export function examineFieldSpecificationList(
     xorNode: PQP.Parser.TXorNode,
 ): ExaminedFieldSpecificationList {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.FieldSpecificationList);
+    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.FieldSpecificationList);
 
     const nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection = state.nodeIdMapCollection;
     const fields: [string, PQP.Language.Type.TPowerQueryType][] = [];
 
     for (const fieldSpecification of PQP.Parser.NodeIdMapIterator.iterFieldSpecification(
         nodeIdMapCollection,
-        xorNode,
+        XorNodeUtils.assertAsFunctionParameterList(xorNode),
     )) {
         const maybeName:
             | PQP.Language.Ast.GeneralizedIdentifier
-            | undefined = PQP.Parser.NodeIdMapUtils.maybeUnwrapNthChildIfAst(
+            | undefined = PQP.Parser.NodeIdMapUtils.maybeUnwrapNthChildIfAstChecked(
             nodeIdMapCollection,
             fieldSpecification.node.id,
             1,
@@ -43,7 +45,7 @@ export function examineFieldSpecificationList(
     }
 
     const isOpen: boolean =
-        PQP.Parser.NodeIdMapUtils.maybeNthChild(
+        PQP.Parser.NodeIdMapUtils.maybeNthChildChecked(
             nodeIdMapCollection,
             xorNode.node.id,
             3,

--- a/src/powerquery-language-services/inspection/type/inspectType/examineFieldSpecificationList.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/examineFieldSpecificationList.ts
@@ -17,7 +17,7 @@ export function examineFieldSpecificationList(
     xorNode: PQP.Parser.TXorNode,
 ): ExaminedFieldSpecificationList {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertAstNodeKind(xorNode, PQP.Language.Ast.NodeKind.FieldSpecificationList);
+    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.FieldSpecificationList);
 
     const nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection = state.nodeIdMapCollection;
     const fields: [string, PQP.Language.Type.TPowerQueryType][] = [];
@@ -27,26 +27,28 @@ export function examineFieldSpecificationList(
         xorNode,
     )) {
         const maybeName:
-            | PQP.Language.Ast.TNode
-            | undefined = PQP.Parser.NodeIdMapUtils.maybeChildAstByAttributeIndex(
+            | PQP.Language.Ast.GeneralizedIdentifier
+            | undefined = PQP.Parser.NodeIdMapUtils.maybeUnwrapNthChildIfAst(
             nodeIdMapCollection,
             fieldSpecification.node.id,
             1,
-            [PQP.Language.Ast.NodeKind.GeneralizedIdentifier],
+            PQP.Language.Ast.NodeKind.GeneralizedIdentifier,
         );
 
         if (maybeName === undefined) {
             break;
         }
-        const name: string = (maybeName as PQP.Language.Ast.GeneralizedIdentifier).literal;
         const type: PQP.Language.Type.TPowerQueryType = inspectTypeFieldSpecification(state, fieldSpecification);
-        fields.push([name, type]);
+        fields.push([maybeName.literal, type]);
     }
 
     const isOpen: boolean =
-        PQP.Parser.NodeIdMapUtils.maybeChildAstByAttributeIndex(nodeIdMapCollection, xorNode.node.id, 3, [
+        PQP.Parser.NodeIdMapUtils.maybeNthChild(
+            nodeIdMapCollection,
+            xorNode.node.id,
+            3,
             PQP.Language.Ast.NodeKind.Constant,
-        ]) !== undefined;
+        ) !== undefined;
 
     return {
         fields: new Map(fields),

--- a/src/powerquery-language-services/inspection/type/inspectType/examineFieldSpecificationList.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/examineFieldSpecificationList.ts
@@ -1,56 +1,55 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
-
-import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+import { Ast, Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import {
+    NodeIdMap,
+    NodeIdMapIterator,
+    NodeIdMapUtils,
+    TXorNode,
+    XorNodeUtils,
+} from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
 import { InspectTypeState } from "./common";
 import { inspectTypeFieldSpecification } from "./inspectTypeFieldSpecification";
 
 export interface ExaminedFieldSpecificationList {
-    readonly fields: Map<string, PQP.Language.Type.TPowerQueryType>;
+    readonly fields: Map<string, Type.TPowerQueryType>;
     readonly isOpen: boolean;
 }
 
 // It's called an examination instead of inspection because it doesn't return TType.
 export function examineFieldSpecificationList(
     state: InspectTypeState,
-    xorNode: PQP.Parser.TXorNode,
+    xorNode: TXorNode,
 ): ExaminedFieldSpecificationList {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.FieldSpecificationList);
+    XorNodeUtils.assertIsNodeKind(xorNode, Ast.NodeKind.FieldSpecificationList);
 
-    const nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection = state.nodeIdMapCollection;
-    const fields: [string, PQP.Language.Type.TPowerQueryType][] = [];
+    const nodeIdMapCollection: NodeIdMap.Collection = state.nodeIdMapCollection;
+    const fields: [string, Type.TPowerQueryType][] = [];
 
-    for (const fieldSpecification of PQP.Parser.NodeIdMapIterator.iterFieldSpecification(
+    for (const fieldSpecification of NodeIdMapIterator.iterFieldSpecification(
         nodeIdMapCollection,
         XorNodeUtils.assertAsFunctionParameterList(xorNode),
     )) {
-        const maybeName:
-            | PQP.Language.Ast.GeneralizedIdentifier
-            | undefined = PQP.Parser.NodeIdMapUtils.maybeUnwrapNthChildIfAstChecked(
+        const maybeName: Ast.GeneralizedIdentifier | undefined = NodeIdMapUtils.maybeUnboxNthChildIfAstChecked(
             nodeIdMapCollection,
             fieldSpecification.node.id,
             1,
-            PQP.Language.Ast.NodeKind.GeneralizedIdentifier,
+            Ast.NodeKind.GeneralizedIdentifier,
         );
 
         if (maybeName === undefined) {
             break;
         }
-        const type: PQP.Language.Type.TPowerQueryType = inspectTypeFieldSpecification(state, fieldSpecification);
+        const type: Type.TPowerQueryType = inspectTypeFieldSpecification(state, fieldSpecification);
         fields.push([maybeName.literal, type]);
     }
 
     const isOpen: boolean =
-        PQP.Parser.NodeIdMapUtils.maybeNthChildChecked(
-            nodeIdMapCollection,
-            xorNode.node.id,
-            3,
-            PQP.Language.Ast.NodeKind.Constant,
-        ) !== undefined;
+        NodeIdMapUtils.maybeNthChildChecked(nodeIdMapCollection, xorNode.node.id, 3, Ast.NodeKind.Constant) !==
+        undefined;
 
     return {
         fields: new Map(fields),

--- a/src/powerquery-language-services/inspection/type/inspectType/examineFieldSpecificationList.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/examineFieldSpecificationList.ts
@@ -24,7 +24,7 @@ export function examineFieldSpecificationList(
     xorNode: TXorNode,
 ): ExaminedFieldSpecificationList {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    XorNodeUtils.assertIsNodeKind(xorNode, Ast.NodeKind.FieldSpecificationList);
+    XorNodeUtils.assertIsNodeKind<Ast.FieldSpecificationList>(xorNode, Ast.NodeKind.FieldSpecificationList);
 
     const nodeIdMapCollection: NodeIdMap.Collection = state.nodeIdMapCollection;
     const fields: [string, Type.TPowerQueryType][] = [];

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeConstant.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeConstant.ts
@@ -3,8 +3,10 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+
 export function inspectTypeConstant(xorNode: PQP.Parser.TXorNode): PQP.Language.Type.TPowerQueryType {
-    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.Constant);
+    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.Constant);
 
     if (xorNode.kind === PQP.Parser.XorNodeKind.Context) {
         return PQP.Language.Type.UnknownInstance;

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeConstant.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeConstant.ts
@@ -4,7 +4,7 @@
 import * as PQP from "@microsoft/powerquery-parser";
 
 export function inspectTypeConstant(xorNode: PQP.Parser.TXorNode): PQP.Language.Type.TPowerQueryType {
-    PQP.Parser.XorNodeUtils.assertAstNodeKind(xorNode, PQP.Language.Ast.NodeKind.Constant);
+    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.Constant);
 
     if (xorNode.kind === PQP.Parser.XorNodeKind.Context) {
         return PQP.Language.Type.UnknownInstance;

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeConstant.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeConstant.ts
@@ -1,77 +1,76 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
+import { Ast, Constant, Type, TypeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { TXorNode, XorNodeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
-import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+export function inspectTypeConstant(xorNode: TXorNode): Type.TPowerQueryType {
+    XorNodeUtils.assertIsNodeKind<Ast.TConstant>(xorNode, Ast.NodeKind.Constant);
 
-export function inspectTypeConstant(xorNode: PQP.Parser.TXorNode): PQP.Language.Type.TPowerQueryType {
-    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.Constant);
-
-    if (xorNode.kind === PQP.Parser.XorNodeKind.Context) {
-        return PQP.Language.Type.UnknownInstance;
+    if (XorNodeUtils.isContextXor(xorNode)) {
+        return Type.UnknownInstance;
     }
 
-    const constant: PQP.Language.Ast.TConstant = xorNode.node as PQP.Language.Ast.TConstant;
+    const constant: Ast.TConstant = xorNode.node;
     switch (constant.constantKind) {
-        case PQP.Language.Constant.PrimitiveTypeConstantKind.Action:
-            return PQP.Language.TypeUtils.createPrimitiveType(false, PQP.Language.Type.TypeKind.Action);
+        case Constant.PrimitiveTypeConstantKind.Action:
+            return TypeUtils.createPrimitiveType(false, Type.TypeKind.Action);
 
-        case PQP.Language.Constant.PrimitiveTypeConstantKind.Any:
-            return PQP.Language.Type.AnyInstance;
+        case Constant.PrimitiveTypeConstantKind.Any:
+            return Type.AnyInstance;
 
-        case PQP.Language.Constant.PrimitiveTypeConstantKind.AnyNonNull:
-            return PQP.Language.TypeUtils.createPrimitiveType(false, PQP.Language.Type.TypeKind.AnyNonNull);
+        case Constant.PrimitiveTypeConstantKind.AnyNonNull:
+            return TypeUtils.createPrimitiveType(false, Type.TypeKind.AnyNonNull);
 
-        case PQP.Language.Constant.PrimitiveTypeConstantKind.Binary:
-            return PQP.Language.TypeUtils.createPrimitiveType(false, PQP.Language.Type.TypeKind.Binary);
+        case Constant.PrimitiveTypeConstantKind.Binary:
+            return TypeUtils.createPrimitiveType(false, Type.TypeKind.Binary);
 
-        case PQP.Language.Constant.PrimitiveTypeConstantKind.Date:
-            return PQP.Language.TypeUtils.createPrimitiveType(false, PQP.Language.Type.TypeKind.Date);
+        case Constant.PrimitiveTypeConstantKind.Date:
+            return TypeUtils.createPrimitiveType(false, Type.TypeKind.Date);
 
-        case PQP.Language.Constant.PrimitiveTypeConstantKind.DateTime:
-            return PQP.Language.TypeUtils.createPrimitiveType(false, PQP.Language.Type.TypeKind.DateTime);
+        case Constant.PrimitiveTypeConstantKind.DateTime:
+            return TypeUtils.createPrimitiveType(false, Type.TypeKind.DateTime);
 
-        case PQP.Language.Constant.PrimitiveTypeConstantKind.DateTimeZone:
-            return PQP.Language.TypeUtils.createPrimitiveType(false, PQP.Language.Type.TypeKind.DateTimeZone);
+        case Constant.PrimitiveTypeConstantKind.DateTimeZone:
+            return TypeUtils.createPrimitiveType(false, Type.TypeKind.DateTimeZone);
 
-        case PQP.Language.Constant.PrimitiveTypeConstantKind.Duration:
-            return PQP.Language.TypeUtils.createPrimitiveType(false, PQP.Language.Type.TypeKind.Duration);
+        case Constant.PrimitiveTypeConstantKind.Duration:
+            return TypeUtils.createPrimitiveType(false, Type.TypeKind.Duration);
 
-        case PQP.Language.Constant.PrimitiveTypeConstantKind.Function:
-            return PQP.Language.TypeUtils.createPrimitiveType(false, PQP.Language.Type.TypeKind.Function);
+        case Constant.PrimitiveTypeConstantKind.Function:
+            return TypeUtils.createPrimitiveType(false, Type.TypeKind.Function);
 
-        case PQP.Language.Constant.PrimitiveTypeConstantKind.List:
-            return PQP.Language.TypeUtils.createPrimitiveType(false, PQP.Language.Type.TypeKind.List);
+        case Constant.PrimitiveTypeConstantKind.List:
+            return TypeUtils.createPrimitiveType(false, Type.TypeKind.List);
 
-        case PQP.Language.Constant.PrimitiveTypeConstantKind.Logical:
-            return PQP.Language.TypeUtils.createPrimitiveType(false, PQP.Language.Type.TypeKind.Logical);
+        case Constant.PrimitiveTypeConstantKind.Logical:
+            return TypeUtils.createPrimitiveType(false, Type.TypeKind.Logical);
 
-        case PQP.Language.Constant.PrimitiveTypeConstantKind.None:
-            return PQP.Language.TypeUtils.createPrimitiveType(false, PQP.Language.Type.TypeKind.None);
+        case Constant.PrimitiveTypeConstantKind.None:
+            return TypeUtils.createPrimitiveType(false, Type.TypeKind.None);
 
-        case PQP.Language.Constant.PrimitiveTypeConstantKind.Null:
-            return PQP.Language.Type.NoneInstance;
+        case Constant.PrimitiveTypeConstantKind.Null:
+            return Type.NoneInstance;
 
-        case PQP.Language.Constant.PrimitiveTypeConstantKind.Number:
-            return PQP.Language.TypeUtils.createPrimitiveType(false, PQP.Language.Type.TypeKind.Number);
+        case Constant.PrimitiveTypeConstantKind.Number:
+            return TypeUtils.createPrimitiveType(false, Type.TypeKind.Number);
 
-        case PQP.Language.Constant.PrimitiveTypeConstantKind.Record:
-            return PQP.Language.TypeUtils.createPrimitiveType(false, PQP.Language.Type.TypeKind.Record);
+        case Constant.PrimitiveTypeConstantKind.Record:
+            return TypeUtils.createPrimitiveType(false, Type.TypeKind.Record);
 
-        case PQP.Language.Constant.PrimitiveTypeConstantKind.Table:
-            return PQP.Language.TypeUtils.createPrimitiveType(false, PQP.Language.Type.TypeKind.Table);
+        case Constant.PrimitiveTypeConstantKind.Table:
+            return TypeUtils.createPrimitiveType(false, Type.TypeKind.Table);
 
-        case PQP.Language.Constant.PrimitiveTypeConstantKind.Text:
-            return PQP.Language.TypeUtils.createPrimitiveType(false, PQP.Language.Type.TypeKind.Text);
+        case Constant.PrimitiveTypeConstantKind.Text:
+            return TypeUtils.createPrimitiveType(false, Type.TypeKind.Text);
 
-        case PQP.Language.Constant.PrimitiveTypeConstantKind.Time:
-            return PQP.Language.TypeUtils.createPrimitiveType(false, PQP.Language.Type.TypeKind.Time);
+        case Constant.PrimitiveTypeConstantKind.Time:
+            return TypeUtils.createPrimitiveType(false, Type.TypeKind.Time);
 
-        case PQP.Language.Constant.PrimitiveTypeConstantKind.Type:
-            return PQP.Language.TypeUtils.createPrimitiveType(false, PQP.Language.Type.TypeKind.Type);
+        case Constant.PrimitiveTypeConstantKind.Type:
+            return TypeUtils.createPrimitiveType(false, Type.TypeKind.Type);
 
         default:
-            return PQP.Language.Type.UnknownInstance;
+            return Type.UnknownInstance;
     }
 }

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeEachExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeEachExpression.ts
@@ -3,6 +3,8 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+
 import { inspectTypeFromChildAttributeIndex, InspectTypeState } from "./common";
 
 export function inspectTypeEachExpression(
@@ -10,7 +12,7 @@ export function inspectTypeEachExpression(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.EachExpression);
+    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.EachExpression);
 
     const expressionType: PQP.Language.Type.TPowerQueryType = inspectTypeFromChildAttributeIndex(state, xorNode, 1);
 

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeEachExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeEachExpression.ts
@@ -10,7 +10,7 @@ export function inspectTypeEachExpression(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertAstNodeKind(xorNode, PQP.Language.Ast.NodeKind.EachExpression);
+    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.EachExpression);
 
     const expressionType: PQP.Language.Type.TPowerQueryType = inspectTypeFromChildAttributeIndex(state, xorNode, 1);
 

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeEachExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeEachExpression.ts
@@ -1,28 +1,24 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
-
-import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+import { Ast, Type, TypeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { TXorNode, XorNodeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
 import { inspectTypeFromChildAttributeIndex, InspectTypeState } from "./common";
 
-export function inspectTypeEachExpression(
-    state: InspectTypeState,
-    xorNode: PQP.Parser.TXorNode,
-): PQP.Language.Type.TPowerQueryType {
+export function inspectTypeEachExpression(state: InspectTypeState, xorNode: TXorNode): Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.EachExpression);
+    XorNodeUtils.assertIsNodeKind(xorNode, Ast.NodeKind.EachExpression);
 
-    const expressionType: PQP.Language.Type.TPowerQueryType = inspectTypeFromChildAttributeIndex(state, xorNode, 1);
+    const expressionType: Type.TPowerQueryType = inspectTypeFromChildAttributeIndex(state, xorNode, 1);
 
-    return PQP.Language.TypeUtils.createDefinedFunction(
+    return TypeUtils.createDefinedFunction(
         false,
         [
             {
                 isNullable: false,
                 isOptional: false,
-                maybeType: PQP.Language.Type.TypeKind.Any,
+                maybeType: Type.TypeKind.Any,
                 nameLiteral: "_",
             },
         ],

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeErrorHandlingExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeErrorHandlingExpression.ts
@@ -10,15 +10,15 @@ export function inspectTypeErrorHandlingExpression(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertAstNodeKind(xorNode, PQP.Language.Ast.NodeKind.ErrorHandlingExpression);
+    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.ErrorHandlingExpression);
 
     const maybeOtherwiseExpression:
-        | PQP.Parser.TXorNode
-        | undefined = PQP.Parser.NodeIdMapUtils.maybeChildXorByAttributeIndex(
+        | PQP.Parser.XorNode<PQP.Language.Ast.OtherwiseExpression>
+        | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChild(
         state.nodeIdMapCollection,
         xorNode.node.id,
         2,
-        [PQP.Language.Ast.NodeKind.OtherwiseExpression],
+        PQP.Language.Ast.NodeKind.OtherwiseExpression,
     );
 
     return PQP.Language.TypeUtils.createAnyUnion([

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeErrorHandlingExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeErrorHandlingExpression.ts
@@ -3,6 +3,8 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+
 import { inspectTypeFromChildAttributeIndex, InspectTypeState, inspectXor } from "./common";
 
 export function inspectTypeErrorHandlingExpression(
@@ -10,11 +12,11 @@ export function inspectTypeErrorHandlingExpression(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.ErrorHandlingExpression);
+    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.ErrorHandlingExpression);
 
     const maybeOtherwiseExpression:
         | PQP.Parser.XorNode<PQP.Language.Ast.OtherwiseExpression>
-        | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChild(
+        | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChildChecked<PQP.Language.Ast.OtherwiseExpression>(
         state.nodeIdMapCollection,
         xorNode.node.id,
         2,

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeErrorHandlingExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeErrorHandlingExpression.ts
@@ -1,32 +1,28 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
-
-import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+import { Ast, Type, TypeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import {
+    NodeIdMapUtils,
+    TXorNode,
+    XorNode,
+    XorNodeUtils,
+} from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
 import { inspectTypeFromChildAttributeIndex, InspectTypeState, inspectXor } from "./common";
 
-export function inspectTypeErrorHandlingExpression(
-    state: InspectTypeState,
-    xorNode: PQP.Parser.TXorNode,
-): PQP.Language.Type.TPowerQueryType {
+export function inspectTypeErrorHandlingExpression(state: InspectTypeState, xorNode: TXorNode): Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.ErrorHandlingExpression);
+    XorNodeUtils.assertIsNodeKind(xorNode, Ast.NodeKind.ErrorHandlingExpression);
 
-    const maybeOtherwiseExpression:
-        | PQP.Parser.XorNode<PQP.Language.Ast.OtherwiseExpression>
-        | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChildChecked<PQP.Language.Ast.OtherwiseExpression>(
-        state.nodeIdMapCollection,
-        xorNode.node.id,
-        2,
-        PQP.Language.Ast.NodeKind.OtherwiseExpression,
-    );
+    const maybeOtherwiseExpression: XorNode<Ast.OtherwiseExpression> | undefined = NodeIdMapUtils.maybeNthChildChecked<
+        Ast.OtherwiseExpression
+    >(state.nodeIdMapCollection, xorNode.node.id, 2, Ast.NodeKind.OtherwiseExpression);
 
-    return PQP.Language.TypeUtils.createAnyUnion([
+    return TypeUtils.createAnyUnion([
         inspectTypeFromChildAttributeIndex(state, xorNode, 1),
         maybeOtherwiseExpression !== undefined
             ? inspectXor(state, maybeOtherwiseExpression)
-            : PQP.Language.TypeUtils.createPrimitiveType(false, PQP.Language.Type.TypeKind.Record),
+            : TypeUtils.createPrimitiveType(false, Type.TypeKind.Record),
     ]);
 }

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFieldProjection.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFieldProjection.ts
@@ -3,63 +3,66 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
-import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+import { Ast, Type, TypeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import {
+    NodeIdMapIterator,
+    NodeIdMapUtils,
+    TXorNode,
+    XorNodeUtils,
+} from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
 import { InspectTypeState, inspectXor } from "./common";
 
-export function inspectTypeFieldProjection(
-    state: InspectTypeState,
-    xorNode: PQP.Parser.TXorNode,
-): PQP.Language.Type.TPowerQueryType {
+export function inspectTypeFieldProjection(state: InspectTypeState, xorNode: TXorNode): Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.FieldProjection);
+    XorNodeUtils.assertIsNodeKind(xorNode, Ast.NodeKind.FieldProjection);
 
-    const projectedFieldNames: ReadonlyArray<string> = PQP.Parser.NodeIdMapIterator.iterFieldProjectionNames(
+    const projectedFieldNames: ReadonlyArray<string> = NodeIdMapIterator.iterFieldProjectionNames(
         state.nodeIdMapCollection,
         xorNode,
     );
-    const previousSibling: PQP.Parser.TXorNode = PQP.Parser.NodeIdMapUtils.assertGetRecursiveExpressionPreviousSibling(
+    const previousSibling: TXorNode = NodeIdMapUtils.assertGetRecursiveExpressionPreviousSibling(
         state.nodeIdMapCollection,
         xorNode.node.id,
     );
-    const previousSiblingType: PQP.Language.Type.TPowerQueryType = inspectXor(state, previousSibling);
+    const previousSiblingType: Type.TPowerQueryType = inspectXor(state, previousSibling);
     const isOptional: boolean =
-        PQP.Parser.NodeIdMapUtils.maybeUnwrapNthChildIfAstChecked(
+        NodeIdMapUtils.maybeUnboxNthChildIfAstChecked(
             state.nodeIdMapCollection,
             xorNode.node.id,
             3,
-            PQP.Language.Ast.NodeKind.Constant,
+            Ast.NodeKind.Constant,
         ) !== undefined;
 
     return inspectFieldProjectionHelper(previousSiblingType, projectedFieldNames, isOptional);
 }
 
 function inspectFieldProjectionHelper(
-    previousSiblingType: PQP.Language.Type.TPowerQueryType,
+    previousSiblingType: Type.TPowerQueryType,
     projectedFieldNames: ReadonlyArray<string>,
     isOptional: boolean,
-): PQP.Language.Type.TPowerQueryType {
+): Type.TPowerQueryType {
     switch (previousSiblingType.kind) {
-        case PQP.Language.Type.TypeKind.Any: {
-            const projectedFields: PQP.Language.Type.UnorderedFields = new Map(
-                projectedFieldNames.map((fieldName: string) => [fieldName, PQP.Language.Type.AnyInstance]),
+        case Type.TypeKind.Any: {
+            const projectedFields: Type.UnorderedFields = new Map(
+                projectedFieldNames.map((fieldName: string) => [fieldName, Type.AnyInstance]),
             );
 
             return {
-                kind: PQP.Language.Type.TypeKind.Any,
-                maybeExtendedKind: PQP.Language.Type.ExtendedTypeKind.AnyUnion,
+                kind: Type.TypeKind.Any,
+                maybeExtendedKind: Type.ExtendedTypeKind.AnyUnion,
                 isNullable: previousSiblingType.isNullable,
                 unionedTypePairs: [
                     {
-                        kind: PQP.Language.Type.TypeKind.Record,
-                        maybeExtendedKind: PQP.Language.Type.ExtendedTypeKind.DefinedRecord,
+                        kind: Type.TypeKind.Record,
+                        maybeExtendedKind: Type.ExtendedTypeKind.DefinedRecord,
                         isNullable: previousSiblingType.isNullable,
                         fields: projectedFields,
                         isOpen: false,
                     },
                     {
-                        kind: PQP.Language.Type.TypeKind.Table,
-                        maybeExtendedKind: PQP.Language.Type.ExtendedTypeKind.DefinedTable,
+                        kind: Type.TypeKind.Table,
+                        maybeExtendedKind: Type.ExtendedTypeKind.DefinedTable,
                         isNullable: previousSiblingType.isNullable,
                         fields: new PQP.OrderedMap([...projectedFields]),
                         isOpen: false,
@@ -68,46 +71,44 @@ function inspectFieldProjectionHelper(
             };
         }
 
-        case PQP.Language.Type.TypeKind.Record:
-        case PQP.Language.Type.TypeKind.Table: {
+        case Type.TypeKind.Record:
+        case Type.TypeKind.Table: {
             // All we know is previousSibling was a Record/Table.
             // Create a DefinedRecord/DefinedTable with the projected fields.
-            if (PQP.Language.TypeUtils.isDefinedRecord(previousSiblingType)) {
+            if (TypeUtils.isDefinedRecord(previousSiblingType)) {
                 return reducedFieldsToKeys(previousSiblingType, projectedFieldNames, isOptional, reducedRecordFields);
-            } else if (PQP.Language.TypeUtils.isDefinedTable(previousSiblingType)) {
+            } else if (TypeUtils.isDefinedTable(previousSiblingType)) {
                 return reducedFieldsToKeys(previousSiblingType, projectedFieldNames, isOptional, reducedTableFields);
             } else {
-                const newFields: Map<string, PQP.Language.Type.TPowerQueryType> = new Map(
-                    projectedFieldNames.map((fieldName: string) => [fieldName, PQP.Language.Type.AnyInstance]),
+                const newFields: Map<string, Type.TPowerQueryType> = new Map(
+                    projectedFieldNames.map((fieldName: string) => [fieldName, Type.AnyInstance]),
                 );
-                return previousSiblingType.kind === PQP.Language.Type.TypeKind.Record
-                    ? PQP.Language.TypeUtils.createDefinedRecord(false, newFields, false)
-                    : PQP.Language.TypeUtils.createDefinedTable(false, new PQP.OrderedMap([...newFields]), false);
+                return previousSiblingType.kind === Type.TypeKind.Record
+                    ? TypeUtils.createDefinedRecord(false, newFields, false)
+                    : TypeUtils.createDefinedTable(false, new PQP.OrderedMap([...newFields]), false);
             }
         }
 
         default:
-            return PQP.Language.Type.NoneInstance;
+            return Type.NoneInstance;
     }
 }
 
 // Returns a subset of `current` using `keys`.
 // If a mismatch is found it either returns Null if isOptional, else None.
-function reducedFieldsToKeys<T extends PQP.Language.Type.DefinedRecord | PQP.Language.Type.DefinedTable>(
+function reducedFieldsToKeys<T extends Type.DefinedRecord | Type.DefinedTable>(
     current: T,
     keys: ReadonlyArray<string>,
     isOptional: boolean,
     createFieldsFn: (
         current: T,
         keys: ReadonlyArray<string>,
-    ) => T extends PQP.Language.Type.DefinedRecord
-        ? PQP.Language.Type.UnorderedFields
-        : PQP.Language.Type.OrderedFields,
-): T | PQP.Language.Type.None | PQP.Language.Type.Null {
+    ) => T extends Type.DefinedRecord ? Type.UnorderedFields : Type.OrderedFields,
+): T | Type.None | Type.Null {
     const currentFieldNames: ReadonlyArray<string> = [...current.fields.keys()];
 
     if (!current.isOpen && !PQP.ArrayUtils.isSubset(currentFieldNames, keys)) {
-        return isOptional ? PQP.Language.Type.NullInstance : PQP.Language.Type.NoneInstance;
+        return isOptional ? Type.NullInstance : Type.NoneInstance;
     }
 
     return {
@@ -117,16 +118,10 @@ function reducedFieldsToKeys<T extends PQP.Language.Type.DefinedRecord | PQP.Lan
     };
 }
 
-function reducedRecordFields(
-    current: PQP.Language.Type.DefinedRecord,
-    keys: ReadonlyArray<string>,
-): PQP.Language.Type.UnorderedFields {
+function reducedRecordFields(current: Type.DefinedRecord, keys: ReadonlyArray<string>): Type.UnorderedFields {
     return PQP.MapUtils.pick(current.fields, keys);
 }
 
-function reducedTableFields(
-    current: PQP.Language.Type.DefinedTable,
-    keys: ReadonlyArray<string>,
-): PQP.Language.Type.OrderedFields {
+function reducedTableFields(current: Type.DefinedTable, keys: ReadonlyArray<string>): Type.OrderedFields {
     return new PQP.OrderedMap([...PQP.MapUtils.pick(current.fields, keys).entries()]);
 }

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFieldProjection.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFieldProjection.ts
@@ -3,6 +3,8 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+
 import { InspectTypeState, inspectXor } from "./common";
 
 export function inspectTypeFieldProjection(
@@ -10,7 +12,7 @@ export function inspectTypeFieldProjection(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.FieldProjection);
+    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.FieldProjection);
 
     const projectedFieldNames: ReadonlyArray<string> = PQP.Parser.NodeIdMapIterator.iterFieldProjectionNames(
         state.nodeIdMapCollection,
@@ -22,7 +24,7 @@ export function inspectTypeFieldProjection(
     );
     const previousSiblingType: PQP.Language.Type.TPowerQueryType = inspectXor(state, previousSibling);
     const isOptional: boolean =
-        PQP.Parser.NodeIdMapUtils.maybeUnwrapNthChildIfAst(
+        PQP.Parser.NodeIdMapUtils.maybeUnwrapNthChildIfAstChecked(
             state.nodeIdMapCollection,
             xorNode.node.id,
             3,

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFieldProjection.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFieldProjection.ts
@@ -10,7 +10,7 @@ export function inspectTypeFieldProjection(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertAstNodeKind(xorNode, PQP.Language.Ast.NodeKind.FieldProjection);
+    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.FieldProjection);
 
     const projectedFieldNames: ReadonlyArray<string> = PQP.Parser.NodeIdMapIterator.iterFieldProjectionNames(
         state.nodeIdMapCollection,
@@ -22,9 +22,12 @@ export function inspectTypeFieldProjection(
     );
     const previousSiblingType: PQP.Language.Type.TPowerQueryType = inspectXor(state, previousSibling);
     const isOptional: boolean =
-        PQP.Parser.NodeIdMapUtils.maybeChildAstByAttributeIndex(state.nodeIdMapCollection, xorNode.node.id, 3, [
+        PQP.Parser.NodeIdMapUtils.maybeUnwrapNthChildIfAst(
+            state.nodeIdMapCollection,
+            xorNode.node.id,
+            3,
             PQP.Language.Ast.NodeKind.Constant,
-        ]) !== undefined;
+        ) !== undefined;
 
     return inspectFieldProjectionHelper(previousSiblingType, projectedFieldNames, isOptional);
 }

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFieldProjection.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFieldProjection.ts
@@ -15,7 +15,7 @@ import { InspectTypeState, inspectXor } from "./common";
 
 export function inspectTypeFieldProjection(state: InspectTypeState, xorNode: TXorNode): Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    XorNodeUtils.assertIsNodeKind(xorNode, Ast.NodeKind.FieldProjection);
+    XorNodeUtils.assertIsNodeKind<Ast.FieldProjection>(xorNode, Ast.NodeKind.FieldProjection);
 
     const projectedFieldNames: ReadonlyArray<string> = NodeIdMapIterator.iterFieldProjectionNames(
         state.nodeIdMapCollection,

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFieldSelector.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFieldSelector.ts
@@ -1,69 +1,61 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
-
 import { Assert } from "@microsoft/powerquery-parser";
-import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+import { Ast, Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { NodeIdMapUtils, TXorNode, XorNodeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
 import { InspectTypeState, inspectXor } from "./common";
 
-export function inspectTypeFieldSelector(
-    state: InspectTypeState,
-    xorNode: PQP.Parser.TXorNode,
-): PQP.Language.Type.TPowerQueryType {
+export function inspectTypeFieldSelector(state: InspectTypeState, xorNode: TXorNode): Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.FieldSelector);
+    XorNodeUtils.assertIsNodeKind(xorNode, Ast.NodeKind.FieldSelector);
 
-    const maybeFieldName:
-        | PQP.Language.Ast.GeneralizedIdentifier
-        | undefined = PQP.Parser.NodeIdMapUtils.maybeUnwrapWrappedContentIfAstChecked(
+    const maybeFieldName: Ast.GeneralizedIdentifier | undefined = NodeIdMapUtils.maybeUnboxWrappedContentIfAstChecked(
         state.nodeIdMapCollection,
         xorNode.node.id,
-        PQP.Language.Ast.NodeKind.GeneralizedIdentifier,
+        Ast.NodeKind.GeneralizedIdentifier,
     );
     if (maybeFieldName === undefined) {
-        return PQP.Language.Type.UnknownInstance;
+        return Type.UnknownInstance;
     }
     const fieldName: string = maybeFieldName.literal;
 
-    const previousSibling: PQP.Parser.TXorNode = PQP.Parser.NodeIdMapUtils.assertGetRecursiveExpressionPreviousSibling(
+    const previousSibling: TXorNode = NodeIdMapUtils.assertGetRecursiveExpressionPreviousSibling(
         state.nodeIdMapCollection,
         xorNode.node.id,
     );
-    const previousSiblingType: PQP.Language.Type.TPowerQueryType = inspectXor(state, previousSibling);
+    const previousSiblingType: Type.TPowerQueryType = inspectXor(state, previousSibling);
     const isOptional: boolean =
-        PQP.Parser.NodeIdMapUtils.maybeUnwrapNthChildIfAstChecked(
+        NodeIdMapUtils.maybeUnboxNthChildIfAstChecked(
             state.nodeIdMapCollection,
             xorNode.node.id,
             3,
-            PQP.Language.Ast.NodeKind.Constant,
+            Ast.NodeKind.Constant,
         ) !== undefined;
 
     switch (previousSiblingType.kind) {
-        case PQP.Language.Type.TypeKind.Any:
-            return PQP.Language.Type.AnyInstance;
+        case Type.TypeKind.Any:
+            return Type.AnyInstance;
 
-        case PQP.Language.Type.TypeKind.Unknown:
-            return PQP.Language.Type.UnknownInstance;
+        case Type.TypeKind.Unknown:
+            return Type.UnknownInstance;
 
-        case PQP.Language.Type.TypeKind.Record:
-        case PQP.Language.Type.TypeKind.Table:
+        case Type.TypeKind.Record:
+        case Type.TypeKind.Table:
             switch (previousSiblingType.maybeExtendedKind) {
                 case undefined:
-                    return PQP.Language.Type.AnyInstance;
+                    return Type.AnyInstance;
 
-                case PQP.Language.Type.ExtendedTypeKind.DefinedRecord:
-                case PQP.Language.Type.ExtendedTypeKind.DefinedTable: {
-                    const maybeNamedField:
-                        | PQP.Language.Type.TPowerQueryType
-                        | undefined = previousSiblingType.fields.get(fieldName);
+                case Type.ExtendedTypeKind.DefinedRecord:
+                case Type.ExtendedTypeKind.DefinedTable: {
+                    const maybeNamedField: Type.TPowerQueryType | undefined = previousSiblingType.fields.get(fieldName);
                     if (maybeNamedField !== undefined) {
                         return maybeNamedField;
                     } else if (previousSiblingType.isOpen) {
-                        return PQP.Language.Type.AnyInstance;
+                        return Type.AnyInstance;
                     } else {
-                        return isOptional ? PQP.Language.Type.NullInstance : PQP.Language.Type.NoneInstance;
+                        return isOptional ? Type.NullInstance : Type.NoneInstance;
                     }
                 }
 
@@ -72,6 +64,6 @@ export function inspectTypeFieldSelector(
             }
 
         default:
-            return PQP.Language.Type.NoneInstance;
+            return Type.NoneInstance;
     }
 }

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFieldSelector.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFieldSelector.ts
@@ -9,7 +9,7 @@ import { InspectTypeState, inspectXor } from "./common";
 
 export function inspectTypeFieldSelector(state: InspectTypeState, xorNode: TXorNode): Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    XorNodeUtils.assertIsNodeKind(xorNode, Ast.NodeKind.FieldSelector);
+    XorNodeUtils.assertIsNodeKind<Ast.FieldSelector>(xorNode, Ast.NodeKind.FieldSelector);
 
     const maybeFieldName: Ast.GeneralizedIdentifier | undefined = NodeIdMapUtils.maybeUnboxWrappedContentIfAstChecked(
         state.nodeIdMapCollection,

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFieldSelector.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFieldSelector.ts
@@ -12,9 +12,11 @@ export function inspectTypeFieldSelector(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertAstNodeKind(xorNode, PQP.Language.Ast.NodeKind.FieldSelector);
+    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.FieldSelector);
 
-    const maybeFieldName: PQP.Language.Ast.TNode | undefined = PQP.Parser.NodeIdMapUtils.maybeWrappedContentAst(
+    const maybeFieldName:
+        | PQP.Language.Ast.GeneralizedIdentifier
+        | undefined = PQP.Parser.NodeIdMapUtils.maybeUnwrapWrappedContentIfAst(
         state.nodeIdMapCollection,
         xorNode,
         PQP.Language.Ast.NodeKind.GeneralizedIdentifier,
@@ -22,7 +24,7 @@ export function inspectTypeFieldSelector(
     if (maybeFieldName === undefined) {
         return PQP.Language.Type.UnknownInstance;
     }
-    const fieldName: string = (maybeFieldName as PQP.Language.Ast.GeneralizedIdentifier).literal;
+    const fieldName: string = maybeFieldName.literal;
 
     const previousSibling: PQP.Parser.TXorNode = PQP.Parser.NodeIdMapUtils.assertGetRecursiveExpressionPreviousSibling(
         state.nodeIdMapCollection,
@@ -30,9 +32,12 @@ export function inspectTypeFieldSelector(
     );
     const previousSiblingType: PQP.Language.Type.TPowerQueryType = inspectXor(state, previousSibling);
     const isOptional: boolean =
-        PQP.Parser.NodeIdMapUtils.maybeChildAstByAttributeIndex(state.nodeIdMapCollection, xorNode.node.id, 3, [
+        PQP.Parser.NodeIdMapUtils.maybeUnwrapNthChildIfAst(
+            state.nodeIdMapCollection,
+            xorNode.node.id,
+            3,
             PQP.Language.Ast.NodeKind.Constant,
-        ]) !== undefined;
+        ) !== undefined;
 
     switch (previousSiblingType.kind) {
         case PQP.Language.Type.TypeKind.Any:

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFieldSelector.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFieldSelector.ts
@@ -4,6 +4,7 @@
 import * as PQP from "@microsoft/powerquery-parser";
 
 import { Assert } from "@microsoft/powerquery-parser";
+import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
 
 import { InspectTypeState, inspectXor } from "./common";
 
@@ -12,13 +13,13 @@ export function inspectTypeFieldSelector(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.FieldSelector);
+    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.FieldSelector);
 
     const maybeFieldName:
         | PQP.Language.Ast.GeneralizedIdentifier
-        | undefined = PQP.Parser.NodeIdMapUtils.maybeUnwrapWrappedContentIfAst(
+        | undefined = PQP.Parser.NodeIdMapUtils.maybeUnwrapWrappedContentIfAstChecked(
         state.nodeIdMapCollection,
-        xorNode,
+        xorNode.node.id,
         PQP.Language.Ast.NodeKind.GeneralizedIdentifier,
     );
     if (maybeFieldName === undefined) {
@@ -32,7 +33,7 @@ export function inspectTypeFieldSelector(
     );
     const previousSiblingType: PQP.Language.Type.TPowerQueryType = inspectXor(state, previousSibling);
     const isOptional: boolean =
-        PQP.Parser.NodeIdMapUtils.maybeUnwrapNthChildIfAst(
+        PQP.Parser.NodeIdMapUtils.maybeUnwrapNthChildIfAstChecked(
             state.nodeIdMapCollection,
             xorNode.node.id,
             3,

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFieldSpecification.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFieldSpecification.ts
@@ -3,6 +3,8 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+
 import { InspectTypeState, inspectXor } from "./common";
 
 export function inspectTypeFieldSpecification(
@@ -10,7 +12,7 @@ export function inspectTypeFieldSpecification(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.FieldSpecification);
+    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.FieldSpecification);
 
     const maybeFieldTypeSpecification: PQP.Parser.TXorNode | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChild(
         state.nodeIdMapCollection,

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFieldSpecification.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFieldSpecification.ts
@@ -8,7 +8,7 @@ import { InspectTypeState, inspectXor } from "./common";
 
 export function inspectTypeFieldSpecification(state: InspectTypeState, xorNode: TXorNode): Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    XorNodeUtils.assertIsNodeKind(xorNode, Ast.NodeKind.FieldSpecification);
+    XorNodeUtils.assertIsNodeKind<Ast.FieldSpecification>(xorNode, Ast.NodeKind.FieldSpecification);
 
     const maybeFieldTypeSpecification: TXorNode | undefined = NodeIdMapUtils.maybeNthChild(
         state.nodeIdMapCollection,

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFieldSpecification.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFieldSpecification.ts
@@ -1,20 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
-
-import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+import { Ast, Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { NodeIdMapUtils, TXorNode, XorNodeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
 import { InspectTypeState, inspectXor } from "./common";
 
-export function inspectTypeFieldSpecification(
-    state: InspectTypeState,
-    xorNode: PQP.Parser.TXorNode,
-): PQP.Language.Type.TPowerQueryType {
+export function inspectTypeFieldSpecification(state: InspectTypeState, xorNode: TXorNode): Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.FieldSpecification);
+    XorNodeUtils.assertIsNodeKind(xorNode, Ast.NodeKind.FieldSpecification);
 
-    const maybeFieldTypeSpecification: PQP.Parser.TXorNode | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChild(
+    const maybeFieldTypeSpecification: TXorNode | undefined = NodeIdMapUtils.maybeNthChild(
         state.nodeIdMapCollection,
         xorNode.node.id,
         2,
@@ -22,5 +18,5 @@ export function inspectTypeFieldSpecification(
 
     return maybeFieldTypeSpecification !== undefined
         ? inspectXor(state, maybeFieldTypeSpecification)
-        : PQP.Language.Type.AnyInstance;
+        : Type.AnyInstance;
 }

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFieldSpecification.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFieldSpecification.ts
@@ -10,15 +10,12 @@ export function inspectTypeFieldSpecification(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertAstNodeKind(xorNode, PQP.Language.Ast.NodeKind.FieldSpecification);
+    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.FieldSpecification);
 
-    const maybeFieldTypeSpecification:
-        | PQP.Parser.TXorNode
-        | undefined = PQP.Parser.NodeIdMapUtils.maybeChildXorByAttributeIndex(
+    const maybeFieldTypeSpecification: PQP.Parser.TXorNode | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChild(
         state.nodeIdMapCollection,
         xorNode.node.id,
         2,
-        undefined,
     );
 
     return maybeFieldTypeSpecification !== undefined

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFunctionExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFunctionExpression.ts
@@ -3,6 +3,8 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+
 import {
     PseduoFunctionExpressionType,
     pseudoFunctionExpressionType,
@@ -15,7 +17,7 @@ export function inspectTypeFunctionExpression(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.FunctionExpression);
+    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.FunctionExpression);
 
     const pseudoType: PseduoFunctionExpressionType = pseudoFunctionExpressionType(state.nodeIdMapCollection, xorNode);
     const pseudoReturnType: PQP.Language.Type.TPowerQueryType = pseudoType.returnType;

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFunctionExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFunctionExpression.ts
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
-
-import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+import { Ast, Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { TXorNode, XorNodeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
 import {
     PseduoFunctionExpressionType,
@@ -12,55 +11,51 @@ import {
 } from "../../pseudoFunctionExpressionType";
 import { allForAnyUnion, inspectTypeFromChildAttributeIndex, InspectTypeState } from "./common";
 
-export function inspectTypeFunctionExpression(
-    state: InspectTypeState,
-    xorNode: PQP.Parser.TXorNode,
-): PQP.Language.Type.TPowerQueryType {
+export function inspectTypeFunctionExpression(state: InspectTypeState, xorNode: TXorNode): Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.FunctionExpression);
+    XorNodeUtils.assertIsNodeKind(xorNode, Ast.NodeKind.FunctionExpression);
 
     const pseudoType: PseduoFunctionExpressionType = pseudoFunctionExpressionType(state.nodeIdMapCollection, xorNode);
-    const pseudoReturnType: PQP.Language.Type.TPowerQueryType = pseudoType.returnType;
-    const expressionType: PQP.Language.Type.TPowerQueryType = inspectTypeFromChildAttributeIndex(state, xorNode, 3);
+    const pseudoReturnType: Type.TPowerQueryType = pseudoType.returnType;
+    const expressionType: Type.TPowerQueryType = inspectTypeFromChildAttributeIndex(state, xorNode, 3);
 
     // FunctionExpression.maybeFunctionReturnType doesn't always match FunctionExpression.expression.
     // By examining the expression we might get a more accurate return type (eg. Function vs DefinedFunction),
     // or discover an error (eg. maybeFunctionReturnType is Number but expression is Text).
 
-    let returnType: PQP.Language.Type.TPowerQueryType;
+    let returnType: Type.TPowerQueryType;
     // If the stated return type is Any,
     // then it might as well be the expression's type as it can't be any wider than Any.
-    if (pseudoReturnType.kind === PQP.Language.Type.TypeKind.Any) {
+    if (pseudoReturnType.kind === Type.TypeKind.Any) {
         returnType = expressionType;
     }
-    // If the return type is Any then see if we can narrow it to the stated return PQP.Language.type.
+    // If the return type is Any then see if we can narrow it to the stated return Type.
     else if (
-        expressionType.kind === PQP.Language.Type.TypeKind.Any &&
-        expressionType.maybeExtendedKind === PQP.Language.Type.ExtendedTypeKind.AnyUnion &&
+        expressionType.kind === Type.TypeKind.Any &&
+        expressionType.maybeExtendedKind === Type.ExtendedTypeKind.AnyUnion &&
         allForAnyUnion(
             expressionType,
-            (type: PQP.Language.Type.TPowerQueryType) =>
-                type.kind === pseudoReturnType.kind || type.kind === PQP.Language.Type.TypeKind.Any,
+            (type: Type.TPowerQueryType) => type.kind === pseudoReturnType.kind || type.kind === Type.TypeKind.Any,
         )
     ) {
         returnType = expressionType;
     }
     // If the stated return type doesn't match the expression's type then it's None.
     else if (pseudoReturnType.kind !== expressionType.kind) {
-        return PQP.Language.Type.NoneInstance;
+        return Type.NoneInstance;
     }
-    // If the expression's type can't be known, then assume it's the stated return PQP.Language.type.
-    else if (expressionType.kind === PQP.Language.Type.TypeKind.Unknown) {
+    // If the expression's type can't be known, then assume it's the stated return Type.
+    else if (expressionType.kind === Type.TypeKind.Unknown) {
         returnType = pseudoReturnType;
     }
-    // Else fallback to the expression's PQP.Language.type.
+    // Else fallback to the expression's Type.
     else {
         returnType = expressionType;
     }
 
     return {
-        kind: PQP.Language.Type.TypeKind.Function,
-        maybeExtendedKind: PQP.Language.Type.ExtendedTypeKind.DefinedFunction,
+        kind: Type.TypeKind.Function,
+        maybeExtendedKind: Type.ExtendedTypeKind.DefinedFunction,
         isNullable: false,
         parameters: pseudoType.parameters.map((pseudoParameter: PseudoFunctionParameterType) => {
             return {

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFunctionExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFunctionExpression.ts
@@ -15,7 +15,7 @@ export function inspectTypeFunctionExpression(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertAstNodeKind(xorNode, PQP.Language.Ast.NodeKind.FunctionExpression);
+    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.FunctionExpression);
 
     const pseudoType: PseduoFunctionExpressionType = pseudoFunctionExpressionType(state.nodeIdMapCollection, xorNode);
     const pseudoReturnType: PQP.Language.Type.TPowerQueryType = pseudoType.returnType;

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFunctionType.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFunctionType.ts
@@ -10,21 +10,23 @@ export function inspectTypeFunctionType(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.FunctionType | PQP.Language.Type.Unknown {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertAstNodeKind(xorNode, PQP.Language.Ast.NodeKind.FunctionType);
+    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.FunctionType);
 
     const maybeParameters:
-        | PQP.Parser.TXorNode
-        | undefined = PQP.Parser.NodeIdMapUtils.maybeChildXorByAttributeIndex(
+        | PQP.Parser.XorNode<PQP.Language.Ast.TParameterList>
+        | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChild(
         state.nodeIdMapCollection,
         xorNode.node.id,
         1,
-        [PQP.Language.Ast.NodeKind.ParameterList],
+        PQP.Language.Ast.NodeKind.ParameterList,
     );
     if (maybeParameters === undefined) {
         return PQP.Language.Type.UnknownInstance;
     }
 
-    const maybeArrayWrapper: PQP.Parser.TXorNode | undefined = PQP.Parser.NodeIdMapUtils.maybeWrappedContent(
+    const maybeArrayWrapper:
+        | PQP.Parser.XorNode<PQP.Language.Ast.TArrayWrapper>
+        | undefined = PQP.Parser.NodeIdMapUtils.maybeWrappedContent(
         state.nodeIdMapCollection,
         maybeParameters,
         PQP.Language.Ast.NodeKind.ArrayWrapper,

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFunctionType.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFunctionType.ts
@@ -3,56 +3,50 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
-import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+import { Ast, Type, TypeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import {
+    NodeIdMapIterator,
+    NodeIdMapUtils,
+    TXorNode,
+    XorNode,
+    XorNodeUtils,
+} from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
 import { inspectTypeFromChildAttributeIndex, InspectTypeState } from "./common";
 
-export function inspectTypeFunctionType(
-    state: InspectTypeState,
-    xorNode: PQP.Parser.TXorNode,
-): PQP.Language.Type.FunctionType | PQP.Language.Type.Unknown {
+export function inspectTypeFunctionType(state: InspectTypeState, xorNode: TXorNode): Type.FunctionType | Type.Unknown {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.FunctionType);
+    XorNodeUtils.assertIsNodeKind(xorNode, Ast.NodeKind.FunctionType);
 
-    const maybeParameters:
-        | PQP.Parser.XorNode<PQP.Language.Ast.TParameterList>
-        | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChildChecked<PQP.Language.Ast.TParameterList>(
-        state.nodeIdMapCollection,
-        xorNode.node.id,
-        1,
-        PQP.Language.Ast.NodeKind.ParameterList,
-    );
+    const maybeParameters: XorNode<Ast.TParameterList> | undefined = NodeIdMapUtils.maybeNthChildChecked<
+        Ast.TParameterList
+    >(state.nodeIdMapCollection, xorNode.node.id, 1, Ast.NodeKind.ParameterList);
     if (maybeParameters === undefined) {
-        return PQP.Language.Type.UnknownInstance;
+        return Type.UnknownInstance;
     }
 
-    const maybeArrayWrapper:
-        | PQP.Parser.XorNode<PQP.Language.Ast.TArrayWrapper>
-        | undefined = PQP.Parser.NodeIdMapUtils.maybeUnwrapArrayWrapper(
+    const maybeArrayWrapper: XorNode<Ast.TArrayWrapper> | undefined = NodeIdMapUtils.maybeUnboxArrayWrapper(
         state.nodeIdMapCollection,
         maybeParameters.node.id,
     );
     if (maybeArrayWrapper === undefined) {
-        return PQP.Language.Type.UnknownInstance;
+        return Type.UnknownInstance;
     }
 
-    const parameterTypes: ReadonlyArray<PQP.Language.Type.FunctionParameter> = PQP.Parser.NodeIdMapIterator.iterArrayWrapper(
+    const parameterTypes: ReadonlyArray<Type.FunctionParameter> = NodeIdMapIterator.iterArrayWrapper(
         state.nodeIdMapCollection,
         maybeArrayWrapper,
     )
-        .map((parameter: PQP.Parser.TXorNode) =>
-            PQP.Language.TypeUtils.inspectParameter(
-                state.nodeIdMapCollection,
-                XorNodeUtils.assertAsParameter(parameter),
-            ),
+        .map((parameter: TXorNode) =>
+            TypeUtils.inspectParameter(state.nodeIdMapCollection, XorNodeUtils.assertAsParameter(parameter)),
         )
         .filter(PQP.TypeScriptUtils.isDefined);
 
-    const returnType: PQP.Language.Type.TPowerQueryType = inspectTypeFromChildAttributeIndex(state, xorNode, 2);
+    const returnType: Type.TPowerQueryType = inspectTypeFromChildAttributeIndex(state, xorNode, 2);
 
     return {
-        kind: PQP.Language.Type.TypeKind.Type,
-        maybeExtendedKind: PQP.Language.Type.ExtendedTypeKind.FunctionType,
+        kind: Type.TypeKind.Type,
+        maybeExtendedKind: Type.ExtendedTypeKind.FunctionType,
         isNullable: false,
         parameters: parameterTypes,
         returnType,

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIdentifier.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIdentifier.ts
@@ -10,7 +10,7 @@ export function inspectTypeIdentifier(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertAstNodeKind(xorNode, PQP.Language.Ast.NodeKind.Identifier);
+    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.Identifier);
 
     if (xorNode.kind === PQP.Parser.XorNodeKind.Context) {
         return PQP.Language.Type.UnknownInstance;

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIdentifier.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIdentifier.ts
@@ -1,26 +1,19 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
-
-import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+import { Ast, Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { TXorNode, XorNodeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
 import { InspectTypeState, maybeDereferencedIdentifierType } from "./common";
 
-export function inspectTypeIdentifier(
-    state: InspectTypeState,
-    xorNode: PQP.Parser.TXorNode,
-): PQP.Language.Type.TPowerQueryType {
+export function inspectTypeIdentifier(state: InspectTypeState, xorNode: TXorNode): Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.Identifier);
+    XorNodeUtils.assertIsNodeKind(xorNode, Ast.NodeKind.Identifier);
 
-    if (xorNode.kind === PQP.Parser.XorNodeKind.Context) {
-        return PQP.Language.Type.UnknownInstance;
+    if (XorNodeUtils.isContextXor(xorNode)) {
+        return Type.UnknownInstance;
     }
 
-    const dereferencedType: PQP.Language.Type.TPowerQueryType | undefined = maybeDereferencedIdentifierType(
-        state,
-        xorNode,
-    );
-    return dereferencedType ?? PQP.Language.Type.UnknownInstance;
+    const dereferencedType: Type.TPowerQueryType | undefined = maybeDereferencedIdentifierType(state, xorNode);
+    return dereferencedType ?? Type.UnknownInstance;
 }

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIdentifier.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIdentifier.ts
@@ -3,6 +3,8 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+
 import { InspectTypeState, maybeDereferencedIdentifierType } from "./common";
 
 export function inspectTypeIdentifier(
@@ -10,7 +12,7 @@ export function inspectTypeIdentifier(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.Identifier);
+    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.Identifier);
 
     if (xorNode.kind === PQP.Parser.XorNodeKind.Context) {
         return PQP.Language.Type.UnknownInstance;

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIdentifierExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIdentifierExpression.ts
@@ -10,7 +10,7 @@ export function inspectTypeIdentifierExpression(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertAstNodeKind(xorNode, PQP.Language.Ast.NodeKind.IdentifierExpression);
+    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.IdentifierExpression);
 
     if (xorNode.kind === PQP.Parser.XorNodeKind.Context) {
         return PQP.Language.Type.UnknownInstance;

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIdentifierExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIdentifierExpression.ts
@@ -3,6 +3,8 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+
 import { InspectTypeState, maybeDereferencedIdentifierType } from "./common";
 
 export function inspectTypeIdentifierExpression(
@@ -10,7 +12,7 @@ export function inspectTypeIdentifierExpression(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.IdentifierExpression);
+    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.IdentifierExpression);
 
     if (xorNode.kind === PQP.Parser.XorNodeKind.Context) {
         return PQP.Language.Type.UnknownInstance;

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIdentifierExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIdentifierExpression.ts
@@ -1,26 +1,19 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
-
-import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+import { Ast, Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { TXorNode, XorNodeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
 import { InspectTypeState, maybeDereferencedIdentifierType } from "./common";
 
-export function inspectTypeIdentifierExpression(
-    state: InspectTypeState,
-    xorNode: PQP.Parser.TXorNode,
-): PQP.Language.Type.TPowerQueryType {
+export function inspectTypeIdentifierExpression(state: InspectTypeState, xorNode: TXorNode): Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.IdentifierExpression);
+    XorNodeUtils.assertIsNodeKind(xorNode, Ast.NodeKind.IdentifierExpression);
 
-    if (xorNode.kind === PQP.Parser.XorNodeKind.Context) {
-        return PQP.Language.Type.UnknownInstance;
+    if (XorNodeUtils.isContextXor(xorNode)) {
+        return Type.UnknownInstance;
     }
 
-    const dereferencedType: PQP.Language.Type.TPowerQueryType | undefined = maybeDereferencedIdentifierType(
-        state,
-        xorNode,
-    );
-    return dereferencedType ?? PQP.Language.Type.UnknownInstance;
+    const dereferencedType: Type.TPowerQueryType | undefined = maybeDereferencedIdentifierType(state, xorNode);
+    return dereferencedType ?? Type.UnknownInstance;
 }

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIfExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIfExpression.ts
@@ -3,6 +3,8 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+
 import { allForAnyUnion, inspectTypeFromChildAttributeIndex, InspectTypeState } from "./common";
 
 export function inspectTypeIfExpression(
@@ -10,7 +12,7 @@ export function inspectTypeIfExpression(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.IfExpression);
+    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.IfExpression);
 
     const conditionType: PQP.Language.Type.TPowerQueryType = inspectTypeFromChildAttributeIndex(state, xorNode, 1);
     if (conditionType.kind === PQP.Language.Type.TypeKind.Unknown) {

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIfExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIfExpression.ts
@@ -10,7 +10,7 @@ export function inspectTypeIfExpression(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertAstNodeKind(xorNode, PQP.Language.Ast.NodeKind.IfExpression);
+    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.IfExpression);
 
     const conditionType: PQP.Language.Type.TPowerQueryType = inspectTypeFromChildAttributeIndex(state, xorNode, 1);
     if (conditionType.kind === PQP.Language.Type.TypeKind.Unknown) {

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIfExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIfExpression.ts
@@ -1,41 +1,36 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
-
-import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+import { Ast, Type, TypeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { TXorNode, XorNodeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
 import { allForAnyUnion, inspectTypeFromChildAttributeIndex, InspectTypeState } from "./common";
 
-export function inspectTypeIfExpression(
-    state: InspectTypeState,
-    xorNode: PQP.Parser.TXorNode,
-): PQP.Language.Type.TPowerQueryType {
+export function inspectTypeIfExpression(state: InspectTypeState, xorNode: TXorNode): Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.IfExpression);
+    XorNodeUtils.assertIsNodeKind(xorNode, Ast.NodeKind.IfExpression);
 
-    const conditionType: PQP.Language.Type.TPowerQueryType = inspectTypeFromChildAttributeIndex(state, xorNode, 1);
-    if (conditionType.kind === PQP.Language.Type.TypeKind.Unknown) {
-        return PQP.Language.Type.UnknownInstance;
+    const conditionType: Type.TPowerQueryType = inspectTypeFromChildAttributeIndex(state, xorNode, 1);
+    if (conditionType.kind === Type.TypeKind.Unknown) {
+        return Type.UnknownInstance;
     }
     // Any is allowed so long as AnyUnion only contains Any or Logical.
-    else if (conditionType.kind === PQP.Language.Type.TypeKind.Any) {
+    else if (conditionType.kind === Type.TypeKind.Any) {
         if (
-            conditionType.maybeExtendedKind === PQP.Language.Type.ExtendedTypeKind.AnyUnion &&
+            conditionType.maybeExtendedKind === Type.ExtendedTypeKind.AnyUnion &&
             !allForAnyUnion(
                 conditionType,
-                (type: PQP.Language.Type.TPowerQueryType) =>
-                    type.kind === PQP.Language.Type.TypeKind.Logical || type.kind === PQP.Language.Type.TypeKind.Any,
+                (type: Type.TPowerQueryType) => type.kind === Type.TypeKind.Logical || type.kind === Type.TypeKind.Any,
             )
         ) {
-            return PQP.Language.Type.NoneInstance;
+            return Type.NoneInstance;
         }
-    } else if (conditionType.kind !== PQP.Language.Type.TypeKind.Logical) {
-        return PQP.Language.Type.NoneInstance;
+    } else if (conditionType.kind !== Type.TypeKind.Logical) {
+        return Type.NoneInstance;
     }
 
-    const trueExprType: PQP.Language.Type.TPowerQueryType = inspectTypeFromChildAttributeIndex(state, xorNode, 3);
-    const falseExprType: PQP.Language.Type.TPowerQueryType = inspectTypeFromChildAttributeIndex(state, xorNode, 5);
+    const trueExprType: Type.TPowerQueryType = inspectTypeFromChildAttributeIndex(state, xorNode, 3);
+    const falseExprType: Type.TPowerQueryType = inspectTypeFromChildAttributeIndex(state, xorNode, 5);
 
-    return PQP.Language.TypeUtils.createAnyUnion([trueExprType, falseExprType]);
+    return TypeUtils.createAnyUnion([trueExprType, falseExprType]);
 }

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeInvokeExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeInvokeExpression.ts
@@ -13,7 +13,7 @@ export function inspectTypeInvokeExpression(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertAstNodeKind(xorNode, PQP.Language.Ast.NodeKind.InvokeExpression);
+    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.InvokeExpression);
 
     const maybeRequest: ExternalType.ExternalInvocationTypeRequest | undefined = maybeExternalInvokeRequest(
         state,

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeInvokeExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeInvokeExpression.ts
@@ -4,6 +4,7 @@
 import * as PQP from "@microsoft/powerquery-parser";
 
 import { Assert } from "@microsoft/powerquery-parser";
+import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
 
 import { ExternalType, ExternalTypeUtils } from "../../externalType";
 import { InspectTypeState, inspectXor, recursiveIdentifierDereference } from "./common";
@@ -13,7 +14,7 @@ export function inspectTypeInvokeExpression(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.InvokeExpression);
+    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.InvokeExpression);
 
     const maybeRequest: ExternalType.ExternalInvocationTypeRequest | undefined = maybeExternalInvokeRequest(
         state,
@@ -59,7 +60,10 @@ function maybeExternalInvokeRequest(
     const deferencedIdentifier: PQP.Parser.TXorNode = recursiveIdentifierDereference(state, maybeIdentifier);
 
     const types: PQP.Language.Type.TPowerQueryType[] = [];
-    for (const argument of PQP.Parser.NodeIdMapIterator.iterInvokeExpression(state.nodeIdMapCollection, xorNode)) {
+    for (const argument of PQP.Parser.NodeIdMapIterator.iterInvokeExpression(
+        state.nodeIdMapCollection,
+        XorNodeUtils.assertAsInvokeExpression(xorNode),
+    )) {
         types.push(inspectXor(state, argument));
     }
 

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeList.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeList.ts
@@ -1,24 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
+import { Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { NodeIdMapIterator, TXorNode } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
 import { InspectTypeState, inspectXor } from "./common";
 
-export function inspectTypeList(state: InspectTypeState, xorNode: PQP.Parser.TXorNode): PQP.Language.Type.DefinedList {
+export function inspectTypeList(state: InspectTypeState, xorNode: TXorNode): Type.DefinedList {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    const items: ReadonlyArray<PQP.Parser.TXorNode> = PQP.Parser.NodeIdMapIterator.iterListItems(
-        state.nodeIdMapCollection,
-        xorNode,
-    );
-    const elements: ReadonlyArray<PQP.Language.Type.TPowerQueryType> = items.map((item: PQP.Parser.TXorNode) =>
-        inspectXor(state, item),
-    );
+    const items: ReadonlyArray<TXorNode> = NodeIdMapIterator.iterListItems(state.nodeIdMapCollection, xorNode);
+    const elements: ReadonlyArray<Type.TPowerQueryType> = items.map((item: TXorNode) => inspectXor(state, item));
 
     return {
-        kind: PQP.Language.Type.TypeKind.List,
+        kind: Type.TypeKind.List,
         isNullable: false,
-        maybeExtendedKind: PQP.Language.Type.ExtendedTypeKind.DefinedList,
+        maybeExtendedKind: Type.ExtendedTypeKind.DefinedList,
         elements,
     };
 }

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeListType.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeListType.ts
@@ -3,6 +3,8 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+
 import { InspectTypeState, inspectXor } from "./common";
 
 export function inspectTypeListType(
@@ -10,7 +12,7 @@ export function inspectTypeListType(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.ListType | PQP.Language.Type.Unknown {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.ListType);
+    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.ListType);
 
     const maybeListItem: PQP.Parser.TXorNode | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChild(
         state.nodeIdMapCollection,

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeListType.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeListType.ts
@@ -1,32 +1,28 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
-
-import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+import { Ast, Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { NodeIdMapUtils, TXorNode, XorNodeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
 import { InspectTypeState, inspectXor } from "./common";
 
-export function inspectTypeListType(
-    state: InspectTypeState,
-    xorNode: PQP.Parser.TXorNode,
-): PQP.Language.Type.ListType | PQP.Language.Type.Unknown {
+export function inspectTypeListType(state: InspectTypeState, xorNode: TXorNode): Type.ListType | Type.Unknown {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.ListType);
+    XorNodeUtils.assertIsNodeKind(xorNode, Ast.NodeKind.ListType);
 
-    const maybeListItem: PQP.Parser.TXorNode | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChild(
+    const maybeListItem: TXorNode | undefined = NodeIdMapUtils.maybeNthChild(
         state.nodeIdMapCollection,
         xorNode.node.id,
         1,
     );
     if (maybeListItem === undefined) {
-        return PQP.Language.Type.UnknownInstance;
+        return Type.UnknownInstance;
     }
-    const itemType: PQP.Language.Type.TPowerQueryType = inspectXor(state, maybeListItem);
+    const itemType: Type.TPowerQueryType = inspectXor(state, maybeListItem);
 
     return {
-        kind: PQP.Language.Type.TypeKind.Type,
-        maybeExtendedKind: PQP.Language.Type.ExtendedTypeKind.ListType,
+        kind: Type.TypeKind.Type,
+        maybeExtendedKind: Type.ExtendedTypeKind.ListType,
         isNullable: false,
         itemType,
     };

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeListType.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeListType.ts
@@ -10,13 +10,12 @@ export function inspectTypeListType(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.ListType | PQP.Language.Type.Unknown {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertAstNodeKind(xorNode, PQP.Language.Ast.NodeKind.ListType);
+    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.ListType);
 
-    const maybeListItem: PQP.Parser.TXorNode | undefined = PQP.Parser.NodeIdMapUtils.maybeChildXorByAttributeIndex(
+    const maybeListItem: PQP.Parser.TXorNode | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChild(
         state.nodeIdMapCollection,
         xorNode.node.id,
         1,
-        undefined,
     );
     if (maybeListItem === undefined) {
         return PQP.Language.Type.UnknownInstance;

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeLiteralExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeLiteralExpression.ts
@@ -4,11 +4,12 @@
 import * as PQP from "@microsoft/powerquery-parser";
 
 import { Assert } from "@microsoft/powerquery-parser";
+import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
 
 export function inspectTypeLiteralExpression(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPrimitiveType | PQP.Language.Type.TextLiteral | PQP.Language.Type.NumberLiteral {
-    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.LiteralExpression);
+    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.LiteralExpression);
 
     switch (xorNode.kind) {
         case PQP.Parser.XorNodeKind.Ast:

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeLiteralExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeLiteralExpression.ts
@@ -1,40 +1,37 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
+import { Ast, Type, TypeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { TXorNode, XorNodeKind, XorNodeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
 import { Assert } from "@microsoft/powerquery-parser";
-import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
-
 export function inspectTypeLiteralExpression(
-    xorNode: PQP.Parser.TXorNode,
-): PQP.Language.Type.TPrimitiveType | PQP.Language.Type.TextLiteral | PQP.Language.Type.NumberLiteral {
-    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.LiteralExpression);
+    xorNode: TXorNode,
+): Type.TPrimitiveType | Type.TextLiteral | Type.NumberLiteral {
+    XorNodeUtils.assertIsNodeKind<Ast.LiteralExpression>(xorNode, Ast.NodeKind.LiteralExpression);
 
     switch (xorNode.kind) {
-        case PQP.Parser.XorNodeKind.Ast:
+        case XorNodeKind.Ast:
             // We already checked it's a Ast Literal Expression.
-            const literalExpression: PQP.Language.Ast.LiteralExpression = xorNode.node as PQP.Language.Ast.LiteralExpression;
-            const typeKind: PQP.Language.Type.TypeKind = PQP.Language.TypeUtils.typeKindFromLiteralKind(
-                literalExpression.literalKind,
-            );
+            const literalExpression: Ast.LiteralExpression = xorNode.node;
+            const typeKind: Type.TypeKind = TypeUtils.typeKindFromLiteralKind(literalExpression.literalKind);
 
             switch (typeKind) {
-                case PQP.Language.Type.TypeKind.Number:
-                    return PQP.Language.TypeUtils.createNumberLiteral(false, literalExpression.literal);
+                case Type.TypeKind.Number:
+                    return TypeUtils.createNumberLiteral(false, literalExpression.literal);
 
-                case PQP.Language.Type.TypeKind.Text:
-                    return PQP.Language.TypeUtils.createTextLiteral(false, literalExpression.literal);
+                case Type.TypeKind.Text:
+                    return TypeUtils.createTextLiteral(false, literalExpression.literal);
 
                 default:
-                    return PQP.Language.TypeUtils.createPrimitiveType(
-                        literalExpression.literalKind === PQP.Language.Ast.LiteralKind.Null,
+                    return TypeUtils.createPrimitiveType(
+                        literalExpression.literalKind === Ast.LiteralKind.Null,
                         typeKind,
                     );
             }
 
-        case PQP.Parser.XorNodeKind.Context:
-            return PQP.Language.Type.UnknownInstance;
+        case XorNodeKind.Context:
+            return Type.UnknownInstance;
 
         default:
             throw Assert.isNever(xorNode);

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeLiteralExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeLiteralExpression.ts
@@ -8,7 +8,7 @@ import { Assert } from "@microsoft/powerquery-parser";
 export function inspectTypeLiteralExpression(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPrimitiveType | PQP.Language.Type.TextLiteral | PQP.Language.Type.NumberLiteral {
-    PQP.Parser.XorNodeUtils.assertAstNodeKind(xorNode, PQP.Language.Ast.NodeKind.LiteralExpression);
+    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.LiteralExpression);
 
     switch (xorNode.kind) {
         case PQP.Parser.XorNodeKind.Ast:

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeNullCoalescingExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeNullCoalescingExpression.ts
@@ -1,40 +1,31 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
-
-import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+import { Ast, Type, TypeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { NodeIdMapUtils, TXorNode, XorNodeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
 import { inspectTypeFromChildAttributeIndex, InspectTypeState } from "./common";
 
-export function inspectTypeNullCoalescingExpression(
-    state: InspectTypeState,
-    xorNode: PQP.Parser.TXorNode,
-): PQP.Language.Type.TPowerQueryType {
+export function inspectTypeNullCoalescingExpression(state: InspectTypeState, xorNode: TXorNode): Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.NullCoalescingExpression);
+    XorNodeUtils.assertIsNodeKind(xorNode, Ast.NodeKind.NullCoalescingExpression);
 
-    const maybeLeftType: PQP.Language.Type.TPowerQueryType = inspectTypeFromChildAttributeIndex(state, xorNode, 0);
-    const maybeNullCoalescingOperator:
-        | PQP.Language.Ast.TConstant
-        | undefined = PQP.Parser.NodeIdMapUtils.maybeUnwrapNthChildIfAstChecked(
+    const maybeLeftType: Type.TPowerQueryType = inspectTypeFromChildAttributeIndex(state, xorNode, 0);
+    const maybeNullCoalescingOperator: Ast.TConstant | undefined = NodeIdMapUtils.maybeUnboxNthChildIfAstChecked(
         state.nodeIdMapCollection,
         xorNode.node.id,
         1,
-        PQP.Language.Ast.NodeKind.Constant,
+        Ast.NodeKind.Constant,
     );
     // '??' isn't present, treat it as an Expression.
     if (maybeNullCoalescingOperator === undefined) {
         return maybeLeftType;
     }
 
-    const maybeRightType: PQP.Language.Type.TPowerQueryType = inspectTypeFromChildAttributeIndex(state, xorNode, 2);
-    if (
-        maybeLeftType.kind === PQP.Language.Type.TypeKind.None ||
-        maybeRightType.kind === PQP.Language.Type.TypeKind.None
-    ) {
-        return PQP.Language.Type.NoneInstance;
+    const maybeRightType: Type.TPowerQueryType = inspectTypeFromChildAttributeIndex(state, xorNode, 2);
+    if (maybeLeftType.kind === Type.TypeKind.None || maybeRightType.kind === Type.TypeKind.None) {
+        return Type.NoneInstance;
     }
 
-    return PQP.Language.TypeUtils.createAnyUnion([maybeLeftType, maybeRightType]);
+    return TypeUtils.createAnyUnion([maybeLeftType, maybeRightType]);
 }

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeNullCoalescingExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeNullCoalescingExpression.ts
@@ -10,16 +10,16 @@ export function inspectTypeNullCoalescingExpression(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertAstNodeKind(xorNode, PQP.Language.Ast.NodeKind.NullCoalescingExpression);
+    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.NullCoalescingExpression);
 
     const maybeLeftType: PQP.Language.Type.TPowerQueryType = inspectTypeFromChildAttributeIndex(state, xorNode, 0);
     const maybeNullCoalescingOperator:
-        | PQP.Language.Ast.TNode
-        | undefined = PQP.Parser.NodeIdMapUtils.maybeChildAstByAttributeIndex(
+        | PQP.Language.Ast.TConstant
+        | undefined = PQP.Parser.NodeIdMapUtils.maybeUnwrapNthChildIfAst(
         state.nodeIdMapCollection,
         xorNode.node.id,
         1,
-        [PQP.Language.Ast.NodeKind.Constant],
+        PQP.Language.Ast.NodeKind.Constant,
     );
     // '??' isn't present, treat it as an Expression.
     if (maybeNullCoalescingOperator === undefined) {

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeNullCoalescingExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeNullCoalescingExpression.ts
@@ -3,6 +3,8 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+
 import { inspectTypeFromChildAttributeIndex, InspectTypeState } from "./common";
 
 export function inspectTypeNullCoalescingExpression(
@@ -10,12 +12,12 @@ export function inspectTypeNullCoalescingExpression(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.NullCoalescingExpression);
+    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.NullCoalescingExpression);
 
     const maybeLeftType: PQP.Language.Type.TPowerQueryType = inspectTypeFromChildAttributeIndex(state, xorNode, 0);
     const maybeNullCoalescingOperator:
         | PQP.Language.Ast.TConstant
-        | undefined = PQP.Parser.NodeIdMapUtils.maybeUnwrapNthChildIfAst(
+        | undefined = PQP.Parser.NodeIdMapUtils.maybeUnwrapNthChildIfAstChecked(
         state.nodeIdMapCollection,
         xorNode.node.id,
         1,

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeParameter.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeParameter.ts
@@ -3,6 +3,8 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+
 import { inspectTypeFromChildAttributeIndex, InspectTypeState } from "./common";
 
 export function inspectTypeParameter(
@@ -10,11 +12,11 @@ export function inspectTypeParameter(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.Parameter);
+    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.Parameter);
 
     const maybeOptionalConstant:
         | PQP.Language.Ast.TConstant
-        | undefined = PQP.Parser.NodeIdMapUtils.maybeUnwrapNthChildIfAst(
+        | undefined = PQP.Parser.NodeIdMapUtils.maybeUnwrapNthChildIfAstChecked(
         state.nodeIdMapCollection,
         xorNode.node.id,
         0,

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeParameter.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeParameter.ts
@@ -10,15 +10,15 @@ export function inspectTypeParameter(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertAstNodeKind(xorNode, PQP.Language.Ast.NodeKind.Parameter);
+    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.Parameter);
 
     const maybeOptionalConstant:
-        | PQP.Language.Ast.TNode
-        | undefined = PQP.Parser.NodeIdMapUtils.maybeChildAstByAttributeIndex(
+        | PQP.Language.Ast.TConstant
+        | undefined = PQP.Parser.NodeIdMapUtils.maybeUnwrapNthChildIfAst(
         state.nodeIdMapCollection,
         xorNode.node.id,
         0,
-        [PQP.Language.Ast.NodeKind.Constant],
+        PQP.Language.Ast.NodeKind.Constant,
     );
 
     const maybeParameterType:

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeParameter.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeParameter.ts
@@ -1,31 +1,23 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
-
-import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+import { Ast, Type, TypeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { NodeIdMapUtils, TXorNode, XorNodeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
 import { inspectTypeFromChildAttributeIndex, InspectTypeState } from "./common";
 
-export function inspectTypeParameter(
-    state: InspectTypeState,
-    xorNode: PQP.Parser.TXorNode,
-): PQP.Language.Type.TPowerQueryType {
+export function inspectTypeParameter(state: InspectTypeState, xorNode: TXorNode): Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.Parameter);
+    XorNodeUtils.assertIsNodeKind(xorNode, Ast.NodeKind.Parameter);
 
-    const maybeOptionalConstant:
-        | PQP.Language.Ast.TConstant
-        | undefined = PQP.Parser.NodeIdMapUtils.maybeUnwrapNthChildIfAstChecked(
+    const maybeOptionalConstant: Ast.TConstant | undefined = NodeIdMapUtils.maybeUnboxNthChildIfAstChecked(
         state.nodeIdMapCollection,
         xorNode.node.id,
         0,
-        PQP.Language.Ast.NodeKind.Constant,
+        Ast.NodeKind.Constant,
     );
 
-    const maybeParameterType:
-        | PQP.Language.Type.TPowerQueryType
-        | undefined = PQP.Language.TypeUtils.assertAsTPrimitiveType(
+    const maybeParameterType: Type.TPowerQueryType | undefined = TypeUtils.assertAsTPrimitiveType(
         inspectTypeFromChildAttributeIndex(state, xorNode, 2),
     );
 

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypePrimitiveType.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypePrimitiveType.ts
@@ -4,7 +4,7 @@
 import * as PQP from "@microsoft/powerquery-parser";
 
 export function inspectTypePrimitiveType(xorNode: PQP.Parser.TXorNode): PQP.Language.Type.TPowerQueryType {
-    PQP.Parser.XorNodeUtils.assertAstNodeKind(xorNode, PQP.Language.Ast.NodeKind.PrimitiveType);
+    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.PrimitiveType);
 
     if (xorNode.kind === PQP.Parser.XorNodeKind.Context) {
         return PQP.Language.Type.UnknownInstance;

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypePrimitiveType.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypePrimitiveType.ts
@@ -1,19 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
+import { Ast, Type, TypeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { TXorNode, XorNodeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
-import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+export function inspectTypePrimitiveType(xorNode: TXorNode): Type.TPowerQueryType {
+    XorNodeUtils.assertIsNodeKind(xorNode, Ast.NodeKind.PrimitiveType);
 
-export function inspectTypePrimitiveType(xorNode: PQP.Parser.TXorNode): PQP.Language.Type.TPowerQueryType {
-    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.PrimitiveType);
-
-    if (xorNode.kind === PQP.Parser.XorNodeKind.Context) {
-        return PQP.Language.Type.UnknownInstance;
+    if (XorNodeUtils.isContextXor(xorNode)) {
+        return Type.UnknownInstance;
     }
 
-    const kind: PQP.Language.Type.TypeKind = PQP.Language.TypeUtils.typeKindFromPrimitiveTypeConstantKind(
-        (xorNode.node as PQP.Language.Ast.PrimitiveType).primitiveTypeKind,
+    const kind: Type.TypeKind = TypeUtils.typeKindFromPrimitiveTypeConstantKind(
+        (xorNode.node as Ast.PrimitiveType).primitiveTypeKind,
     );
     return {
         kind,

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypePrimitiveType.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypePrimitiveType.ts
@@ -3,8 +3,10 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+
 export function inspectTypePrimitiveType(xorNode: PQP.Parser.TXorNode): PQP.Language.Type.TPowerQueryType {
-    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.PrimitiveType);
+    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.PrimitiveType);
 
     if (xorNode.kind === PQP.Parser.XorNodeKind.Context) {
         return PQP.Language.Type.UnknownInstance;

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRangeExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRangeExpression.ts
@@ -3,6 +3,8 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+
 import { inspectTypeFromChildAttributeIndex, InspectTypeState } from "./common";
 
 export function inspectTypeRangeExpression(
@@ -10,7 +12,7 @@ export function inspectTypeRangeExpression(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.RangeExpression);
+    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.RangeExpression);
 
     const maybeLeftType: PQP.Language.Type.TPowerQueryType | undefined = inspectTypeFromChildAttributeIndex(
         state,

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRangeExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRangeExpression.ts
@@ -10,7 +10,7 @@ export function inspectTypeRangeExpression(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertAstNodeKind(xorNode, PQP.Language.Ast.NodeKind.RangeExpression);
+    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.RangeExpression);
 
     const maybeLeftType: PQP.Language.Type.TPowerQueryType | undefined = inspectTypeFromChildAttributeIndex(
         state,

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRangeExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRangeExpression.ts
@@ -1,53 +1,32 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
-
-import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+import { Ast, Type, TypeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { TXorNode, XorNodeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
 import { inspectTypeFromChildAttributeIndex, InspectTypeState } from "./common";
 
-export function inspectTypeRangeExpression(
-    state: InspectTypeState,
-    xorNode: PQP.Parser.TXorNode,
-): PQP.Language.Type.TPowerQueryType {
+export function inspectTypeRangeExpression(state: InspectTypeState, xorNode: TXorNode): Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.RangeExpression);
+    XorNodeUtils.assertIsNodeKind(xorNode, Ast.NodeKind.RangeExpression);
 
-    const maybeLeftType: PQP.Language.Type.TPowerQueryType | undefined = inspectTypeFromChildAttributeIndex(
-        state,
-        xorNode,
-        0,
-    );
-    const maybeRightType: PQP.Language.Type.TPowerQueryType | undefined = inspectTypeFromChildAttributeIndex(
-        state,
-        xorNode,
-        2,
-    );
+    const maybeLeftType: Type.TPowerQueryType | undefined = inspectTypeFromChildAttributeIndex(state, xorNode, 0);
+    const maybeRightType: Type.TPowerQueryType | undefined = inspectTypeFromChildAttributeIndex(state, xorNode, 2);
 
     if (maybeLeftType === undefined || maybeRightType === undefined) {
-        return PQP.Language.Type.UnknownInstance;
-    } else if (
-        maybeLeftType.kind === PQP.Language.Type.TypeKind.Number &&
-        maybeRightType.kind === PQP.Language.Type.TypeKind.Number
-    ) {
+        return Type.UnknownInstance;
+    } else if (maybeLeftType.kind === Type.TypeKind.Number && maybeRightType.kind === Type.TypeKind.Number) {
         // TODO: handle isNullable better
         if (maybeLeftType.isNullable === true || maybeRightType.isNullable === true) {
-            return PQP.Language.Type.NoneInstance;
+            return Type.NoneInstance;
         } else {
-            return PQP.Language.TypeUtils.createPrimitiveType(maybeLeftType.isNullable, maybeLeftType.kind);
+            return TypeUtils.createPrimitiveType(maybeLeftType.isNullable, maybeLeftType.kind);
         }
-    } else if (
-        maybeLeftType.kind === PQP.Language.Type.TypeKind.None ||
-        maybeRightType.kind === PQP.Language.Type.TypeKind.None
-    ) {
-        return PQP.Language.Type.NoneInstance;
-    } else if (
-        maybeLeftType.kind === PQP.Language.Type.TypeKind.Unknown ||
-        maybeRightType.kind === PQP.Language.Type.TypeKind.Unknown
-    ) {
-        return PQP.Language.Type.UnknownInstance;
+    } else if (maybeLeftType.kind === Type.TypeKind.None || maybeRightType.kind === Type.TypeKind.None) {
+        return Type.NoneInstance;
+    } else if (maybeLeftType.kind === Type.TypeKind.Unknown || maybeRightType.kind === Type.TypeKind.Unknown) {
+        return Type.UnknownInstance;
     } else {
-        return PQP.Language.Type.NoneInstance;
+        return Type.NoneInstance;
     }
 }

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRecord.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRecord.ts
@@ -3,6 +3,8 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+
 import { InspectTypeState, inspectXor } from "./common";
 
 export function inspectTypeRecord(
@@ -10,7 +12,7 @@ export function inspectTypeRecord(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.DefinedRecord {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertIsRecord(xorNode);
+    XorNodeUtils.assertIsRecord(xorNode);
 
     const fields: Map<string, PQP.Language.Type.TPowerQueryType> = new Map();
     for (const keyValuePair of PQP.Parser.NodeIdMapIterator.iterRecord(state.nodeIdMapCollection, xorNode)) {

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRecord.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRecord.ts
@@ -1,31 +1,27 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
-
-import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+import { Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { NodeIdMapIterator, TXorNode, XorNodeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
 import { InspectTypeState, inspectXor } from "./common";
 
-export function inspectTypeRecord(
-    state: InspectTypeState,
-    xorNode: PQP.Parser.TXorNode,
-): PQP.Language.Type.DefinedRecord {
+export function inspectTypeRecord(state: InspectTypeState, xorNode: TXorNode): Type.DefinedRecord {
     state.settings.maybeCancellationToken?.throwIfCancelled();
     XorNodeUtils.assertIsRecord(xorNode);
 
-    const fields: Map<string, PQP.Language.Type.TPowerQueryType> = new Map();
-    for (const keyValuePair of PQP.Parser.NodeIdMapIterator.iterRecord(state.nodeIdMapCollection, xorNode)) {
+    const fields: Map<string, Type.TPowerQueryType> = new Map();
+    for (const keyValuePair of NodeIdMapIterator.iterRecord(state.nodeIdMapCollection, xorNode)) {
         if (keyValuePair.maybeValue) {
             fields.set(keyValuePair.keyLiteral, inspectXor(state, keyValuePair.maybeValue));
         } else {
-            fields.set(keyValuePair.keyLiteral, PQP.Language.Type.UnknownInstance);
+            fields.set(keyValuePair.keyLiteral, Type.UnknownInstance);
         }
     }
 
     return {
-        kind: PQP.Language.Type.TypeKind.Record,
-        maybeExtendedKind: PQP.Language.Type.ExtendedTypeKind.DefinedRecord,
+        kind: Type.TypeKind.Record,
+        maybeExtendedKind: Type.ExtendedTypeKind.DefinedRecord,
         isNullable: false,
         fields,
         isOpen: false,

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRecordType.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRecordType.ts
@@ -1,33 +1,29 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
-
-import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+import { Ast, Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { NodeIdMapUtils, TXorNode, XorNodeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
 import { InspectTypeState } from "./common";
 import { examineFieldSpecificationList } from "./examineFieldSpecificationList";
 
-export function inspectTypeRecordType(
-    state: InspectTypeState,
-    xorNode: PQP.Parser.TXorNode,
-): PQP.Language.Type.RecordType | PQP.Language.Type.Unknown {
+export function inspectTypeRecordType(state: InspectTypeState, xorNode: TXorNode): Type.RecordType | Type.Unknown {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.RecordType);
+    XorNodeUtils.assertIsNodeKind(xorNode, Ast.NodeKind.RecordType);
 
-    const maybeFields: PQP.Parser.TXorNode | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChildChecked(
+    const maybeFields: TXorNode | undefined = NodeIdMapUtils.maybeNthChildChecked(
         state.nodeIdMapCollection,
         xorNode.node.id,
         0,
-        PQP.Language.Ast.NodeKind.FieldSpecificationList,
+        Ast.NodeKind.FieldSpecificationList,
     );
     if (maybeFields === undefined) {
-        return PQP.Language.Type.UnknownInstance;
+        return Type.UnknownInstance;
     }
 
     return {
-        kind: PQP.Language.Type.TypeKind.Type,
-        maybeExtendedKind: PQP.Language.Type.ExtendedTypeKind.RecordType,
+        kind: Type.TypeKind.Type,
+        maybeExtendedKind: Type.ExtendedTypeKind.RecordType,
         isNullable: false,
         ...examineFieldSpecificationList(state, maybeFields),
     };

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRecordType.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRecordType.ts
@@ -11,15 +11,13 @@ export function inspectTypeRecordType(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.RecordType | PQP.Language.Type.Unknown {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertAstNodeKind(xorNode, PQP.Language.Ast.NodeKind.RecordType);
+    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.RecordType);
 
-    const maybeFields:
-        | PQP.Parser.TXorNode
-        | undefined = PQP.Parser.NodeIdMapUtils.maybeChildXorByAttributeIndex(
+    const maybeFields: PQP.Parser.TXorNode | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChild(
         state.nodeIdMapCollection,
         xorNode.node.id,
         0,
-        [PQP.Language.Ast.NodeKind.FieldSpecificationList],
+        PQP.Language.Ast.NodeKind.FieldSpecificationList,
     );
     if (maybeFields === undefined) {
         return PQP.Language.Type.UnknownInstance;

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRecordType.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRecordType.ts
@@ -3,6 +3,8 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+
 import { InspectTypeState } from "./common";
 import { examineFieldSpecificationList } from "./examineFieldSpecificationList";
 
@@ -11,9 +13,9 @@ export function inspectTypeRecordType(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.RecordType | PQP.Language.Type.Unknown {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.RecordType);
+    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.RecordType);
 
-    const maybeFields: PQP.Parser.TXorNode | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChild(
+    const maybeFields: PQP.Parser.TXorNode | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChildChecked(
         state.nodeIdMapCollection,
         xorNode.node.id,
         0,

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRecursivePrimaryExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRecursivePrimaryExpression.ts
@@ -3,6 +3,8 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+
 import { inspectTypeFromChildAttributeIndex, InspectTypeState, inspectXor } from "./common";
 
 export function inspectTypeRecursivePrimaryExpression(
@@ -10,7 +12,7 @@ export function inspectTypeRecursivePrimaryExpression(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.RecursivePrimaryExpression);
+    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.RecursivePrimaryExpression);
 
     const maybeHead: PQP.Parser.TXorNode | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChild(
         state.nodeIdMapCollection,
@@ -28,7 +30,7 @@ export function inspectTypeRecursivePrimaryExpression(
 
     const maybeArrayWrapper:
         | PQP.Parser.XorNode<PQP.Language.Ast.TArrayWrapper>
-        | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChild(
+        | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChildChecked<PQP.Language.Ast.TArrayWrapper>(
         state.nodeIdMapCollection,
         xorNode.node.id,
         1,

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRecursivePrimaryExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRecursivePrimaryExpression.ts
@@ -10,13 +10,12 @@ export function inspectTypeRecursivePrimaryExpression(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertAstNodeKind(xorNode, PQP.Language.Ast.NodeKind.RecursivePrimaryExpression);
+    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.RecursivePrimaryExpression);
 
-    const maybeHead: PQP.Parser.TXorNode | undefined = PQP.Parser.NodeIdMapUtils.maybeChildXorByAttributeIndex(
+    const maybeHead: PQP.Parser.TXorNode | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChild(
         state.nodeIdMapCollection,
         xorNode.node.id,
         0,
-        undefined,
     );
     if (maybeHead === undefined) {
         return PQP.Language.Type.UnknownInstance;
@@ -28,12 +27,12 @@ export function inspectTypeRecursivePrimaryExpression(
     }
 
     const maybeArrayWrapper:
-        | PQP.Parser.TXorNode
-        | undefined = PQP.Parser.NodeIdMapUtils.maybeChildXorByAttributeIndex(
+        | PQP.Parser.XorNode<PQP.Language.Ast.TArrayWrapper>
+        | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChild(
         state.nodeIdMapCollection,
         xorNode.node.id,
         1,
-        [PQP.Language.Ast.NodeKind.ArrayWrapper],
+        PQP.Language.Ast.NodeKind.ArrayWrapper,
     );
     if (maybeArrayWrapper === undefined) {
         return PQP.Language.Type.UnknownInstance;

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRecursivePrimaryExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRecursivePrimaryExpression.ts
@@ -1,58 +1,52 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
-
-import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+import { Ast, Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import {
+    NodeIdMapIterator,
+    NodeIdMapUtils,
+    TXorNode,
+    XorNode,
+    XorNodeUtils,
+} from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
 import { inspectTypeFromChildAttributeIndex, InspectTypeState, inspectXor } from "./common";
 
 export function inspectTypeRecursivePrimaryExpression(
     state: InspectTypeState,
-    xorNode: PQP.Parser.TXorNode,
-): PQP.Language.Type.TPowerQueryType {
+    xorNode: TXorNode,
+): Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.RecursivePrimaryExpression);
+    XorNodeUtils.assertIsNodeKind(xorNode, Ast.NodeKind.RecursivePrimaryExpression);
 
-    const maybeHead: PQP.Parser.TXorNode | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChild(
-        state.nodeIdMapCollection,
-        xorNode.node.id,
-        0,
-    );
+    const maybeHead: TXorNode | undefined = NodeIdMapUtils.maybeNthChild(state.nodeIdMapCollection, xorNode.node.id, 0);
     if (maybeHead === undefined) {
-        return PQP.Language.Type.UnknownInstance;
+        return Type.UnknownInstance;
     }
 
-    const headType: PQP.Language.Type.TPowerQueryType = inspectTypeFromChildAttributeIndex(state, xorNode, 0);
-    if (headType.kind === PQP.Language.Type.TypeKind.None || headType.kind === PQP.Language.Type.TypeKind.Unknown) {
+    const headType: Type.TPowerQueryType = inspectTypeFromChildAttributeIndex(state, xorNode, 0);
+    if (headType.kind === Type.TypeKind.None || headType.kind === Type.TypeKind.Unknown) {
         return headType;
     }
 
-    const maybeArrayWrapper:
-        | PQP.Parser.XorNode<PQP.Language.Ast.TArrayWrapper>
-        | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChildChecked<PQP.Language.Ast.TArrayWrapper>(
-        state.nodeIdMapCollection,
-        xorNode.node.id,
-        1,
-        PQP.Language.Ast.NodeKind.ArrayWrapper,
-    );
+    const maybeArrayWrapper: XorNode<Ast.TArrayWrapper> | undefined = NodeIdMapUtils.maybeNthChildChecked<
+        Ast.TArrayWrapper
+    >(state.nodeIdMapCollection, xorNode.node.id, 1, Ast.NodeKind.ArrayWrapper);
     if (maybeArrayWrapper === undefined) {
-        return PQP.Language.Type.UnknownInstance;
+        return Type.UnknownInstance;
     }
 
-    const maybeExpressions:
-        | ReadonlyArray<PQP.Parser.TXorNode>
-        | undefined = PQP.Parser.NodeIdMapIterator.assertIterChildrenXor(
+    const maybeExpressions: ReadonlyArray<TXorNode> | undefined = NodeIdMapIterator.assertIterChildrenXor(
         state.nodeIdMapCollection,
         maybeArrayWrapper.node.id,
     );
     if (maybeExpressions === undefined) {
-        return PQP.Language.Type.UnknownInstance;
+        return Type.UnknownInstance;
     }
 
-    let leftType: PQP.Language.Type.TPowerQueryType = headType;
+    let leftType: Type.TPowerQueryType = headType;
     for (const right of maybeExpressions) {
-        const rightType: PQP.Language.Type.TPowerQueryType = inspectXor(state, right);
+        const rightType: Type.TPowerQueryType = inspectXor(state, right);
         leftType = rightType;
     }
 

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeTableType.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeTableType.ts
@@ -3,6 +3,8 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+
 import { InspectTypeState, inspectXor } from "./common";
 import { examineFieldSpecificationList } from "./examineFieldSpecificationList";
 
@@ -11,7 +13,7 @@ export function inspectTypeTableType(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TableType | PQP.Language.Type.TableTypePrimaryExpression | PQP.Language.Type.Unknown {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.TableType);
+    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.TableType);
 
     const maybeRowType: PQP.Parser.TXorNode | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChild(
         state.nodeIdMapCollection,

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeTableType.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeTableType.ts
@@ -1,40 +1,39 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
-
-import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
+import { Ast, Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { NodeIdMapUtils, TXorNode, XorNodeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
 import { InspectTypeState, inspectXor } from "./common";
 import { examineFieldSpecificationList } from "./examineFieldSpecificationList";
 
 export function inspectTypeTableType(
     state: InspectTypeState,
-    xorNode: PQP.Parser.TXorNode,
-): PQP.Language.Type.TableType | PQP.Language.Type.TableTypePrimaryExpression | PQP.Language.Type.Unknown {
+    xorNode: TXorNode,
+): Type.TableType | Type.TableTypePrimaryExpression | Type.Unknown {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.TableType);
+    XorNodeUtils.assertIsNodeKind(xorNode, Ast.NodeKind.TableType);
 
-    const maybeRowType: PQP.Parser.TXorNode | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChild(
+    const maybeRowType: TXorNode | undefined = NodeIdMapUtils.maybeNthChild(
         state.nodeIdMapCollection,
         xorNode.node.id,
         1,
     );
     if (maybeRowType === undefined) {
-        return PQP.Language.Type.UnknownInstance;
+        return Type.UnknownInstance;
     }
 
-    if (maybeRowType.node.kind === PQP.Language.Ast.NodeKind.FieldSpecificationList) {
+    if (maybeRowType.node.kind === Ast.NodeKind.FieldSpecificationList) {
         return {
-            kind: PQP.Language.Type.TypeKind.Type,
-            maybeExtendedKind: PQP.Language.Type.ExtendedTypeKind.TableType,
+            kind: Type.TypeKind.Type,
+            maybeExtendedKind: Type.ExtendedTypeKind.TableType,
             isNullable: false,
             ...examineFieldSpecificationList(state, maybeRowType),
         };
     } else {
         return {
-            kind: PQP.Language.Type.TypeKind.Type,
-            maybeExtendedKind: PQP.Language.Type.ExtendedTypeKind.TableTypePrimaryExpression,
+            kind: Type.TypeKind.Type,
+            maybeExtendedKind: Type.ExtendedTypeKind.TableTypePrimaryExpression,
             isNullable: false,
             primaryExpression: inspectXor(state, maybeRowType),
         };

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeTableType.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeTableType.ts
@@ -11,13 +11,12 @@ export function inspectTypeTableType(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TableType | PQP.Language.Type.TableTypePrimaryExpression | PQP.Language.Type.Unknown {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertAstNodeKind(xorNode, PQP.Language.Ast.NodeKind.TableType);
+    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.TableType);
 
-    const maybeRowType: PQP.Parser.TXorNode | undefined = PQP.Parser.NodeIdMapUtils.maybeChildXorByAttributeIndex(
+    const maybeRowType: PQP.Parser.TXorNode | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChild(
         state.nodeIdMapCollection,
         xorNode.node.id,
         1,
-        undefined,
     );
     if (maybeRowType === undefined) {
         return PQP.Language.Type.UnknownInstance;

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeUnaryExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeUnaryExpression.ts
@@ -12,24 +12,26 @@ export function inspectTypeUnaryExpression(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertAstNodeKind(xorNode, PQP.Language.Ast.NodeKind.UnaryExpression);
+    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.UnaryExpression);
 
     const nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection = state.nodeIdMapCollection;
     const maybeUnaryOperatorWrapper:
-        | PQP.Parser.TXorNode
-        | undefined = PQP.Parser.NodeIdMapUtils.maybeChildXorByAttributeIndex(nodeIdMapCollection, xorNode.node.id, 0, [
+        | PQP.Parser.XorNode<PQP.Language.Ast.TArrayWrapper>
+        | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChild(
+        nodeIdMapCollection,
+        xorNode.node.id,
+        0,
         PQP.Language.Ast.NodeKind.ArrayWrapper,
-    ]);
+    );
     if (maybeUnaryOperatorWrapper === undefined) {
         return PQP.Language.Type.UnknownInstance;
     }
     const unaryOperatorWrapper: PQP.Parser.TXorNode | undefined = maybeUnaryOperatorWrapper;
 
-    const maybeExpression: PQP.Parser.TXorNode | undefined = PQP.Parser.NodeIdMapUtils.maybeChildXorByAttributeIndex(
+    const maybeExpression: PQP.Parser.TXorNode | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChild(
         nodeIdMapCollection,
         xorNode.node.id,
         1,
-        undefined,
     );
     if (maybeExpression === undefined) {
         return PQP.Language.Type.UnknownInstance;

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeUnaryExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeUnaryExpression.ts
@@ -4,6 +4,7 @@
 import * as PQP from "@microsoft/powerquery-parser";
 
 import { Assert } from "@microsoft/powerquery-parser";
+import { XorNodeUtils } from "../../../../../../powerquery-parser/lib/powerquery-parser/parser";
 
 import { InspectTypeState, inspectXor } from "./common";
 
@@ -12,12 +13,12 @@ export function inspectTypeUnaryExpression(
     xorNode: PQP.Parser.TXorNode,
 ): PQP.Language.Type.TPowerQueryType {
     state.settings.maybeCancellationToken?.throwIfCancelled();
-    PQP.Parser.XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.UnaryExpression);
+    XorNodeUtils.assertIsNodeKind(xorNode, PQP.Language.Ast.NodeKind.UnaryExpression);
 
     const nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection = state.nodeIdMapCollection;
     const maybeUnaryOperatorWrapper:
         | PQP.Parser.XorNode<PQP.Language.Ast.TArrayWrapper>
-        | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChild(
+        | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChildChecked<PQP.Language.Ast.TArrayWrapper>(
         nodeIdMapCollection,
         xorNode.node.id,
         0,

--- a/src/powerquery-language-services/inspection/type/task.ts
+++ b/src/powerquery-language-services/inspection/type/task.ts
@@ -3,7 +3,9 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
-import { Assert } from "@microsoft/powerquery-parser";
+import { Assert, ResultUtils } from "@microsoft/powerquery-parser";
+import { Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { NodeIdMap, NodeIdMapUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
 import { InspectionSettings } from "../..";
 import { NodeScope } from "../scope";
@@ -13,11 +15,11 @@ import { assertGetOrCreateNodeScope, getOrCreateScopeItemType, InspectTypeState,
 
 export type TriedScopeType = PQP.Result<ScopeTypeByKey, PQP.CommonError.CommonError>;
 
-export type TriedType = PQP.Result<PQP.Language.Type.TPowerQueryType, PQP.CommonError.CommonError>;
+export type TriedType = PQP.Result<Type.TPowerQueryType, PQP.CommonError.CommonError>;
 
 export function tryScopeType(
     settings: InspectionSettings,
-    nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
+    nodeIdMapCollection: NodeIdMap.Collection,
     nodeId: number,
     // If a TypeCache is given, then potentially add to its values and include it as part of the return,
     // Else create a new TypeCache and include it in the return.
@@ -31,12 +33,12 @@ export function tryScopeType(
         scopeById: typeCache.scopeById,
     };
 
-    return PQP.ResultUtils.ensureResult(settings.locale, () => inspectScopeType(state, nodeId));
+    return ResultUtils.ensureResult(settings.locale, () => inspectScopeType(state, nodeId));
 }
 
 export function tryType(
     settings: InspectionSettings,
-    nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
+    nodeIdMapCollection: NodeIdMap.Collection,
     nodeId: number,
     typeCache: TypeCache = TypeCacheUtils.createEmptyCache(),
 ): TriedType {
@@ -48,8 +50,8 @@ export function tryType(
         scopeById: typeCache.scopeById,
     };
 
-    return PQP.ResultUtils.ensureResult(settings.locale, () =>
-        inspectXor(state, PQP.Parser.NodeIdMapUtils.assertGetXor(nodeIdMapCollection, nodeId)),
+    return ResultUtils.ensureResult(settings.locale, () =>
+        inspectXor(state, NodeIdMapUtils.assertGetXor(nodeIdMapCollection, nodeId)),
     );
 }
 
@@ -68,7 +70,7 @@ function inspectScopeType(state: InspectTypeState, nodeId: number): ScopeTypeByK
 
     const result: ScopeTypeByKey = new Map();
     for (const [key, scopeItem] of nodeScope.entries()) {
-        const type: PQP.Language.Type.TPowerQueryType = Assert.asDefined(
+        const type: Type.TPowerQueryType = Assert.asDefined(
             state.givenTypeById.get(scopeItem.id),
             `expected nodeId to be in givenTypeById`,
             { nodeId: scopeItem.id },

--- a/src/powerquery-language-services/inspection/typeCache/typeCache.ts
+++ b/src/powerquery-language-services/inspection/typeCache/typeCache.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
+import { Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 
 import { ScopeById } from "../scope";
 
-export type TypeById = Map<number, PQP.Language.Type.TPowerQueryType>;
+export type TypeById = Map<number, Type.TPowerQueryType>;
 
 // A cache that can be re-used for successive calls for the same document.
 export interface TypeCache {

--- a/src/powerquery-language-services/inspectionUtils.ts
+++ b/src/powerquery-language-services/inspectionUtils.ts
@@ -134,7 +134,7 @@ export function getSymbolKindFromLiteralExpression(node: PQP.Language.Ast.Litera
     }
 }
 
-export function getSymbolKindFromNode(node: PQP.Language.Ast.INode | PQP.Parser.ParseContext.Node): SymbolKind {
+export function getSymbolKindFromNode(node: PQP.Language.Ast.INode | PQP.Parser.ParseContext.TNode): SymbolKind {
     switch (node.kind) {
         case PQP.Language.Ast.NodeKind.Constant:
             return SymbolKind.Constant;

--- a/src/powerquery-language-services/inspectionUtils.ts
+++ b/src/powerquery-language-services/inspectionUtils.ts
@@ -3,6 +3,9 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { Assert, ResultUtils } from "@microsoft/powerquery-parser";
+import { Ast, Type, TypeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { ParseContext } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 import { DocumentSymbol, SignatureHelp, SymbolKind } from "vscode-languageserver-types";
 
 import { Inspection, PositionUtils } from ".";
@@ -25,7 +28,7 @@ export function getMaybeContextForSignatureProvider(
     inspected: Inspection.Inspection,
 ): SignatureProviderContext | undefined {
     if (
-        PQP.ResultUtils.isError(inspected.triedCurrentInvokeExpression) ||
+        ResultUtils.isError(inspected.triedCurrentInvokeExpression) ||
         inspected.triedCurrentInvokeExpression.value === undefined
     ) {
         return undefined;
@@ -51,16 +54,14 @@ export function getMaybeContextForSignatureProvider(
 
 export function getMaybeSignatureHelp(context: SignatureProviderContext): SignatureHelp | null {
     const identifierLiteral: string | undefined = context.functionName;
-    if (identifierLiteral === undefined || !PQP.Language.TypeUtils.isDefinedFunction(context.functionType)) {
+    if (identifierLiteral === undefined || !TypeUtils.isDefinedFunction(context.functionType)) {
         // tslint:disable-next-line: no-null-keyword
         return null;
     }
-    const nameOfParameters: string = context.functionType.parameters
-        .map(PQP.Language.TypeUtils.nameOfFunctionParameter)
-        .join(", ");
+    const nameOfParameters: string = context.functionType.parameters.map(TypeUtils.nameOfFunctionParameter).join(", ");
     const label: string = `${identifierLiteral}(${nameOfParameters})`;
 
-    const parameters: ReadonlyArray<PQP.Language.Type.FunctionParameter> = context.functionType.parameters;
+    const parameters: ReadonlyArray<Type.FunctionParameter> = context.functionType.parameters;
     return {
         // tslint:disable-next-line: no-null-keyword
         activeParameter: context.argumentOrdinal ?? null,
@@ -68,7 +69,7 @@ export function getMaybeSignatureHelp(context: SignatureProviderContext): Signat
         signatures: [
             {
                 label,
-                parameters: parameters.map((parameter: PQP.Language.Type.FunctionParameter) => {
+                parameters: parameters.map((parameter: Type.FunctionParameter) => {
                     return {
                         label: parameter.nameLiteral,
                     };
@@ -78,13 +79,8 @@ export function getMaybeSignatureHelp(context: SignatureProviderContext): Signat
     };
 }
 
-export function getMaybeType(
-    inspection: Inspection.Inspection,
-    identifier: string,
-): PQP.Language.Type.TPowerQueryType | undefined {
-    return PQP.ResultUtils.isOk(inspection.triedScopeType)
-        ? inspection.triedScopeType.value.get(identifier)
-        : undefined;
+export function getMaybeType(inspection: Inspection.Inspection, identifier: string): Type.TPowerQueryType | undefined {
+    return ResultUtils.isOk(inspection.triedScopeType) ? inspection.triedScopeType.value.get(identifier) : undefined;
 }
 
 export function getScopeItemKindText(scopeItemKind: Inspection.ScopeItemKind): string {
@@ -108,55 +104,55 @@ export function getScopeItemKindText(scopeItemKind: Inspection.ScopeItemKind): s
             return "unknown";
 
         default:
-            throw PQP.Assert.isNever(scopeItemKind);
+            throw Assert.isNever(scopeItemKind);
     }
 }
 
-export function getSymbolKindFromLiteralExpression(node: PQP.Language.Ast.LiteralExpression): SymbolKind {
+export function getSymbolKindFromLiteralExpression(node: Ast.LiteralExpression): SymbolKind {
     switch (node.literalKind) {
-        case PQP.Language.Ast.LiteralKind.List:
+        case Ast.LiteralKind.List:
             return SymbolKind.Array;
 
-        case PQP.Language.Ast.LiteralKind.Logical:
+        case Ast.LiteralKind.Logical:
             return SymbolKind.Boolean;
 
-        case PQP.Language.Ast.LiteralKind.Null:
+        case Ast.LiteralKind.Null:
             return SymbolKind.Null;
 
-        case PQP.Language.Ast.LiteralKind.Numeric:
+        case Ast.LiteralKind.Numeric:
             return SymbolKind.Number;
 
-        case PQP.Language.Ast.LiteralKind.Text:
+        case Ast.LiteralKind.Text:
             return SymbolKind.String;
 
         default:
-            return PQP.Assert.isNever(node.literalKind);
+            return Assert.isNever(node.literalKind);
     }
 }
 
-export function getSymbolKindFromNode(node: PQP.Language.Ast.INode | PQP.Parser.ParseContext.TNode): SymbolKind {
+export function getSymbolKindFromNode(node: Ast.INode | ParseContext.TNode): SymbolKind {
     switch (node.kind) {
-        case PQP.Language.Ast.NodeKind.Constant:
+        case Ast.NodeKind.Constant:
             return SymbolKind.Constant;
 
-        case PQP.Language.Ast.NodeKind.FunctionExpression:
+        case Ast.NodeKind.FunctionExpression:
             return SymbolKind.Function;
 
-        case PQP.Language.Ast.NodeKind.ListExpression:
-        case PQP.Language.Ast.NodeKind.ListLiteral:
+        case Ast.NodeKind.ListExpression:
+        case Ast.NodeKind.ListLiteral:
             return SymbolKind.Array;
 
-        case PQP.Language.Ast.NodeKind.LiteralExpression:
-            return getSymbolKindFromLiteralExpression(node as PQP.Language.Ast.LiteralExpression);
+        case Ast.NodeKind.LiteralExpression:
+            return getSymbolKindFromLiteralExpression(node as Ast.LiteralExpression);
 
-        case PQP.Language.Ast.NodeKind.MetadataExpression:
+        case Ast.NodeKind.MetadataExpression:
             return SymbolKind.TypeParameter;
 
-        case PQP.Language.Ast.NodeKind.RecordExpression:
-        case PQP.Language.Ast.NodeKind.RecordLiteral:
+        case Ast.NodeKind.RecordExpression:
+        case Ast.NodeKind.RecordLiteral:
             return SymbolKind.Struct;
 
-        case PQP.Language.Ast.NodeKind.Section:
+        case Ast.NodeKind.Section:
             return SymbolKind.Module;
 
         default:
@@ -164,13 +160,11 @@ export function getSymbolKindFromNode(node: PQP.Language.Ast.INode | PQP.Parser.
     }
 }
 
-export function getSymbolsForLetExpression(
-    expressionNode: PQP.Language.Ast.LetExpression,
-): ReadonlyArray<DocumentSymbol> {
+export function getSymbolsForLetExpression(expressionNode: Ast.LetExpression): ReadonlyArray<DocumentSymbol> {
     const documentSymbols: DocumentSymbol[] = [];
 
     for (const element of expressionNode.variableList.elements) {
-        const pairedExpression: PQP.Language.Ast.ICsv<PQP.Language.Ast.IdentifierPairedExpression> = element;
+        const pairedExpression: Ast.ICsv<Ast.IdentifierPairedExpression> = element;
         const memberSymbol: DocumentSymbol = getSymbolForIdentifierPairedExpression(pairedExpression.node);
         documentSymbols.push(memberSymbol);
     }
@@ -179,7 +173,7 @@ export function getSymbolsForLetExpression(
 }
 
 export function getSymbolsForRecord(
-    recordNode: PQP.Language.Ast.RecordExpression | PQP.Language.Ast.RecordLiteral,
+    recordNode: Ast.RecordExpression | Ast.RecordLiteral,
 ): ReadonlyArray<DocumentSymbol> {
     const documentSymbols: DocumentSymbol[] = [];
 
@@ -196,14 +190,14 @@ export function getSymbolsForRecord(
     return documentSymbols;
 }
 
-export function getSymbolsForSection(sectionNode: PQP.Language.Ast.Section): ReadonlyArray<DocumentSymbol> {
-    return sectionNode.sectionMembers.elements.map((sectionMember: PQP.Language.Ast.SectionMember) =>
+export function getSymbolsForSection(sectionNode: Ast.Section): ReadonlyArray<DocumentSymbol> {
+    return sectionNode.sectionMembers.elements.map((sectionMember: Ast.SectionMember) =>
         getSymbolForIdentifierPairedExpression(sectionMember.namePairedExpression),
     );
 }
 
 export function getSymbolForIdentifierPairedExpression(
-    identifierPairedExpressionNode: PQP.Language.Ast.IdentifierPairedExpression,
+    identifierPairedExpressionNode: Ast.IdentifierPairedExpression,
 ): DocumentSymbol {
     return {
         kind: getSymbolKindFromNode(identifierPairedExpressionNode.value),
@@ -218,11 +212,11 @@ export function getAutocompleteItemsFromScope(
     context: AutocompleteItemProviderContext,
     inspection: Inspection.Inspection,
 ): ReadonlyArray<Inspection.AutocompleteItem> {
-    if (PQP.ResultUtils.isError(inspection.triedNodeScope)) {
+    if (ResultUtils.isError(inspection.triedNodeScope)) {
         return [];
     }
     const nodeScope: Inspection.NodeScope = inspection.triedNodeScope.value;
-    const scopeTypeByKey: Inspection.ScopeTypeByKey = PQP.ResultUtils.isOk(inspection.triedScopeType)
+    const scopeTypeByKey: Inspection.ScopeTypeByKey = ResultUtils.isOk(inspection.triedScopeType)
         ? inspection.triedScopeType.value
         : new Map();
 
@@ -235,7 +229,7 @@ export function getAutocompleteItemsFromScope(
             | undefined = AutocompleteItemUtils.maybeCreateFromScopeItem(
             label,
             scopeItem,
-            scopeTypeByKey.get(label) ?? PQP.Language.Type.UnknownInstance,
+            scopeTypeByKey.get(label) ?? Type.UnknownInstance,
             maybeContextTest,
         );
 

--- a/src/powerquery-language-services/library/library.ts
+++ b/src/powerquery-language-services/library/library.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
+import { Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 import { CompletionItemKind } from "vscode-languageserver-types";
+
 import { ExternalType } from "../inspection";
 
 export type LibraryDefinitions = ReadonlyMap<string, TLibraryDefinition>;
@@ -21,7 +22,7 @@ export interface ILibrary {
 }
 
 export interface ILibraryDefinition {
-    readonly asPowerQueryType: PQP.Language.Type.TPowerQueryType;
+    readonly asPowerQueryType: Type.TPowerQueryType;
     readonly completionItemKind: CompletionItemKind;
     readonly description: string;
     readonly kind: LibraryDefinitionKind;
@@ -42,7 +43,7 @@ export interface LibraryParameter {
     readonly isNullable: boolean;
     readonly label: string;
     readonly maybeDocumentation: string | undefined;
-    readonly typeKind: PQP.Language.Type.TypeKind;
+    readonly typeKind: Type.TypeKind;
 }
 
 export interface LibraryType extends ILibraryDefinition {

--- a/src/powerquery-language-services/library/libraryUtils.ts
+++ b/src/powerquery-language-services/library/libraryUtils.ts
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
-
+import { Assert } from "@microsoft/powerquery-parser";
+import { Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 import { CompletionItemKind, ParameterInformation, SignatureInformation } from "vscode-languageserver-types";
+
 import {
     LibraryConstant,
     LibraryDefinitionKind,
@@ -53,7 +54,7 @@ export function assertIsType(maybeDefinition: TLibraryDefinition | undefined): a
 export function createConstantDefinition(
     label: string,
     description: string,
-    asType: PQP.Language.Type.TPowerQueryType,
+    asType: Type.TPowerQueryType,
     completionItemKind: CompletionItemKind,
 ): LibraryConstant {
     return {
@@ -68,7 +69,7 @@ export function createConstantDefinition(
 export function createFunctionDefinition(
     label: string,
     description: string,
-    asType: PQP.Language.Type.TPowerQueryType,
+    asType: Type.TPowerQueryType,
     completionItemKind: CompletionItemKind,
     parameters: ReadonlyArray<LibraryParameter>,
 ): LibraryFunction {
@@ -121,6 +122,6 @@ export function nameOf(kind: LibraryDefinitionKind): string {
             return "library type";
 
         default:
-            throw PQP.Assert.isNever(kind);
+            throw Assert.isNever(kind);
     }
 }

--- a/src/powerquery-language-services/localization/localization.ts
+++ b/src/powerquery-language-services/localization/localization.ts
@@ -1,4 +1,4 @@
-import * as PQP from "@microsoft/powerquery-parser";
+import { StringUtils } from "@microsoft/powerquery-parser";
 
 import { ILocalizationTemplates } from "./templates";
 
@@ -29,7 +29,7 @@ interface ILocalization {
 
 export const Localization: ILocalization = {
     error_validation_duplicate_identifier: (templates: ILocalizationTemplates, identifier: string) =>
-        PQP.StringUtils.assertGetFormatted(
+        StringUtils.assertGetFormatted(
             templates.error_validation_duplicate_identifier,
             new Map([["identifier", identifier]]),
         ),
@@ -40,7 +40,7 @@ export const Localization: ILocalization = {
         argName: string,
     ) => {
         if (maybeFuncName) {
-            return PQP.StringUtils.assertGetFormatted(
+            return StringUtils.assertGetFormatted(
                 templates.error_validation_invokeExpression_missingMandatory_named,
                 new Map([
                     ["funcName", maybeFuncName],
@@ -48,7 +48,7 @@ export const Localization: ILocalization = {
                 ]),
             );
         } else {
-            return PQP.StringUtils.assertGetFormatted(
+            return StringUtils.assertGetFormatted(
                 templates.error_validation_invokeExpression_missingMandatory_unnamed,
                 new Map([["argName", argName]]),
             );
@@ -61,7 +61,7 @@ export const Localization: ILocalization = {
         numMax: number,
         numGiven: number,
     ) =>
-        PQP.StringUtils.assertGetFormatted(
+        StringUtils.assertGetFormatted(
             templates.error_validation_invokeExpression_numArgs,
             new Map([
                 ["numMin", numMin.toString()],
@@ -78,7 +78,7 @@ export const Localization: ILocalization = {
         actual: string,
     ) => {
         if (maybeFuncName) {
-            return PQP.StringUtils.assertGetFormatted(
+            return StringUtils.assertGetFormatted(
                 templates.error_validation_invokeExpression_typeMismatch_named,
                 new Map([
                     ["funcName", maybeFuncName],
@@ -88,7 +88,7 @@ export const Localization: ILocalization = {
                 ]),
             );
         } else {
-            return PQP.StringUtils.assertGetFormatted(
+            return StringUtils.assertGetFormatted(
                 templates.error_validation_invokeExpression_typeMismatch_unnamed,
                 new Map([
                     ["argName", argName],

--- a/src/powerquery-language-services/positionUtils.ts
+++ b/src/powerquery-language-services/positionUtils.ts
@@ -3,6 +3,14 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { Assert } from "@microsoft/powerquery-parser";
+import { Ast } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import {
+    NodeIdMap,
+    NodeIdMapUtils,
+    TXorNode,
+    XorNodeKind,
+} from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 import type { Position, Range } from "vscode-languageserver-types";
 
 export function createPositionFromTokenPosition(tokenPosition: PQP.Language.Token.TokenPosition): Position {
@@ -15,18 +23,12 @@ export function createPositionFromTokenPosition(tokenPosition: PQP.Language.Toke
 // Attempts to turn a TXorNode into a Range.
 // Returns undefined if there are no leafs nodes.
 export function createRangeFromXorNode(
-    nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
-    xorNode: PQP.Parser.TXorNode,
+    nodeIdMapCollection: NodeIdMap.Collection,
+    xorNode: TXorNode,
 ): Range | undefined {
     const nodeId: number = xorNode.node.id;
-    const maybeLeftMostLeaf: PQP.Language.Ast.TNode | undefined = PQP.Parser.NodeIdMapUtils.maybeLeftMostLeaf(
-        nodeIdMapCollection,
-        nodeId,
-    );
-    const maybeRightMostLeaf: PQP.Language.Ast.TNode | undefined = PQP.Parser.NodeIdMapUtils.maybeRightMostLeaf(
-        nodeIdMapCollection,
-        nodeId,
-    );
+    const maybeLeftMostLeaf: Ast.TNode | undefined = NodeIdMapUtils.maybeLeftMostLeaf(nodeIdMapCollection, nodeId);
+    const maybeRightMostLeaf: Ast.TNode | undefined = NodeIdMapUtils.maybeRightMostLeaf(nodeIdMapCollection, nodeId);
 
     return maybeLeftMostLeaf === undefined || maybeRightMostLeaf === undefined
         ? undefined
@@ -54,83 +56,79 @@ export function createRangeFromTokenRange(tokenRange: PQP.Language.Token.TokenRa
     return createRangeFromTokenPositions(tokenRange.positionStart, tokenRange.positionEnd) as Range;
 }
 
-export function isBeforeXor(position: Position, xorNode: PQP.Parser.TXorNode, isBoundIncluded: boolean): boolean {
+export function isBeforeXor(position: Position, xorNode: TXorNode, isBoundIncluded: boolean): boolean {
     switch (xorNode.kind) {
-        case PQP.Parser.XorNodeKind.Ast:
+        case XorNodeKind.Ast:
             return isBeforeAst(position, xorNode.node, isBoundIncluded);
 
-        case PQP.Parser.XorNodeKind.Context:
+        case XorNodeKind.Context:
             return isBeforeContext(position, xorNode.node, isBoundIncluded);
 
         default:
-            throw PQP.Assert.isNever(xorNode);
+            throw Assert.isNever(xorNode);
     }
 }
 
 export function isInXor(
-    nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
+    nodeIdMapCollection: NodeIdMap.Collection,
     position: Position,
-    xorNode: PQP.Parser.TXorNode,
+    xorNode: TXorNode,
     isLowerBoundIncluded: boolean,
     isUpperBoundIncluded: boolean,
 ): boolean {
     switch (xorNode.kind) {
-        case PQP.Parser.XorNodeKind.Ast:
+        case XorNodeKind.Ast:
             return isInAst(position, xorNode.node, isLowerBoundIncluded, isUpperBoundIncluded);
 
-        case PQP.Parser.XorNodeKind.Context:
+        case XorNodeKind.Context:
             return isInContext(nodeIdMapCollection, position, xorNode.node, isLowerBoundIncluded, isUpperBoundIncluded);
 
         default:
-            throw PQP.Assert.isNever(xorNode);
+            throw Assert.isNever(xorNode);
     }
 }
 
-export function isOnXorStart(position: Position, xorNode: PQP.Parser.TXorNode): boolean {
+export function isOnXorStart(position: Position, xorNode: TXorNode): boolean {
     switch (xorNode.kind) {
-        case PQP.Parser.XorNodeKind.Ast:
+        case XorNodeKind.Ast:
             return isOnAstStart(position, xorNode.node);
 
-        case PQP.Parser.XorNodeKind.Context:
+        case XorNodeKind.Context:
             return isOnContextStart(position, xorNode.node);
 
         default:
-            throw PQP.Assert.isNever(xorNode);
+            throw Assert.isNever(xorNode);
     }
 }
 
-export function isOnXorEnd(
-    nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
-    position: Position,
-    xorNode: PQP.Parser.TXorNode,
-): boolean {
+export function isOnXorEnd(nodeIdMapCollection: NodeIdMap.Collection, position: Position, xorNode: TXorNode): boolean {
     switch (xorNode.kind) {
-        case PQP.Parser.XorNodeKind.Ast:
+        case XorNodeKind.Ast:
             return isOnAstEnd(position, xorNode.node);
 
-        case PQP.Parser.XorNodeKind.Context:
+        case XorNodeKind.Context:
             return isOnContextEnd(nodeIdMapCollection, position, xorNode.node);
 
         default:
-            throw PQP.Assert.isNever(xorNode);
+            throw Assert.isNever(xorNode);
     }
 }
 
 export function isAfterXor(
-    nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
+    nodeIdMapCollection: NodeIdMap.Collection,
     position: Position,
-    xorNode: PQP.Parser.TXorNode,
+    xorNode: TXorNode,
     isBoundIncluded: boolean,
 ): boolean {
     switch (xorNode.kind) {
-        case PQP.Parser.XorNodeKind.Ast:
+        case XorNodeKind.Ast:
             return isAfterAst(position, xorNode.node, isBoundIncluded);
 
-        case PQP.Parser.XorNodeKind.Context:
+        case XorNodeKind.Context:
             return isAfterContext(nodeIdMapCollection, position, xorNode.node, isBoundIncluded);
 
         default:
-            throw PQP.Assert.isNever(xorNode);
+            throw Assert.isNever(xorNode);
     }
 }
 
@@ -149,7 +147,7 @@ export function isBeforeContext(
 }
 
 export function isInContext(
-    nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
+    nodeIdMapCollection: NodeIdMap.Collection,
     position: Position,
     contextNode: PQP.Parser.ParseContext.TNode,
     isLowerBoundIncluded: boolean,
@@ -168,14 +166,11 @@ export function isOnContextStart(position: Position, contextNode: PQP.Parser.Par
 }
 
 export function isOnContextEnd(
-    nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
+    nodeIdMapCollection: NodeIdMap.Collection,
     position: Position,
     contextNode: PQP.Parser.ParseContext.TNode,
 ): boolean {
-    const maybeLeaf: PQP.Language.Ast.TNode | undefined = PQP.Parser.NodeIdMapUtils.maybeRightMostLeaf(
-        nodeIdMapCollection,
-        contextNode.id,
-    );
+    const maybeLeaf: Ast.TNode | undefined = NodeIdMapUtils.maybeRightMostLeaf(nodeIdMapCollection, contextNode.id);
     if (maybeLeaf === undefined) {
         return false;
     }
@@ -184,15 +179,12 @@ export function isOnContextEnd(
 }
 
 export function isAfterContext(
-    nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
+    nodeIdMapCollection: NodeIdMap.Collection,
     position: Position,
     contextNode: PQP.Parser.ParseContext.TNode,
     isBoundIncluded: boolean,
 ): boolean {
-    const maybeLeaf: PQP.Language.Ast.TNode | undefined = PQP.Parser.NodeIdMapUtils.maybeRightMostLeaf(
-        nodeIdMapCollection,
-        contextNode.id,
-    );
+    const maybeLeaf: Ast.TNode | undefined = NodeIdMapUtils.maybeRightMostLeaf(nodeIdMapCollection, contextNode.id);
     if (maybeLeaf === undefined) {
         // We're assuming position is a valid range for the document.
         // Therefore if the context node didn't have a token (caused by EOF) we can make this assumption.
@@ -202,18 +194,18 @@ export function isAfterContext(
             return isAfterTokenPosition(position, contextNode.maybeTokenStart.positionEnd, isBoundIncluded);
         }
     }
-    const leaf: PQP.Language.Ast.TNode = maybeLeaf;
+    const leaf: Ast.TNode = maybeLeaf;
 
     return isAfterAst(position, leaf, isBoundIncluded);
 }
 
-export function isBeforeAst(position: Position, astNode: PQP.Language.Ast.TNode, isBoundIncluded: boolean): boolean {
+export function isBeforeAst(position: Position, astNode: Ast.TNode, isBoundIncluded: boolean): boolean {
     return isBeforeTokenPosition(position, astNode.tokenRange.positionStart, isBoundIncluded);
 }
 
 export function isInAst(
     position: Position,
-    astNode: PQP.Language.Ast.TNode,
+    astNode: Ast.TNode,
     isLowerBoundIncluded: boolean,
     isHigherBoundIncluded: boolean,
 ): boolean {
@@ -222,15 +214,15 @@ export function isInAst(
     );
 }
 
-export function isOnAstStart(position: Position, astNode: PQP.Language.Ast.TNode): boolean {
+export function isOnAstStart(position: Position, astNode: Ast.TNode): boolean {
     return isOnTokenPosition(position, astNode.tokenRange.positionStart);
 }
 
-export function isOnAstEnd(position: Position, astNode: PQP.Language.Ast.TNode): boolean {
+export function isOnAstEnd(position: Position, astNode: Ast.TNode): boolean {
     return isOnTokenPosition(position, astNode.tokenRange.positionEnd);
 }
 
-export function isAfterAst(position: Position, astNode: PQP.Language.Ast.TNode, isBoundIncluded: boolean): boolean {
+export function isAfterAst(position: Position, astNode: Ast.TNode, isBoundIncluded: boolean): boolean {
     return isAfterTokenPosition(position, astNode.tokenRange.positionEnd, isBoundIncluded);
 }
 

--- a/src/powerquery-language-services/positionUtils.ts
+++ b/src/powerquery-language-services/positionUtils.ts
@@ -136,7 +136,7 @@ export function isAfterXor(
 
 export function isBeforeContext(
     position: Position,
-    contextNode: PQP.Parser.ParseContext.Node,
+    contextNode: PQP.Parser.ParseContext.TNode,
     isBoundIncluded: boolean,
 ): boolean {
     const maybeTokenStart: PQP.Language.Token.Token | undefined = contextNode.maybeTokenStart;
@@ -151,7 +151,7 @@ export function isBeforeContext(
 export function isInContext(
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
     position: Position,
-    contextNode: PQP.Parser.ParseContext.Node,
+    contextNode: PQP.Parser.ParseContext.TNode,
     isLowerBoundIncluded: boolean,
     isHigherBoundIncluded: boolean,
 ): boolean {
@@ -161,7 +161,7 @@ export function isInContext(
     );
 }
 
-export function isOnContextStart(position: Position, contextNode: PQP.Parser.ParseContext.Node): boolean {
+export function isOnContextStart(position: Position, contextNode: PQP.Parser.ParseContext.TNode): boolean {
     return contextNode.maybeTokenStart !== undefined
         ? isOnTokenPosition(position, contextNode.maybeTokenStart.positionStart)
         : false;
@@ -170,7 +170,7 @@ export function isOnContextStart(position: Position, contextNode: PQP.Parser.Par
 export function isOnContextEnd(
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
     position: Position,
-    contextNode: PQP.Parser.ParseContext.Node,
+    contextNode: PQP.Parser.ParseContext.TNode,
 ): boolean {
     const maybeLeaf: PQP.Language.Ast.TNode | undefined = PQP.Parser.NodeIdMapUtils.maybeRightMostLeaf(
         nodeIdMapCollection,
@@ -186,7 +186,7 @@ export function isOnContextEnd(
 export function isAfterContext(
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
     position: Position,
-    contextNode: PQP.Parser.ParseContext.Node,
+    contextNode: PQP.Parser.ParseContext.TNode,
     isBoundIncluded: boolean,
 ): boolean {
     const maybeLeaf: PQP.Language.Ast.TNode | undefined = PQP.Parser.NodeIdMapUtils.maybeRightMostLeaf(

--- a/src/powerquery-language-services/providers/commonTypes.ts
+++ b/src/powerquery-language-services/providers/commonTypes.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
+import type { Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 import type { Hover, Range, SignatureHelp } from "vscode-languageserver-types";
 
 import type { AutocompleteItem } from "../inspection/autocomplete/autocompleteItem";
@@ -36,7 +36,7 @@ export interface SignatureProviderContext extends ProviderContext {
     readonly argumentOrdinal: number | undefined;
     readonly functionName: string | undefined;
     readonly isNameInLocalScope: boolean;
-    readonly functionType: PQP.Language.Type.TPowerQueryType;
+    readonly functionType: Type.TPowerQueryType;
 }
 
 export interface ISymbolProvider extends AutocompleteItemProvider, HoverProvider, SignatureHelpProvider, ILibrary {}

--- a/src/powerquery-language-services/providers/languageCompletionItemProvider.ts
+++ b/src/powerquery-language-services/providers/languageCompletionItemProvider.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
+import { ResultUtils } from "@microsoft/powerquery-parser";
+import { KeywordKind } from "@microsoft/powerquery-parser/lib/powerquery-parser/language/keyword/keyword";
 
 import { Inspection } from "..";
 import { AutocompleteItem } from "../inspection/autocomplete/autocompleteItem";
@@ -12,17 +13,17 @@ export class LanguageAutocompleteItemProvider implements AutocompleteItemProvide
     // Power Query defines constructor functions (ex. #table()) as keywords, but we want
     // them to be treated like library functions instead.
     private static readonly ExcludedKeywords: ReadonlyArray<string> = [
-        PQP.Language.Keyword.KeywordKind.HashBinary,
-        PQP.Language.Keyword.KeywordKind.HashDate,
-        PQP.Language.Keyword.KeywordKind.HashDateTime,
-        PQP.Language.Keyword.KeywordKind.HashDateTimeZone,
-        PQP.Language.Keyword.KeywordKind.HashDuration,
-        PQP.Language.Keyword.KeywordKind.HashInfinity,
-        PQP.Language.Keyword.KeywordKind.HashNan,
-        PQP.Language.Keyword.KeywordKind.HashSections,
-        PQP.Language.Keyword.KeywordKind.HashShared,
-        PQP.Language.Keyword.KeywordKind.HashTable,
-        PQP.Language.Keyword.KeywordKind.HashTime,
+        KeywordKind.HashBinary,
+        KeywordKind.HashDate,
+        KeywordKind.HashDateTime,
+        KeywordKind.HashDateTimeZone,
+        KeywordKind.HashDuration,
+        KeywordKind.HashInfinity,
+        KeywordKind.HashNan,
+        KeywordKind.HashSections,
+        KeywordKind.HashShared,
+        KeywordKind.HashTable,
+        KeywordKind.HashTime,
     ];
 
     constructor(private readonly maybeTriedInspection: WorkspaceCache.InspectionCacheItem) {}
@@ -46,7 +47,7 @@ export class LanguageAutocompleteItemProvider implements AutocompleteItemProvide
     private getKeywords(
         triedKeywordAutocomplete: Inspection.TriedAutocompleteKeyword,
     ): ReadonlyArray<AutocompleteItem> {
-        if (PQP.ResultUtils.isError(triedKeywordAutocomplete)) {
+        if (ResultUtils.isError(triedKeywordAutocomplete)) {
             return [];
         }
 
@@ -59,7 +60,7 @@ export class LanguageAutocompleteItemProvider implements AutocompleteItemProvide
     private getLanguageConstants(
         triedLanguageConstantAutocomplete: Inspection.TriedAutocompleteLanguageConstant,
     ): ReadonlyArray<AutocompleteItem> {
-        return PQP.ResultUtils.isOk(triedLanguageConstantAutocomplete) && triedLanguageConstantAutocomplete.value
+        return ResultUtils.isOk(triedLanguageConstantAutocomplete) && triedLanguageConstantAutocomplete.value
             ? [triedLanguageConstantAutocomplete.value]
             : [];
     }
@@ -67,7 +68,7 @@ export class LanguageAutocompleteItemProvider implements AutocompleteItemProvide
     private getPrimitiveTypes(
         triedPrimitiveTypeAutocomplete: Inspection.TriedAutocompletePrimitiveType,
     ): ReadonlyArray<AutocompleteItem> {
-        return PQP.ResultUtils.isOk(triedPrimitiveTypeAutocomplete) && triedPrimitiveTypeAutocomplete.value
+        return ResultUtils.isOk(triedPrimitiveTypeAutocomplete) && triedPrimitiveTypeAutocomplete.value
             ? triedPrimitiveTypeAutocomplete.value
             : [];
     }

--- a/src/powerquery-language-services/providers/librarySymbolProvider.ts
+++ b/src/powerquery-language-services/providers/librarySymbolProvider.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
-
+import { Assert } from "@microsoft/powerquery-parser";
+import { TypeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 import { Hover, MarkupKind, SignatureHelp, SignatureInformation } from "vscode-languageserver-types";
 
 import { Inspection } from "..";
@@ -58,7 +58,7 @@ export class LibrarySymbolProvider implements ISymbolProvider {
         const definition: Library.TLibraryDefinition = maybeDefinition;
 
         const definitionText: string = LibrarySymbolProvider.getDefinitionKindText(definition.kind);
-        const definitionTypeText: string = PQP.Language.TypeUtils.nameOf(definition.asPowerQueryType);
+        const definitionTypeText: string = TypeUtils.nameOf(definition.asPowerQueryType);
 
         return {
             contents: {
@@ -102,7 +102,7 @@ export class LibrarySymbolProvider implements ISymbolProvider {
                 return "library type";
 
             default:
-                throw PQP.Assert.isNever(kind);
+                throw Assert.isNever(kind);
         }
     }
 
@@ -112,6 +112,6 @@ export class LibrarySymbolProvider implements ISymbolProvider {
             this.signatureInformationByLabel.set(key, LibraryUtils.createSignatureInformation(definition));
         }
 
-        return PQP.Assert.asDefined(this.signatureInformationByLabel.get(key));
+        return Assert.asDefined(this.signatureInformationByLabel.get(key));
     }
 }

--- a/src/powerquery-language-services/providers/localDocumentSymbolProvider.ts
+++ b/src/powerquery-language-services/providers/localDocumentSymbolProvider.ts
@@ -138,13 +138,10 @@ export class LocalDocumentSymbolProvider implements ISymbolProvider {
             return undefined;
         }
 
-        const maybeExpression:
-            | PQP.Parser.TXorNode
-            | undefined = PQP.Parser.NodeIdMapUtils.maybeChildXorByAttributeIndex(
+        const maybeExpression: PQP.Parser.TXorNode | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChild(
             parseState.contextState.nodeIdMapCollection,
             maybeIdentifierPairedExpression.node.id,
             2,
-            undefined,
         );
 
         // We're on an identifier in some other context which we don't support.

--- a/src/powerquery-language-services/providers/localDocumentSymbolProvider.ts
+++ b/src/powerquery-language-services/providers/localDocumentSymbolProvider.ts
@@ -127,7 +127,7 @@ export class LocalDocumentSymbolProvider implements ISymbolProvider {
 
         const maybeIdentifierPairedExpression:
             | PQP.Parser.TXorNode
-            | undefined = PQP.Parser.AncestryUtils.maybeNthXor(activeNode.ancestry, 1, [
+            | undefined = PQP.Parser.AncestryUtils.maybeNthXorChecked(activeNode.ancestry, 1, [
             PQP.Language.Ast.NodeKind.GeneralizedIdentifierPairedAnyLiteral,
             PQP.Language.Ast.NodeKind.GeneralizedIdentifierPairedExpression,
             PQP.Language.Ast.NodeKind.IdentifierPairedExpression,

--- a/src/powerquery-language-services/providers/localDocumentSymbolProvider.ts
+++ b/src/powerquery-language-services/providers/localDocumentSymbolProvider.ts
@@ -1,8 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
-
+import { ResultUtils } from "@microsoft/powerquery-parser";
+import { Ast, Type, TypeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import {
+    AncestryUtils,
+    NodeIdMapUtils,
+    ParseState,
+    TXorNode,
+} from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 import { Hover, MarkupKind, SignatureHelp } from "vscode-languageserver-types";
 
 import * as InspectionUtils from "../inspectionUtils";
@@ -68,7 +74,7 @@ export class LocalDocumentSymbolProvider implements ISymbolProvider {
             return maybeHover;
         }
 
-        if (!PQP.ResultUtils.isOk(inspection.triedNodeScope) || !PQP.ResultUtils.isOk(inspection.triedScopeType)) {
+        if (!ResultUtils.isOk(inspection.triedNodeScope) || !ResultUtils.isOk(inspection.triedScopeType)) {
             // tslint:disable-next-line: no-null-keyword
             return null;
         }
@@ -112,25 +118,24 @@ export class LocalDocumentSymbolProvider implements ISymbolProvider {
         inspectionTask: WorkspaceCache.InspectionTask,
         activeNode: Inspection.ActiveNode,
     ): Promise<Hover | undefined> {
-        const parseState: PQP.Parser.ParseState = inspectionTask.parseState;
-        const ancestry: ReadonlyArray<PQP.Parser.TXorNode> = activeNode.ancestry;
-        const maybeLeafKind: PQP.Language.Ast.NodeKind | undefined = ancestry[0]?.node.kind;
+        const parseState: ParseState = inspectionTask.parseState;
+        const ancestry: ReadonlyArray<TXorNode> = activeNode.ancestry;
+        const maybeLeafKind: Ast.NodeKind | undefined = ancestry[0]?.node.kind;
 
-        const isValidLeafNodeKind: boolean = [
-            PQP.Language.Ast.NodeKind.GeneralizedIdentifier,
-            PQP.Language.Ast.NodeKind.Identifier,
-        ].includes(maybeLeafKind);
+        const isValidLeafNodeKind: boolean = [Ast.NodeKind.GeneralizedIdentifier, Ast.NodeKind.Identifier].includes(
+            maybeLeafKind,
+        );
 
         if (!isValidLeafNodeKind) {
             return undefined;
         }
 
         const maybeIdentifierPairedExpression:
-            | PQP.Parser.TXorNode
-            | undefined = PQP.Parser.AncestryUtils.maybeNthXorChecked(activeNode.ancestry, 1, [
-            PQP.Language.Ast.NodeKind.GeneralizedIdentifierPairedAnyLiteral,
-            PQP.Language.Ast.NodeKind.GeneralizedIdentifierPairedExpression,
-            PQP.Language.Ast.NodeKind.IdentifierPairedExpression,
+            | TXorNode
+            | undefined = AncestryUtils.maybeNthXorChecked(activeNode.ancestry, 1, [
+            Ast.NodeKind.GeneralizedIdentifierPairedAnyLiteral,
+            Ast.NodeKind.GeneralizedIdentifierPairedExpression,
+            Ast.NodeKind.IdentifierPairedExpression,
         ]);
 
         // We're on an identifier in some other context which we don't support.
@@ -138,7 +143,7 @@ export class LocalDocumentSymbolProvider implements ISymbolProvider {
             return undefined;
         }
 
-        const maybeExpression: PQP.Parser.TXorNode | undefined = PQP.Parser.NodeIdMapUtils.maybeNthChild(
+        const maybeExpression: TXorNode | undefined = NodeIdMapUtils.maybeNthChild(
             parseState.contextState.nodeIdMapCollection,
             maybeIdentifierPairedExpression.node.id,
             2,
@@ -157,31 +162,30 @@ export class LocalDocumentSymbolProvider implements ISymbolProvider {
         );
 
         // TODO handle error
-        if (PQP.ResultUtils.isError(triedExpressionType)) {
+        if (ResultUtils.isError(triedExpressionType)) {
             return undefined;
         }
 
         let scopeItemText: string = "unknown";
         // If it's a SectionMember
-        const maybeThirdNodeKind: PQP.Language.Ast.NodeKind = ancestry[2]?.node.kind;
-        if (maybeThirdNodeKind === PQP.Language.Ast.NodeKind.SectionMember) {
+        const maybeThirdNodeKind: Ast.NodeKind = ancestry[2]?.node.kind;
+        if (maybeThirdNodeKind === Ast.NodeKind.SectionMember) {
             scopeItemText = InspectionUtils.getScopeItemKindText(Inspection.ScopeItemKind.SectionMember);
         }
 
         // Else if it's RecordExpression or RecordLiteral
-        const maybeFifthNodeKind: PQP.Language.Ast.NodeKind = ancestry[4]?.node.kind;
-        const isRecordNodeKind: boolean = [
-            PQP.Language.Ast.NodeKind.RecordExpression,
-            PQP.Language.Ast.NodeKind.RecordLiteral,
-        ].includes(maybeFifthNodeKind);
+        const maybeFifthNodeKind: Ast.NodeKind = ancestry[4]?.node.kind;
+        const isRecordNodeKind: boolean = [Ast.NodeKind.RecordExpression, Ast.NodeKind.RecordLiteral].includes(
+            maybeFifthNodeKind,
+        );
 
         if (isRecordNodeKind) {
             scopeItemText = InspectionUtils.getScopeItemKindText(Inspection.ScopeItemKind.RecordField);
-        } else if (maybeFifthNodeKind === PQP.Language.Ast.NodeKind.LetExpression) {
+        } else if (maybeFifthNodeKind === Ast.NodeKind.LetExpression) {
             scopeItemText = InspectionUtils.getScopeItemKindText(Inspection.ScopeItemKind.LetVariable);
         }
 
-        const nameOfExpressionType: string = PQP.Language.TypeUtils.nameOf(triedExpressionType.value);
+        const nameOfExpressionType: string = TypeUtils.nameOf(triedExpressionType.value);
 
         return {
             contents: {
@@ -206,9 +210,9 @@ export class LocalDocumentSymbolProvider implements ISymbolProvider {
 
         const scopeItemText: string = InspectionUtils.getScopeItemKindText(maybeScopeItem.kind);
 
-        const maybeScopeItemType: PQP.Language.Type.TPowerQueryType | undefined = scopeType.get(identifierLiteral);
+        const maybeScopeItemType: Type.TPowerQueryType | undefined = scopeType.get(identifierLiteral);
         const scopeItemTypeText: string =
-            maybeScopeItemType !== undefined ? PQP.Language.TypeUtils.nameOf(maybeScopeItemType) : "unknown";
+            maybeScopeItemType !== undefined ? TypeUtils.nameOf(maybeScopeItemType) : "unknown";
 
         return {
             contents: {
@@ -233,7 +237,7 @@ export class LocalDocumentSymbolProvider implements ISymbolProvider {
     private getMaybeInspectionInvokeExpression(): Inspection.InvokeExpression | undefined {
         const maybeInspection: Inspection.Inspection | undefined = this.getMaybeInspection();
 
-        return maybeInspection !== undefined && PQP.ResultUtils.isOk(maybeInspection.triedCurrentInvokeExpression)
+        return maybeInspection !== undefined && ResultUtils.isOk(maybeInspection.triedCurrentInvokeExpression)
             ? maybeInspection.triedCurrentInvokeExpression.value
             : undefined;
     }
@@ -243,7 +247,7 @@ export class LocalDocumentSymbolProvider implements ISymbolProvider {
     ): ReadonlyArray<Inspection.AutocompleteItem> {
         const triedFieldAccess: Inspection.TriedAutocompleteFieldAccess = inspection.autocomplete.triedFieldAccess;
 
-        return PQP.ResultUtils.isOk(triedFieldAccess) && triedFieldAccess.value !== undefined
+        return ResultUtils.isOk(triedFieldAccess) && triedFieldAccess.value !== undefined
             ? triedFieldAccess.value.autocompleteItems
             : [];
     }

--- a/src/powerquery-language-services/validate/validateDuplicateIdentifiers.ts
+++ b/src/powerquery-language-services/validate/validateDuplicateIdentifiers.ts
@@ -3,10 +3,17 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { Ast } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import {
+    NodeIdMap,
+    NodeIdMapIterator,
+    NodeIdMapUtils,
+    TXorNode,
+} from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
+import { TextDocument } from "vscode-languageserver-textdocument";
 import type { Diagnostic, DiagnosticRelatedInformation, DocumentUri } from "vscode-languageserver-types";
 import { DiagnosticSeverity } from "vscode-languageserver-types";
 
-import { TextDocument } from "vscode-languageserver-textdocument";
 import { PositionUtils } from "..";
 import { DiagnosticErrorCode } from "../diagnosticErrorCode";
 import { Localization, LocalizationUtils } from "../localization";
@@ -26,7 +33,7 @@ export function validateDuplicateIdentifiers(
         validationSettings,
     );
 
-    let maybeNodeIdMapCollection: PQP.Parser.NodeIdMap.Collection | undefined;
+    let maybeNodeIdMapCollection: NodeIdMap.Collection | undefined;
     if (PQP.TaskUtils.isParseStageOk(cacheItem)) {
         maybeNodeIdMapCollection = cacheItem.nodeIdMapCollection;
     } else if (PQP.TaskUtils.isParseStageParseError(cacheItem)) {
@@ -37,7 +44,7 @@ export function validateDuplicateIdentifiers(
         return [];
     }
     const documentUri: string = textDocument.uri;
-    const nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection = maybeNodeIdMapCollection;
+    const nodeIdMapCollection: NodeIdMap.Collection = maybeNodeIdMapCollection;
 
     return [
         ...validateDuplicateIdentifiersForLetExpresion(documentUri, nodeIdMapCollection, validationSettings),
@@ -48,56 +55,54 @@ export function validateDuplicateIdentifiers(
 
 function validateDuplicateIdentifiersForLetExpresion(
     documentUri: DocumentUri,
-    nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
+    nodeIdMapCollection: NodeIdMap.Collection,
     validationSettings: ValidationSettings,
 ): ReadonlyArray<Diagnostic> {
     const letIds: ReadonlyArray<number> = [
-        ...(nodeIdMapCollection.idsByNodeKind.get(PQP.Language.Ast.NodeKind.LetExpression) ?? []),
+        ...(nodeIdMapCollection.idsByNodeKind.get(Ast.NodeKind.LetExpression) ?? []),
     ];
 
     return validateDuplicateIdentifiersForKeyValuePair(
         documentUri,
         nodeIdMapCollection,
         letIds,
-        PQP.Parser.NodeIdMapIterator.iterLetExpression,
+        NodeIdMapIterator.iterLetExpression,
         validationSettings,
     );
 }
 
 function validateDuplicateIdentifiersForRecord(
     documentUri: DocumentUri,
-    nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
+    nodeIdMapCollection: NodeIdMap.Collection,
     validationSettings: ValidationSettings,
 ): ReadonlyArray<Diagnostic> {
     const recordIds: ReadonlyArray<number> = [
-        ...(nodeIdMapCollection.idsByNodeKind.get(PQP.Language.Ast.NodeKind.RecordExpression) ?? []),
-        ...(nodeIdMapCollection.idsByNodeKind.get(PQP.Language.Ast.NodeKind.RecordLiteral) ?? []),
-        ...(nodeIdMapCollection.idsByNodeKind.get(PQP.Language.Ast.NodeKind.RecordType) ?? []),
+        ...(nodeIdMapCollection.idsByNodeKind.get(Ast.NodeKind.RecordExpression) ?? []),
+        ...(nodeIdMapCollection.idsByNodeKind.get(Ast.NodeKind.RecordLiteral) ?? []),
+        ...(nodeIdMapCollection.idsByNodeKind.get(Ast.NodeKind.RecordType) ?? []),
     ];
 
     return validateDuplicateIdentifiersForKeyValuePair(
         documentUri,
         nodeIdMapCollection,
         recordIds,
-        PQP.Parser.NodeIdMapIterator.iterRecord,
+        NodeIdMapIterator.iterRecord,
         validationSettings,
     );
 }
 
 function validateDuplicateIdentifiersForSection(
     documentUri: DocumentUri,
-    nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
+    nodeIdMapCollection: NodeIdMap.Collection,
     validationSettings: ValidationSettings,
 ): ReadonlyArray<Diagnostic> {
-    const recordIds: ReadonlyArray<number> = [
-        ...(nodeIdMapCollection.idsByNodeKind.get(PQP.Language.Ast.NodeKind.Section) ?? []),
-    ];
+    const recordIds: ReadonlyArray<number> = [...(nodeIdMapCollection.idsByNodeKind.get(Ast.NodeKind.Section) ?? [])];
 
     return validateDuplicateIdentifiersForKeyValuePair(
         documentUri,
         nodeIdMapCollection,
         recordIds,
-        PQP.Parser.NodeIdMapIterator.iterSection,
+        NodeIdMapIterator.iterSection,
         validationSettings,
     );
 }
@@ -108,12 +113,12 @@ function validateDuplicateIdentifiersForSection(
 //          ...
 function validateDuplicateIdentifiersForKeyValuePair(
     documentUri: DocumentUri,
-    nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
+    nodeIdMapCollection: NodeIdMap.Collection,
     nodeIds: ReadonlyArray<number>,
     iterNodeFn: (
-        nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
-        node: PQP.Parser.TXorNode,
-    ) => ReadonlyArray<PQP.Parser.NodeIdMapIterator.TKeyValuePair>,
+        nodeIdMapCollection: NodeIdMap.Collection,
+        node: TXorNode,
+    ) => ReadonlyArray<NodeIdMapIterator.TKeyValuePair>,
     validationSettings: ValidationSettings,
 ): ReadonlyArray<Diagnostic> {
     if (!nodeIds.length) {
@@ -123,18 +128,16 @@ function validateDuplicateIdentifiersForKeyValuePair(
     const result: Diagnostic[] = [];
 
     for (const nodeId of nodeIds) {
-        const node: PQP.Parser.TXorNode = PQP.Parser.NodeIdMapUtils.assertGetXor(nodeIdMapCollection, nodeId);
-        const duplicateFieldsByKey: Map<string, PQP.Parser.NodeIdMapIterator.TKeyValuePair[]> = new Map();
-        const knownFieldByKey: Map<string, PQP.Parser.NodeIdMapIterator.TKeyValuePair> = new Map();
+        const node: TXorNode = NodeIdMapUtils.assertGetXor(nodeIdMapCollection, nodeId);
+        const duplicateFieldsByKey: Map<string, NodeIdMapIterator.TKeyValuePair[]> = new Map();
+        const knownFieldByKey: Map<string, NodeIdMapIterator.TKeyValuePair> = new Map();
 
         for (const field of iterNodeFn(nodeIdMapCollection, node)) {
             const keyLiteral: string = field.normalizedKeyLiteral;
-            const maybeDuplicateFields:
-                | PQP.Parser.NodeIdMapIterator.TKeyValuePair[]
-                | undefined = duplicateFieldsByKey.get(keyLiteral);
-            const maybeKnownField: PQP.Parser.NodeIdMapIterator.TKeyValuePair | undefined = knownFieldByKey.get(
+            const maybeDuplicateFields: NodeIdMapIterator.TKeyValuePair[] | undefined = duplicateFieldsByKey.get(
                 keyLiteral,
             );
+            const maybeKnownField: NodeIdMapIterator.TKeyValuePair | undefined = knownFieldByKey.get(keyLiteral);
 
             if (maybeDuplicateFields) {
                 maybeDuplicateFields.push(field);
@@ -148,7 +151,7 @@ function validateDuplicateIdentifiersForKeyValuePair(
         for (const duplicates of duplicateFieldsByKey.values()) {
             const numFields: number = duplicates.length;
             const asRelatedInformation: DiagnosticRelatedInformation[] = duplicates.map(
-                (keyValuePair: PQP.Parser.NodeIdMapIterator.TKeyValuePair) => {
+                (keyValuePair: NodeIdMapIterator.TKeyValuePair) => {
                     return {
                         location: {
                             uri: documentUri,
@@ -160,7 +163,7 @@ function validateDuplicateIdentifiersForKeyValuePair(
             );
 
             for (let index: number = 0; index < numFields; index += 1) {
-                const duplicate: PQP.Parser.NodeIdMapIterator.TKeyValuePair = duplicates[index];
+                const duplicate: NodeIdMapIterator.TKeyValuePair = duplicates[index];
                 // Grab all DiagnosticRelatedInformation for a given key besides the one we're iterating over.
                 const relatedInformation: DiagnosticRelatedInformation[] = asRelatedInformation.filter(
                     (_: DiagnosticRelatedInformation, relatedIndex: number) => index !== relatedIndex,
@@ -175,7 +178,7 @@ function validateDuplicateIdentifiersForKeyValuePair(
 }
 
 function createDuplicateIdentifierDiagnostic(
-    keyValuePair: PQP.Parser.NodeIdMapIterator.TKeyValuePair,
+    keyValuePair: NodeIdMapIterator.TKeyValuePair,
     relatedInformation: DiagnosticRelatedInformation[],
     validationSettings: ValidationSettings,
 ): Diagnostic {
@@ -190,7 +193,7 @@ function createDuplicateIdentifierDiagnostic(
 }
 
 function createDuplicateIdentifierDiagnosticMessage(
-    keyValuePair: PQP.Parser.NodeIdMapIterator.TKeyValuePair,
+    keyValuePair: NodeIdMapIterator.TKeyValuePair,
     validationSettings: ValidationSettings,
 ): string {
     return Localization.error_validation_duplicate_identifier(

--- a/src/powerquery-language-services/validate/validateDuplicateIdentifiers.ts
+++ b/src/powerquery-language-services/validate/validateDuplicateIdentifiers.ts
@@ -7,11 +7,11 @@ import type { Diagnostic, DiagnosticRelatedInformation, DocumentUri } from "vsco
 import { DiagnosticSeverity } from "vscode-languageserver-types";
 
 import { TextDocument } from "vscode-languageserver-textdocument";
+import { PositionUtils } from "..";
 import { DiagnosticErrorCode } from "../diagnosticErrorCode";
 import { Localization, LocalizationUtils } from "../localization";
 import { WorkspaceCache, WorkspaceCacheUtils } from "../workspaceCache";
 import { ValidationSettings } from "./validationSettings";
-import { PositionUtils } from "..";
 
 export function validateDuplicateIdentifiers(
     textDocument: TextDocument,

--- a/src/powerquery-language-services/validate/validateFunctionExpression.ts
+++ b/src/powerquery-language-services/validate/validateFunctionExpression.ts
@@ -4,7 +4,6 @@
 import { Assert, ResultUtils } from "@microsoft/powerquery-parser";
 import { Ast, Type, TypeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 import { NodeIdMap, NodeIdMapUtils, TXorNode } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
-
 import type { Range } from "vscode-languageserver-textdocument";
 import { Diagnostic, DiagnosticSeverity } from "vscode-languageserver-types";
 

--- a/src/powerquery-language-services/validate/validateFunctionExpression.ts
+++ b/src/powerquery-language-services/validate/validateFunctionExpression.ts
@@ -1,0 +1,180 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as PQP from "@microsoft/powerquery-parser";
+
+import type { Range } from "vscode-languageserver-textdocument";
+import { Diagnostic, DiagnosticSeverity } from "vscode-languageserver-types";
+
+import { Inspection, PositionUtils } from "..";
+import { DiagnosticErrorCode } from "../diagnosticErrorCode";
+import { Localization, LocalizationUtils } from "../localization";
+import { ILocalizationTemplates } from "../localization/templates";
+import { ValidationSettings } from "./validationSettings";
+
+export function validateFunctionExpression(
+    validationSettings: ValidationSettings,
+    nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
+    maybeCache?: Inspection.TypeCache,
+): Diagnostic[] {
+    const maybeInvokeExpressionIds: Set<number> | undefined = nodeIdMapCollection.idsByNodeKind.get(
+        PQP.Language.Ast.NodeKind.FunctionExpression,
+    );
+    if (maybeInvokeExpressionIds === undefined) {
+        return [];
+    }
+
+    PQP.Parser.NodeIdMapIterator.
+
+    const result: Diagnostic[] = [];
+    for (const nodeId of maybeInvokeExpressionIds) {
+        const triedInvokeExpression: Inspection.TriedInvokeExpression = Inspection.tryInvokeExpression(
+            validationSettings,
+            nodeIdMapCollection,
+            nodeId,
+            maybeCache,
+        );
+        if (PQP.ResultUtils.isError(triedInvokeExpression)) {
+            throw triedInvokeExpression;
+        }
+
+        result.push(
+            ...invokeExpressionToDiagnostics(validationSettings, nodeIdMapCollection, triedInvokeExpression.value),
+        );
+    }
+
+    return result;
+}
+
+function invokeExpressionToDiagnostics(
+    validationSettings: ValidationSettings,
+    nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
+    inspected: Inspection.InvokeExpression,
+): Diagnostic[] {
+    const result: Diagnostic[] = [];
+
+    if (inspected.maybeArguments !== undefined) {
+        const invokeExpressionArguments: Inspection.InvokeExpressionArguments = inspected.maybeArguments;
+        const givenArguments: ReadonlyArray<PQP.Parser.TXorNode> = inspected.maybeArguments.givenArguments;
+        const invokeExpressionRange: Range = PQP.Assert.asDefined(
+            PositionUtils.createRangeFromXorNode(nodeIdMapCollection, inspected.invokeExpressionXorNode),
+            "expected at least one leaf node under InvokeExpression",
+        );
+
+        const maybeFunctionName: string | undefined = PQP.Parser.NodeIdMapUtils.maybeInvokeExpressionIdentifierLiteral(
+            nodeIdMapCollection,
+            inspected.invokeExpressionXorNode.node.id,
+        );
+
+        for (const [argIndex, mismatch] of invokeExpressionArguments.typeChecked.invalid.entries()) {
+            const maybeGivenArgumentRange: Range | undefined = PositionUtils.createRangeFromXorNode(
+                nodeIdMapCollection,
+                givenArguments[argIndex],
+            );
+
+            result.push(
+                createDiagnosticForArgumentMismatch(
+                    validationSettings,
+                    mismatch,
+                    maybeFunctionName,
+                    invokeExpressionRange,
+                    maybeGivenArgumentRange,
+                ),
+            );
+        }
+
+        const numGivenArguments: number = invokeExpressionArguments.givenArguments.length;
+        if (
+            numGivenArguments < invokeExpressionArguments.numMinExpectedArguments ||
+            numGivenArguments > invokeExpressionArguments.numMaxExpectedArguments
+        ) {
+            result.push(
+                createDiagnosticForArgumentNumberMismatch(
+                    validationSettings,
+                    invokeExpressionRange,
+                    invokeExpressionArguments.numMinExpectedArguments,
+                    invokeExpressionArguments.numMaxExpectedArguments,
+                    numGivenArguments,
+                ),
+            );
+        }
+    }
+
+    return result;
+}
+
+function createDiagnosticForArgumentNumberMismatch(
+    validationSettings: ValidationSettings,
+    invokeExpressionRange: Range,
+    numMin: number,
+    numMax: number,
+    numGiven: number,
+): Diagnostic {
+    const templates: ILocalizationTemplates = LocalizationUtils.getLocalizationTemplates(validationSettings.locale);
+
+    return {
+        code: DiagnosticErrorCode.InvokeArgumentCountMismatch,
+        message: Localization.error_validation_invokeExpression_numArgs(templates, numMin, numMax, numGiven),
+        range: invokeExpressionRange,
+        severity: DiagnosticSeverity.Error,
+        source: validationSettings.source,
+    };
+}
+
+function createDiagnosticForArgumentMismatch(
+    validationSettings: ValidationSettings,
+    mismatch: PQP.Language.TypeUtils.InvocationMismatch,
+    maybeFunctionName: string | undefined,
+    invokeExpressionRange: Range,
+    maybeGivenArgumentRange: Range | undefined,
+): Diagnostic {
+    let range: Range;
+    let message: string;
+
+    const parameter: PQP.Language.Type.FunctionParameter = mismatch.expected;
+    const argName: string = parameter.nameLiteral;
+    const expected: string = PQP.Language.TypeUtils.nameOfTypeKind(
+        parameter.maybeType ?? PQP.Language.Type.AnyInstance.kind,
+    );
+
+    // An argument containing at least one leaf node was given.
+    if (maybeGivenArgumentRange) {
+        const actual: string = PQP.Language.TypeUtils.nameOfTypeKind(PQP.Assert.asDefined(mismatch.actual).kind);
+
+        range = maybeGivenArgumentRange;
+        message = createTypeMismatchMessage(validationSettings.locale, maybeFunctionName, argName, expected, actual);
+    } else {
+        range = invokeExpressionRange;
+        message = createMissingMandatoryMessage(validationSettings.locale, maybeFunctionName, argName);
+    }
+
+    return {
+        code: DiagnosticErrorCode.InvokeArgumentTypeMismatch,
+        message,
+        range,
+        severity: DiagnosticSeverity.Error,
+        source: validationSettings.source,
+    };
+}
+
+function createMissingMandatoryMessage(locale: string, maybeFunctionName: string | undefined, argName: string): string {
+    const templates: ILocalizationTemplates = LocalizationUtils.getLocalizationTemplates(locale);
+    return Localization.error_validation_invokeExpression_missingMandatory(templates, maybeFunctionName, argName);
+}
+
+function createTypeMismatchMessage(
+    locale: string,
+    maybeFunctionName: string | undefined,
+    argName: string,
+    expected: string,
+    actual: string,
+): string {
+    const templates: ILocalizationTemplates = LocalizationUtils.getLocalizationTemplates(locale);
+    return Localization.error_validation_invokeExpression_typeMismatch(
+        templates,
+        maybeFunctionName,
+        argName,
+        expected,
+        actual,
+    );
+}

--- a/src/powerquery-language-services/validate/validateFunctionExpression.ts
+++ b/src/powerquery-language-services/validate/validateFunctionExpression.ts
@@ -24,8 +24,6 @@ export function validateFunctionExpression(
         return [];
     }
 
-    PQP.Parser.NodeIdMapIterator.
-
     const result: Diagnostic[] = [];
     for (const nodeId of maybeInvokeExpressionIds) {
         const triedInvokeExpression: Inspection.TriedInvokeExpression = Inspection.tryInvokeExpression(

--- a/src/powerquery-language-services/validate/validateInvokeExpression.ts
+++ b/src/powerquery-language-services/validate/validateInvokeExpression.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
-
+import { Assert, ResultUtils } from "@microsoft/powerquery-parser";
+import { Ast, Type, TypeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { NodeIdMap, NodeIdMapUtils, TXorNode } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 import type { Range } from "vscode-languageserver-textdocument";
 import { Diagnostic, DiagnosticSeverity } from "vscode-languageserver-types";
 
@@ -14,11 +15,11 @@ import { ValidationSettings } from "./validationSettings";
 
 export function validateInvokeExpression(
     validationSettings: ValidationSettings,
-    nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
+    nodeIdMapCollection: NodeIdMap.Collection,
     maybeCache?: Inspection.TypeCache,
 ): Diagnostic[] {
     const maybeInvokeExpressionIds: Set<number> | undefined = nodeIdMapCollection.idsByNodeKind.get(
-        PQP.Language.Ast.NodeKind.InvokeExpression,
+        Ast.NodeKind.InvokeExpression,
     );
     if (maybeInvokeExpressionIds === undefined) {
         return [];
@@ -32,7 +33,7 @@ export function validateInvokeExpression(
             nodeId,
             maybeCache,
         );
-        if (PQP.ResultUtils.isError(triedInvokeExpression)) {
+        if (ResultUtils.isError(triedInvokeExpression)) {
             throw triedInvokeExpression;
         }
 
@@ -46,20 +47,20 @@ export function validateInvokeExpression(
 
 function invokeExpressionToDiagnostics(
     validationSettings: ValidationSettings,
-    nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
+    nodeIdMapCollection: NodeIdMap.Collection,
     inspected: Inspection.InvokeExpression,
 ): Diagnostic[] {
     const result: Diagnostic[] = [];
 
     if (inspected.maybeArguments !== undefined) {
         const invokeExpressionArguments: Inspection.InvokeExpressionArguments = inspected.maybeArguments;
-        const givenArguments: ReadonlyArray<PQP.Parser.TXorNode> = inspected.maybeArguments.givenArguments;
-        const invokeExpressionRange: Range = PQP.Assert.asDefined(
+        const givenArguments: ReadonlyArray<TXorNode> = inspected.maybeArguments.givenArguments;
+        const invokeExpressionRange: Range = Assert.asDefined(
             PositionUtils.createRangeFromXorNode(nodeIdMapCollection, inspected.invokeExpressionXorNode),
             "expected at least one leaf node under InvokeExpression",
         );
 
-        const maybeFunctionName: string | undefined = PQP.Parser.NodeIdMapUtils.maybeInvokeExpressionIdentifierLiteral(
+        const maybeFunctionName: string | undefined = NodeIdMapUtils.maybeInvokeExpressionIdentifierLiteral(
             nodeIdMapCollection,
             inspected.invokeExpressionXorNode.node.id,
         );
@@ -121,7 +122,7 @@ function createDiagnosticForArgumentNumberMismatch(
 
 function createDiagnosticForArgumentMismatch(
     validationSettings: ValidationSettings,
-    mismatch: PQP.Language.TypeUtils.InvocationMismatch,
+    mismatch: TypeUtils.InvocationMismatch,
     maybeFunctionName: string | undefined,
     invokeExpressionRange: Range,
     maybeGivenArgumentRange: Range | undefined,
@@ -129,15 +130,13 @@ function createDiagnosticForArgumentMismatch(
     let range: Range;
     let message: string;
 
-    const parameter: PQP.Language.Type.FunctionParameter = mismatch.expected;
+    const parameter: Type.FunctionParameter = mismatch.expected;
     const argName: string = parameter.nameLiteral;
-    const expected: string = PQP.Language.TypeUtils.nameOfTypeKind(
-        parameter.maybeType ?? PQP.Language.Type.AnyInstance.kind,
-    );
+    const expected: string = TypeUtils.nameOfTypeKind(parameter.maybeType ?? Type.AnyInstance.kind);
 
     // An argument containing at least one leaf node was given.
     if (maybeGivenArgumentRange) {
-        const actual: string = PQP.Language.TypeUtils.nameOfTypeKind(PQP.Assert.asDefined(mismatch.actual).kind);
+        const actual: string = TypeUtils.nameOfTypeKind(Assert.asDefined(mismatch.actual).kind);
 
         range = maybeGivenArgumentRange;
         message = createTypeMismatchMessage(validationSettings.locale, maybeFunctionName, argName, expected, actual);

--- a/src/powerquery-language-services/validate/validateLexAndParse.ts
+++ b/src/powerquery-language-services/validate/validateLexAndParse.ts
@@ -2,8 +2,10 @@
 // Licensed under the MIT license.
 
 import * as PQP from "@microsoft/powerquery-parser";
-import { TextDocument } from "vscode-languageserver-textdocument";
 
+import { Ast } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { NodeIdMapUtils, ParseContext } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
+import { TextDocument } from "vscode-languageserver-textdocument";
 import type { Diagnostic, Position, Range } from "vscode-languageserver-types";
 import { DiagnosticSeverity } from "vscode-languageserver-types";
 
@@ -102,12 +104,12 @@ function validateParse(triedParse: PQP.Task.TriedParseTask, validationSettings: 
             },
         };
     } else {
-        const maybeRoot: PQP.Parser.ParseContext.Node | undefined = parseContextState.maybeRoot;
+        const maybeRoot: ParseContext.TNode | undefined = parseContextState.maybeRoot;
         if (maybeRoot === undefined) {
             return [];
         }
 
-        const maybeLeaf: PQP.Language.Ast.TNode | undefined = PQP.Parser.NodeIdMapUtils.maybeRightMostLeaf(
+        const maybeLeaf: Ast.TNode | undefined = NodeIdMapUtils.maybeRightMostLeaf(
             error.state.contextState.nodeIdMapCollection,
             maybeRoot.id,
         );

--- a/src/powerquery-language-services/workspaceCache/workspaceCacheUtils.ts
+++ b/src/powerquery-language-services/workspaceCache/workspaceCacheUtils.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import * as PQP from "@microsoft/powerquery-parser";
+
 import { TextDocument, TextDocumentContentChangeEvent } from "vscode-languageserver-textdocument";
 import type { Position } from "vscode-languageserver-types";
 

--- a/src/test/inspection.ts
+++ b/src/test/inspection.ts
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
+import { ResultUtils } from "@microsoft/powerquery-parser";
+
+import { Ast } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 
 import { assert, expect } from "chai";
 import "mocha";
@@ -11,7 +13,7 @@ import { Inspection, InspectionUtils, Position, SignatureProviderContext } from 
 import { MockDocument } from "./mockDocument";
 
 function expectScope(inspected: Inspection.Inspection, expected: ReadonlyArray<string>): void {
-    if (PQP.ResultUtils.isError(inspected.triedNodeScope)) {
+    if (ResultUtils.isError(inspected.triedNodeScope)) {
         throw new Error(`expected inspected.triedNodeScope to be Ok`);
     }
 
@@ -103,12 +105,11 @@ describe("InspectedInvokeExpression", () => {
 
                 TestUtils.assertIsDefined(activeNode.maybeIdentifierUnderPosition);
                 expect(activeNode.maybeIdentifierUnderPosition.kind).equals(
-                    PQP.Language.Ast.NodeKind.Identifier,
+                    Ast.NodeKind.Identifier,
                     "expecting identifier",
                 );
 
-                const identifier: PQP.Language.Ast.GeneralizedIdentifier | PQP.Language.Ast.Identifier =
-                    activeNode.maybeIdentifierUnderPosition;
+                const identifier: Ast.GeneralizedIdentifier | Ast.Identifier = activeNode.maybeIdentifierUnderPosition;
                 expect(identifier.literal).equals("OdbcDataSource");
                 expect(identifier.tokenRange.positionStart.lineNumber).equals(68);
             });

--- a/src/test/inspection/autocomplete/autocompleteKeyword.ts
+++ b/src/test/inspection/autocomplete/autocompleteKeyword.ts
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
-
 import { Assert } from "@microsoft/powerquery-parser";
+import { Ast, Keyword } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 import "mocha";
 import type { Position } from "vscode-languageserver-types";
 
@@ -23,9 +22,9 @@ function assertGetKeywordAutocomplete(text: string, position: Position): Readonl
 describe(`Inspection - Autocomplete - Keyword`, () => {
     it("|", () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`|`);
-        const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
-            ...PQP.Language.Keyword.ExpressionKeywordKinds,
-            PQP.Language.Keyword.KeywordKind.Section,
+        const expected: ReadonlyArray<Keyword.KeywordKind> = [
+            ...Keyword.ExpressionKeywordKinds,
+            Keyword.KeywordKind.Section,
         ];
         const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
         TestUtils.assertAutocompleteItemLabels(expected, actual);
@@ -34,85 +33,79 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
     describe("partial keyword", () => {
         it("a|", () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`a|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("x a|", () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`x a|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
-                PQP.Language.Keyword.KeywordKind.And,
-                PQP.Language.Keyword.KeywordKind.As,
-            ];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.And, Keyword.KeywordKind.As];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("e|", () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`e|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
-                PQP.Language.Keyword.KeywordKind.Each,
-                PQP.Language.Keyword.KeywordKind.Error,
-            ];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Each, Keyword.KeywordKind.Error];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("if x then x e|", () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if x then x e|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Else];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Else];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("i|", () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`i|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.If];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.If];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("l|", () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`l|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Let];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Let];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("m|", () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`m|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("x m|", () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`x m|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Meta];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Meta];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("n|", () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`n|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Not];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Not];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("true o|", () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`true o|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Or];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Or];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("try true o|", () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`try true o|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
-                PQP.Language.Keyword.KeywordKind.Or,
-                PQP.Language.Keyword.KeywordKind.Otherwise,
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [
+                Keyword.KeywordKind.Or,
+                Keyword.KeywordKind.Otherwise,
             ];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
@@ -120,381 +113,356 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
 
         it("try true o |", () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`try true o |`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("try true ot|", () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`try true ot|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
-                PQP.Language.Keyword.KeywordKind.Otherwise,
-            ];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Otherwise];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("try true oth|", () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`try true oth|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
-                PQP.Language.Keyword.KeywordKind.Otherwise,
-            ];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Otherwise];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("s|", () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`s|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
-                PQP.Language.Keyword.KeywordKind.Section,
-            ];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Section];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("[] |", () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[] |`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
-                PQP.Language.Keyword.KeywordKind.Section,
-            ];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Section];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("[] |s", () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[] |s`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("[] s|", () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[] s|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
-                PQP.Language.Keyword.KeywordKind.Section,
-            ];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Section];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("[] s |", () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[] s |`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("section; s|", () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`section; s|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Shared];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Shared];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("section; shared x|", () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`section; shared x|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("section; [] s|", () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`section; [] s|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Shared];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Shared];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("if true t|", () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if true t|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Then];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Then];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it("t|", () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`t|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
-                PQP.Language.Keyword.KeywordKind.True,
-                PQP.Language.Keyword.KeywordKind.Try,
-                PQP.Language.Keyword.KeywordKind.Type,
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [
+                Keyword.KeywordKind.True,
+                Keyword.KeywordKind.Try,
+                Keyword.KeywordKind.Type,
             ];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 
-    describe(`${PQP.Language.Ast.NodeKind.ErrorHandlingExpression}`, () => {
+    describe(`${Ast.NodeKind.ErrorHandlingExpression}`, () => {
         it(`try |`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`try |`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`try true|`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`try true|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.True];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.True];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`try true |`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`try true |`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
-                PQP.Language.Keyword.KeywordKind.And,
-                PQP.Language.Keyword.KeywordKind.As,
-                PQP.Language.Keyword.KeywordKind.Is,
-                PQP.Language.Keyword.KeywordKind.Meta,
-                PQP.Language.Keyword.KeywordKind.Or,
-                PQP.Language.Keyword.KeywordKind.Otherwise,
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [
+                Keyword.KeywordKind.And,
+                Keyword.KeywordKind.As,
+                Keyword.KeywordKind.Is,
+                Keyword.KeywordKind.Meta,
+                Keyword.KeywordKind.Or,
+                Keyword.KeywordKind.Otherwise,
             ];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 
-    describe(`${PQP.Language.Ast.NodeKind.ErrorRaisingExpression}`, () => {
+    describe(`${Ast.NodeKind.ErrorRaisingExpression}`, () => {
         it(`if |error`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if |error`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if error|`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if error|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`error |`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`error |`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 
-    describe(`${PQP.Language.Ast.NodeKind.FunctionExpression}`, () => {
+    describe(`${Ast.NodeKind.FunctionExpression}`, () => {
         it(`let x = (_ |) => a in x`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let x = (_ |) => a in x`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.As];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.As];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`let x = (_ a|) => a in`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let x = (_ a|) => a in`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.As];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.As];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 
-    describe(`${PQP.Language.Ast.NodeKind.IfExpression}`, () => {
+    describe(`${Ast.NodeKind.IfExpression}`, () => {
         it(`if|`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(` if |`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if |`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if 1|`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if 1|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if |if`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if |if`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if i|f`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if i|f`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.If];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.If];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if if | `, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if if |`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if 1 |`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if 1 |`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Then];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Then];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if 1 t|`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if 1 t|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Then];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Then];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if 1 then |`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if 1 then |`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if 1 then 1|`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if 1 then 1|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if 1 then 1 e|`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if 1 then 1 e|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Else];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Else];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if 1 then 1 else|`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if 1 then 1 else|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if 1 th|en 1 else`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if 1 th|en 1 else`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Then];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Then];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if 1 then 1 else |`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if 1 then 1 else |`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 
-    describe(`${PQP.Language.Ast.NodeKind.InvokeExpression}`, () => {
+    describe(`${Ast.NodeKind.InvokeExpression}`, () => {
         it(`foo(|`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`foo(|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`foo(a|`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`foo(a|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`foo(a|,`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`foo(a|,`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`foo(a,|`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`foo(a,|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 
-    describe(`${PQP.Language.Ast.NodeKind.ListExpression}`, () => {
+    describe(`${Ast.NodeKind.ListExpression}`, () => {
         it(`{|`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`{|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`{1|`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`{1|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`{1|,`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`{1|,`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`{1,|`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`{1,|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`{1,|2`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`{1,|2`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`{1,|2,`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`{1,|2,`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`{1..|`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`{1..|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 
-    describe(`${PQP.Language.Ast.NodeKind.OtherwiseExpression}`, () => {
+    describe(`${Ast.NodeKind.OtherwiseExpression}`, () => {
         it(`try true otherwise| false`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `try true otherwise| false`,
             );
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
@@ -503,131 +471,123 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `try true otherwise |false`,
             );
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`try true oth|`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`try true oth|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
-                PQP.Language.Keyword.KeywordKind.Otherwise,
-            ];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Otherwise];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`try true otherwise |`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`try true otherwise |`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 
-    describe(`${PQP.Language.Ast.NodeKind.ParenthesizedExpression}`, () => {
+    describe(`${Ast.NodeKind.ParenthesizedExpression}`, () => {
         it(`+(|`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+(|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 
-    describe(`${PQP.Language.Ast.NodeKind.RecordExpression}`, () => {
+    describe(`${Ast.NodeKind.RecordExpression}`, () => {
         it(`+[|`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+[a=|`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[a=|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+[a=1|`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[a=1|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+[a|=1`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[a|=1`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+[a=1|]`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[a=1|]`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+[a=|1]`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[a=| 1]`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+[a=1|,`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[a=1|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+[a=1,|`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[a=1,|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+[a=1|,b`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[a=1|,b`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+[a=1|,b=`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[a=1|,b=`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+[a=|1,b=`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[a=|1,b=`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+[a=1,b=2|`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[a=1,b=2|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+[a=1,b=2 |`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[a=1,b=2 |`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
@@ -636,40 +596,35 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
     describe(`AutocompleteExpression`, () => {
         it(`error |`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`error |`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`let x = |`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let x = |`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`() => |`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`() => |`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if |`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if |`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`if true then |`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if true then |`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
@@ -678,84 +633,77 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `if true then true else |`,
             );
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`foo(|`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`foo(|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`let x = 1 in |`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let x = 1 in |`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+{|`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+{|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`try true otherwise |`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`try true otherwise |`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`+(|`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+(|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 
-    describe(`${PQP.Language.Ast.NodeKind.SectionMember}`, () => {
+    describe(`${Ast.NodeKind.SectionMember}`, () => {
         it(`section; [] |`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`section; [] |`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Shared];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Shared];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`section; [] x |`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`section; [] x |`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`section; x = |`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`section; x = |`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`section; x = 1 |`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`section; x = 1 |`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
-                PQP.Language.Keyword.KeywordKind.And,
-                PQP.Language.Keyword.KeywordKind.As,
-                PQP.Language.Keyword.KeywordKind.Is,
-                PQP.Language.Keyword.KeywordKind.Meta,
-                PQP.Language.Keyword.KeywordKind.Or,
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [
+                Keyword.KeywordKind.And,
+                Keyword.KeywordKind.As,
+                Keyword.KeywordKind.Is,
+                Keyword.KeywordKind.Meta,
+                Keyword.KeywordKind.Or,
             ];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
@@ -763,7 +711,7 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
 
         it(`section; x = 1 i|`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`section; x = 1 i|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Is];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Is];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
@@ -772,38 +720,36 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `section foo; a = () => true; b = "string"; c = 1; d = |;`,
             );
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 
-    describe(`${PQP.Language.Ast.NodeKind.LetExpression}`, () => {
+    describe(`${Ast.NodeKind.LetExpression}`, () => {
         it(`let a = |`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = |`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`let a = 1|`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = 1|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`let a = 1 |`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = 1 |`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
-                PQP.Language.Keyword.KeywordKind.And,
-                PQP.Language.Keyword.KeywordKind.As,
-                PQP.Language.Keyword.KeywordKind.Is,
-                PQP.Language.Keyword.KeywordKind.Meta,
-                PQP.Language.Keyword.KeywordKind.Or,
-                PQP.Language.Keyword.KeywordKind.In,
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [
+                Keyword.KeywordKind.And,
+                Keyword.KeywordKind.As,
+                Keyword.KeywordKind.Is,
+                Keyword.KeywordKind.Meta,
+                Keyword.KeywordKind.Or,
+                Keyword.KeywordKind.In,
             ];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
@@ -811,13 +757,13 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
 
         it(`let a = 1 | foobar`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = 1 | foobar`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
-                PQP.Language.Keyword.KeywordKind.And,
-                PQP.Language.Keyword.KeywordKind.As,
-                PQP.Language.Keyword.KeywordKind.Is,
-                PQP.Language.Keyword.KeywordKind.Meta,
-                PQP.Language.Keyword.KeywordKind.Or,
-                PQP.Language.Keyword.KeywordKind.In,
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [
+                Keyword.KeywordKind.And,
+                Keyword.KeywordKind.As,
+                Keyword.KeywordKind.Is,
+                Keyword.KeywordKind.Meta,
+                Keyword.KeywordKind.Or,
+                Keyword.KeywordKind.In,
             ];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
@@ -825,52 +771,48 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
 
         it(`let a = 1 i|`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = 1 i|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
-                PQP.Language.Keyword.KeywordKind.Is,
-                PQP.Language.Keyword.KeywordKind.In,
-            ];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Is, Keyword.KeywordKind.In];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`let a = 1 o|`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = 1 o|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Or];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Or];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`let a = 1 m|`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = 1 m|`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [PQP.Language.Keyword.KeywordKind.Meta];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Meta];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`let a = 1, |`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = 1, |`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`let a = let b = |`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = let b = |`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> =
-                PQP.Language.Keyword.ExpressionKeywordKinds;
+            const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
         it(`let a = let b = 1 |`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = let b = 1 |`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [
-                PQP.Language.Keyword.KeywordKind.And,
-                PQP.Language.Keyword.KeywordKind.As,
-                PQP.Language.Keyword.KeywordKind.Is,
-                PQP.Language.Keyword.KeywordKind.Meta,
-                PQP.Language.Keyword.KeywordKind.Or,
-                PQP.Language.Keyword.KeywordKind.In,
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [
+                Keyword.KeywordKind.And,
+                Keyword.KeywordKind.As,
+                Keyword.KeywordKind.Is,
+                Keyword.KeywordKind.Meta,
+                Keyword.KeywordKind.Or,
+                Keyword.KeywordKind.In,
             ];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
@@ -878,7 +820,7 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
 
         it(`let a = let b = 1, |`, () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = let b = 1, |`);
-            const expected: ReadonlyArray<PQP.Language.Keyword.KeywordKind> = [];
+            const expected: ReadonlyArray<Keyword.KeywordKind> = [];
             const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });

--- a/src/test/inspection/autocomplete/autocompleteLanguageConstant.ts
+++ b/src/test/inspection/autocomplete/autocompleteLanguageConstant.ts
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
-
 import { Assert } from "@microsoft/powerquery-parser";
+import { Constant } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 import { expect } from "chai";
 import "mocha";
 import type { Position } from "vscode-languageserver-types";
@@ -30,7 +29,7 @@ describe(`Inspection - Autocomplete - Language constants`, () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`a as |`);
         const expected: AbridgedAutocompleteItem | undefined = {
             jaroWinklerScore: 1,
-            label: PQP.Language.Constant.LanguageConstantKind.Nullable,
+            label: Constant.LanguageConstantKind.Nullable,
         };
         const actual: AbridgedAutocompleteItem | undefined = assertGetLanguageConstantAutocomplete(
             TestConstants.DefaultInspectionSettings,
@@ -44,7 +43,7 @@ describe(`Inspection - Autocomplete - Language constants`, () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`a as n|`);
         const expected: AbridgedAutocompleteItem | undefined = {
             jaroWinklerScore: 1,
-            label: PQP.Language.Constant.LanguageConstantKind.Nullable,
+            label: Constant.LanguageConstantKind.Nullable,
         };
         const actual: AbridgedAutocompleteItem | undefined = assertGetLanguageConstantAutocomplete(
             TestConstants.DefaultInspectionSettings,
@@ -58,7 +57,7 @@ describe(`Inspection - Autocomplete - Language constants`, () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(a as |`);
         const expected: AbridgedAutocompleteItem | undefined = {
             jaroWinklerScore: 1,
-            label: PQP.Language.Constant.LanguageConstantKind.Nullable,
+            label: Constant.LanguageConstantKind.Nullable,
         };
         const actual: AbridgedAutocompleteItem | undefined = assertGetLanguageConstantAutocomplete(
             TestConstants.DefaultInspectionSettings,
@@ -72,7 +71,7 @@ describe(`Inspection - Autocomplete - Language constants`, () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(a as n|`);
         const expected: AbridgedAutocompleteItem | undefined = {
             jaroWinklerScore: 1,
-            label: PQP.Language.Constant.LanguageConstantKind.Nullable,
+            label: Constant.LanguageConstantKind.Nullable,
         };
         const actual: AbridgedAutocompleteItem | undefined = assertGetLanguageConstantAutocomplete(
             TestConstants.DefaultInspectionSettings,
@@ -86,7 +85,7 @@ describe(`Inspection - Autocomplete - Language constants`, () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(x, |`);
         const expected: AbridgedAutocompleteItem | undefined = {
             jaroWinklerScore: 1,
-            label: PQP.Language.Constant.LanguageConstantKind.Optional,
+            label: Constant.LanguageConstantKind.Optional,
         };
         const actual: AbridgedAutocompleteItem | undefined = assertGetLanguageConstantAutocomplete(
             TestConstants.DefaultInspectionSettings,
@@ -100,7 +99,7 @@ describe(`Inspection - Autocomplete - Language constants`, () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(x, op|`);
         const expected: AbridgedAutocompleteItem | undefined = {
             jaroWinklerScore: 1,
-            label: PQP.Language.Constant.LanguageConstantKind.Optional,
+            label: Constant.LanguageConstantKind.Optional,
         };
         const actual: AbridgedAutocompleteItem | undefined = assertGetLanguageConstantAutocomplete(
             TestConstants.DefaultInspectionSettings,

--- a/src/test/inspection/autocomplete/autocompletePrimitiveType.ts
+++ b/src/test/inspection/autocomplete/autocompletePrimitiveType.ts
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as PQP from "@microsoft/powerquery-parser";
-
 import { Assert } from "@microsoft/powerquery-parser";
+import { Constant } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 import "mocha";
 import type { Position } from "vscode-languageserver-types";
 
@@ -23,7 +22,7 @@ function assertGetPrimitiveTypeAutocompleteOk(
 describe(`Inspection - Autocomplete - PrimitiveType`, () => {
     it("type|", () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`type|`);
-        const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> = [];
+        const expected: ReadonlyArray<Constant.PrimitiveTypeConstantKind> = [];
         const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultInspectionSettings,
             text,
@@ -34,8 +33,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
 
     it("type |", () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`type |`);
-        const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> =
-            PQP.Language.Constant.PrimitiveTypeConstantKinds;
+        const expected: ReadonlyArray<Constant.PrimitiveTypeConstantKind> = Constant.PrimitiveTypeConstantKinds;
         const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultInspectionSettings,
             text,
@@ -46,7 +44,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
 
     it("let x = type|", () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let x = type|`);
-        const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> = [];
+        const expected: ReadonlyArray<Constant.PrimitiveTypeConstantKind> = [];
         const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultInspectionSettings,
             text,
@@ -57,8 +55,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
 
     it("let x = type |", () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let x = type |`);
-        const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> =
-            PQP.Language.Constant.PrimitiveTypeConstantKinds;
+        const expected: ReadonlyArray<Constant.PrimitiveTypeConstantKind> = Constant.PrimitiveTypeConstantKinds;
         const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultInspectionSettings,
             text,
@@ -69,8 +66,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
 
     it("type | number", () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`type | number`);
-        const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> =
-            PQP.Language.Constant.PrimitiveTypeConstantKinds;
+        const expected: ReadonlyArray<Constant.PrimitiveTypeConstantKind> = Constant.PrimitiveTypeConstantKinds;
         const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultInspectionSettings,
             text,
@@ -81,10 +77,10 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
 
     it("type n|", () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`type n|`);
-        const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> = [
-            PQP.Language.Constant.PrimitiveTypeConstantKind.None,
-            PQP.Language.Constant.PrimitiveTypeConstantKind.Null,
-            PQP.Language.Constant.PrimitiveTypeConstantKind.Number,
+        const expected: ReadonlyArray<Constant.PrimitiveTypeConstantKind> = [
+            Constant.PrimitiveTypeConstantKind.None,
+            Constant.PrimitiveTypeConstantKind.Null,
+            Constant.PrimitiveTypeConstantKind.Number,
         ];
         const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultInspectionSettings,
@@ -96,7 +92,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
 
     it("(x|) => 1", () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(x|) => 1`);
-        const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> = [];
+        const expected: ReadonlyArray<Constant.PrimitiveTypeConstantKind> = [];
         const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultInspectionSettings,
             text,
@@ -107,7 +103,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
 
     it("(x as| number) => 1", () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(x as| number) => 1`);
-        const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> = [];
+        const expected: ReadonlyArray<Constant.PrimitiveTypeConstantKind> = [];
         const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultInspectionSettings,
             text,
@@ -118,8 +114,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
 
     it("(x as | number) => 1", () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(x as | number) => 1`);
-        const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> =
-            PQP.Language.Constant.PrimitiveTypeConstantKinds;
+        const expected: ReadonlyArray<Constant.PrimitiveTypeConstantKind> = Constant.PrimitiveTypeConstantKinds;
         const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultInspectionSettings,
             text,
@@ -132,7 +127,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
             `(x as| nullable number) => 1`,
         );
-        const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> = [];
+        const expected: ReadonlyArray<Constant.PrimitiveTypeConstantKind> = [];
         const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultInspectionSettings,
             text,
@@ -145,8 +140,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
             `(x as | nullable number) => 1`,
         );
-        const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> =
-            PQP.Language.Constant.PrimitiveTypeConstantKinds;
+        const expected: ReadonlyArray<Constant.PrimitiveTypeConstantKind> = Constant.PrimitiveTypeConstantKinds;
         const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultInspectionSettings,
             text,
@@ -159,7 +153,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
             `(x as nullable| number) => 1`,
         );
-        const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> = [];
+        const expected: ReadonlyArray<Constant.PrimitiveTypeConstantKind> = [];
         const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultInspectionSettings,
             text,
@@ -172,8 +166,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
             `(x as nullable num|ber) => 1`,
         );
-        const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> =
-            PQP.Language.Constant.PrimitiveTypeConstantKinds;
+        const expected: ReadonlyArray<Constant.PrimitiveTypeConstantKind> = Constant.PrimitiveTypeConstantKinds;
         const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultInspectionSettings,
             text,
@@ -184,8 +177,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
 
     it("let a = 1 is |", () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = 1 is |`);
-        const expected: ReadonlyArray<PQP.Language.Constant.PrimitiveTypeConstantKind> =
-            PQP.Language.Constant.PrimitiveTypeConstantKinds;
+        const expected: ReadonlyArray<Constant.PrimitiveTypeConstantKind> = Constant.PrimitiveTypeConstantKinds;
         const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultInspectionSettings,
             text,

--- a/src/test/inspection/currentInvokeExpression.ts
+++ b/src/test/inspection/currentInvokeExpression.ts
@@ -4,17 +4,19 @@
 import * as PQP from "@microsoft/powerquery-parser";
 
 import { Assert } from "@microsoft/powerquery-parser";
+import { Type, TypeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { NodeIdMap } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 import { expect } from "chai";
 import "mocha";
 import type { Position } from "vscode-languageserver-types";
-import { Inspection, InspectionSettings } from "../../powerquery-language-services";
 
 import { TestConstants, TestUtils } from "..";
+import { Inspection, InspectionSettings } from "../../powerquery-language-services";
 import { CurrentInvokeExpressionArguments } from "../../powerquery-language-services/inspection";
 
 function assertInvokeExpressionOk(
     settings: InspectionSettings,
-    nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
+    nodeIdMapCollection: NodeIdMap.Collection,
     position: Position,
 ): Inspection.CurrentInvokeExpression | undefined {
     const activeNode: Inspection.ActiveNode = Inspection.ActiveNodeUtils.assertActiveNode(
@@ -59,7 +61,7 @@ function expectNoParameters_givenExtraneousParameter(inspected: Inspection.Curre
 
     expect(invokeArgs.argumentOrdinal).to.equal(0);
     // tslint:disable-next-line: chai-vague-errors
-    expect(invokeArgs.givenArgumentTypes).to.deep.equal([PQP.Language.TypeUtils.createNumberLiteral(false, `1`)]);
+    expect(invokeArgs.givenArgumentTypes).to.deep.equal([TypeUtils.createNumberLiteral(false, `1`)]);
     expect(invokeArgs.givenArguments.length).to.equal(1);
     expect(invokeArgs.numMaxExpectedArguments).to.equal(0);
     expect(invokeArgs.numMinExpectedArguments).to.equal(0);
@@ -104,7 +106,7 @@ function expectText_givenText(inspected: Inspection.CurrentInvokeExpression | un
 
     expect(invokeArgs.argumentOrdinal).to.equal(0);
     // tslint:disable-next-line: chai-vague-errors
-    expect(invokeArgs.givenArgumentTypes).to.deep.equal([PQP.Language.TypeUtils.createTextLiteral(false, `"foo"`)]);
+    expect(invokeArgs.givenArgumentTypes).to.deep.equal([TypeUtils.createTextLiteral(false, `"foo"`)]);
     expect(invokeArgs.givenArguments.length).to.equal(1);
     expect(invokeArgs.numMaxExpectedArguments).to.equal(1);
     expect(invokeArgs.numMinExpectedArguments).to.equal(1);
@@ -168,7 +170,7 @@ function expectRequiredAndOptional_givenRequired(inspected: Inspection.CurrentIn
 
     expect(invokeArgs.argumentOrdinal).to.equal(0);
     // tslint:disable-next-line: chai-vague-errors
-    expect(invokeArgs.givenArgumentTypes).to.deep.equal([PQP.Language.TypeUtils.createNumberLiteral(false, "1")]);
+    expect(invokeArgs.givenArgumentTypes).to.deep.equal([TypeUtils.createNumberLiteral(false, "1")]);
     expect(invokeArgs.givenArguments.length).to.equal(1);
     expect(invokeArgs.numMaxExpectedArguments).to.equal(2);
     expect(invokeArgs.numMinExpectedArguments).to.equal(1);
@@ -194,8 +196,8 @@ function expectRequiredAndOptional_givenRequiredAndOptional(
     expect(invokeArgs.argumentOrdinal).to.equal(1);
     // tslint:disable-next-line: chai-vague-errors
     expect(invokeArgs.givenArgumentTypes).to.deep.equal([
-        PQP.Language.TypeUtils.createNumberLiteral(false, "1"),
-        PQP.Language.TypeUtils.createTextLiteral(false, `"secondArg"`),
+        TypeUtils.createNumberLiteral(false, "1"),
+        TypeUtils.createTextLiteral(false, `"secondArg"`),
     ]);
     expect(invokeArgs.givenArguments.length).to.equal(2);
     expect(invokeArgs.numMaxExpectedArguments).to.equal(2);
@@ -209,10 +211,10 @@ function expectRequiredAndOptional_givenRequiredAndOptional(
 }
 
 function expectText_givenNumber(inspected: Inspection.CurrentInvokeExpression | undefined): void {
-    const expectedArgument: PQP.Language.Type.FunctionParameter = PQP.Assert.asDefined(
+    const expectedArgument: Type.FunctionParameter = Assert.asDefined(
         TestConstants.DuplicateTextDefinedFunction.parameters[0],
     );
-    const actualArgument: PQP.Language.Type.NumberLiteral = PQP.Language.TypeUtils.createNumberLiteral(false, "1");
+    const actualArgument: Type.NumberLiteral = TypeUtils.createNumberLiteral(false, "1");
 
     Assert.isDefined(inspected);
 
@@ -232,8 +234,8 @@ function expectText_givenNumber(inspected: Inspection.CurrentInvokeExpression | 
     expect(invokeArgs.typeChecked.missing.length).to.equal(0);
     expect(invokeArgs.typeChecked.valid.length).to.equal(0);
 
-    const invalidArguments: Map<number, PQP.Language.TypeUtils.InvocationMismatch> = invokeArgs.typeChecked.invalid;
-    const firstArg: PQP.Language.TypeUtils.InvocationMismatch = PQP.MapUtils.assertGet(invalidArguments, 0);
+    const invalidArguments: Map<number, TypeUtils.InvocationMismatch> = invokeArgs.typeChecked.invalid;
+    const firstArg: TypeUtils.InvocationMismatch = PQP.MapUtils.assertGet(invalidArguments, 0);
 
     expect(firstArg).to.deep.equal({
         expected: expectedArgument,

--- a/src/test/inspection/scope.ts
+++ b/src/test/inspection/scope.ts
@@ -4,6 +4,8 @@
 import * as PQP from "@microsoft/powerquery-parser";
 
 import { Assert } from "@microsoft/powerquery-parser";
+import { Ast, Constant } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { NodeIdMap } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 import { expect } from "chai";
 import "mocha";
 import type { Position } from "vscode-languageserver-types";
@@ -47,7 +49,7 @@ interface AbridgedParameterScopeItem extends IAbridgedNodeScopeItem {
     readonly kind: Inspection.ScopeItemKind.Parameter;
     readonly isNullable: boolean;
     readonly isOptional: boolean;
-    readonly maybeType: PQP.Language.Constant.PrimitiveTypeConstantKind | undefined;
+    readonly maybeType: Constant.PrimitiveTypeConstantKind | undefined;
 }
 
 interface AbridgedRecordScopeItem extends IAbridgedNodeScopeItem {
@@ -136,7 +138,7 @@ function createAbridgedParameterScopeItems(nodeScope: Inspection.NodeScope): Rea
 
 function assertNodeScopeOk(
     settings: PQP.CommonSettings,
-    nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
+    nodeIdMapCollection: NodeIdMap.Collection,
     position: Position,
 ): Inspection.NodeScope {
     const maybeActiveNode: Inspection.TMaybeActiveNode = Inspection.ActiveNodeUtils.maybeActiveNode(
@@ -179,7 +181,7 @@ export function assertGetParseErrScopeOk(
 
 describe(`subset Inspection - Scope - Identifier`, () => {
     describe(`Scope`, () => {
-        describe(`${PQP.Language.Ast.NodeKind.EachExpression} (Ast)`, () => {
+        describe(`${Ast.NodeKind.EachExpression} (Ast)`, () => {
             it(`|each 1`, () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`|each 1`);
                 const expected: ReadonlyArray<TAbridgedNodeScopeItem> = [];
@@ -247,7 +249,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
         });
 
-        describe(`${PQP.Language.Ast.NodeKind.EachExpression} (ParserContext)`, () => {
+        describe(`${Ast.NodeKind.EachExpression} (ParserContext)`, () => {
             it(`each|`, () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`each|`);
                 const expected: AbridgedNodeScope = [];
@@ -274,7 +276,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
         });
 
-        describe(`${PQP.Language.Ast.NodeKind.FunctionExpression} (Ast)`, () => {
+        describe(`${Ast.NodeKind.FunctionExpression} (Ast)`, () => {
             it(`|(x) => z`, () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`|(x) => z`);
                 const expected: AbridgedNodeScope = [];
@@ -329,7 +331,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
         });
 
-        describe(`${PQP.Language.Ast.NodeKind.FunctionExpression} (ParserContext)`, () => {
+        describe(`${Ast.NodeKind.FunctionExpression} (ParserContext)`, () => {
             it(`|(x) =>`, () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`|(x) =>`);
                 const expected: AbridgedNodeScope = [];
@@ -384,7 +386,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
         });
 
-        describe(`${PQP.Language.Ast.NodeKind.IdentifierExpression} (Ast)`, () => {
+        describe(`${Ast.NodeKind.IdentifierExpression} (Ast)`, () => {
             it(`let x = 1, y = x in 1|`, () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `let x = 1, y = x in 1|`,
@@ -412,7 +414,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
         });
 
-        describe(`${PQP.Language.Ast.NodeKind.RecordExpression} (Ast)`, () => {
+        describe(`${Ast.NodeKind.RecordExpression} (Ast)`, () => {
             it(`|[a=1]`, () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`|[a=1]`);
                 const expected: AbridgedNodeScope = [];
@@ -530,7 +532,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
         });
 
-        describe(`${PQP.Language.Ast.NodeKind.RecordExpression} (ParserContext)`, () => {
+        describe(`${Ast.NodeKind.RecordExpression} (ParserContext)`, () => {
             it(`|[a=1`, () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`|[a=1`);
                 const expected: AbridgedNodeScope = [];
@@ -680,7 +682,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
         });
 
-        describe(`${PQP.Language.Ast.NodeKind.Section} (Ast)`, () => {
+        describe(`${Ast.NodeKind.Section} (Ast)`, () => {
             it(`s|ection foo; x = 1; y = 2;`, () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `s|ection foo; x = 1; y = 2;`,
@@ -796,7 +798,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
         });
 
-        describe(`${PQP.Language.Ast.NodeKind.SectionMember} (ParserContext)`, () => {
+        describe(`${Ast.NodeKind.SectionMember} (ParserContext)`, () => {
             it(`s|ection foo; x = 1; y = 2`, () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `s|ection foo; x = 1; y = 2`,
@@ -887,7 +889,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
         });
 
-        describe(`${PQP.Language.Ast.NodeKind.LetExpression} (Ast)`, () => {
+        describe(`${Ast.NodeKind.LetExpression} (Ast)`, () => {
             it(`let a = 1 in |x`, () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = 1 in |x`);
                 const expected: AbridgedNodeScope = [
@@ -1114,7 +1116,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             });
         });
 
-        describe(`${PQP.Language.Ast.NodeKind.LetExpression} (ParserContext)`, () => {
+        describe(`${Ast.NodeKind.LetExpression} (ParserContext)`, () => {
             it(`let a = 1 in |`, () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = 1 in |`);
                 const expected: AbridgedNodeScope = [
@@ -1251,7 +1253,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                     isRecursive: false,
                     isNullable: false,
                     isOptional: false,
-                    maybeType: PQP.Language.Constant.PrimitiveTypeConstantKind.Number,
+                    maybeType: Constant.PrimitiveTypeConstantKind.Number,
                 },
                 {
                     identifier: "c",
@@ -1259,7 +1261,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                     isRecursive: false,
                     isNullable: true,
                     isOptional: false,
-                    maybeType: PQP.Language.Constant.PrimitiveTypeConstantKind.Function,
+                    maybeType: Constant.PrimitiveTypeConstantKind.Function,
                 },
                 {
                     identifier: "d",
@@ -1275,7 +1277,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                     isRecursive: false,
                     isNullable: false,
                     isOptional: true,
-                    maybeType: PQP.Language.Constant.PrimitiveTypeConstantKind.Table,
+                    maybeType: Constant.PrimitiveTypeConstantKind.Table,
                 },
             ];
             const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedParameterScopeItems(

--- a/src/test/inspectionUtils.ts
+++ b/src/test/inspectionUtils.ts
@@ -5,6 +5,8 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { Ast, AstUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+
 import { assert, expect } from "chai";
 import "mocha";
 
@@ -15,15 +17,12 @@ import { MockDocument } from "./mockDocument";
 import { AbridgedDocumentSymbol } from "./testUtils";
 
 // Used to test symbols at a specific level of inspection
-function expectSymbolsForNode(
-    node: PQP.Language.Ast.TNode,
-    expectedSymbols: ReadonlyArray<AbridgedDocumentSymbol>,
-): void {
+function expectSymbolsForNode(node: Ast.TNode, expectedSymbols: ReadonlyArray<AbridgedDocumentSymbol>): void {
     let actualSymbols: ReadonlyArray<AbridgedDocumentSymbol>;
 
-    if (node.kind === PQP.Language.Ast.NodeKind.Section) {
+    if (AstUtils.isSection(node)) {
         actualSymbols = TestUtils.createAbridgedDocumentSymbols(InspectionUtils.getSymbolsForSection(node));
-    } else if (node.kind === PQP.Language.Ast.NodeKind.LetExpression) {
+    } else if (AstUtils.isLetExpression(node)) {
         actualSymbols = TestUtils.createAbridgedDocumentSymbols(InspectionUtils.getSymbolsForLetExpression(node));
     } else {
         throw new Error("unsupported code path");

--- a/src/test/testConstants.ts
+++ b/src/test/testConstants.ts
@@ -3,6 +3,8 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
+import { Type, TypeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+
 import { Assert } from "@microsoft/powerquery-parser";
 
 import {
@@ -28,39 +30,39 @@ export const NoOpLibrary: Library.ILibrary = {
     libraryDefinitions: new Map(),
 };
 
-export const CreateFooAndBarRecordDefinedFunction: PQP.Language.Type.DefinedFunction = PQP.Language.TypeUtils.createDefinedFunction(
+export const CreateFooAndBarRecordDefinedFunction: Type.DefinedFunction = TypeUtils.createDefinedFunction(
     false,
     [],
-    PQP.Language.TypeUtils.createDefinedRecord(
+    TypeUtils.createDefinedRecord(
         false,
-        new Map<string, PQP.Language.Type.TPowerQueryType>([
-            ["foo", PQP.Language.TypeUtils.createTextLiteral(false, `"fooString"`)],
-            ["bar", PQP.Language.TypeUtils.createTextLiteral(false, `"barString"`)],
+        new Map<string, Type.TPowerQueryType>([
+            ["foo", TypeUtils.createTextLiteral(false, `"fooString"`)],
+            ["bar", TypeUtils.createTextLiteral(false, `"barString"`)],
         ]),
         false,
     ),
 );
 
-export const CombineNumberAndOptionalTextDefinedFunction: PQP.Language.Type.DefinedFunction = PQP.Language.TypeUtils.createDefinedFunction(
+export const CombineNumberAndOptionalTextDefinedFunction: Type.DefinedFunction = TypeUtils.createDefinedFunction(
     false,
     [
         {
             isNullable: false,
             isOptional: false,
             nameLiteral: "firstArg",
-            maybeType: PQP.Language.Type.TypeKind.Number,
+            maybeType: Type.TypeKind.Number,
         },
         {
             isNullable: false,
             isOptional: true,
             nameLiteral: "secondArg",
-            maybeType: PQP.Language.Type.TypeKind.Text,
+            maybeType: Type.TypeKind.Text,
         },
     ],
-    PQP.Language.Type.NullInstance,
+    Type.NullInstance,
 );
 
-export const SquareIfNumberDefinedFunction: PQP.Language.Type.DefinedFunction = PQP.Language.TypeUtils.createDefinedFunction(
+export const SquareIfNumberDefinedFunction: Type.DefinedFunction = TypeUtils.createDefinedFunction(
     false,
     [
         {
@@ -70,20 +72,20 @@ export const SquareIfNumberDefinedFunction: PQP.Language.Type.DefinedFunction = 
             nameLiteral: "x",
         },
     ],
-    PQP.Language.Type.AnyInstance,
+    Type.AnyInstance,
 );
 
-export const DuplicateTextDefinedFunction: PQP.Language.Type.DefinedFunction = PQP.Language.TypeUtils.createDefinedFunction(
+export const DuplicateTextDefinedFunction: Type.DefinedFunction = TypeUtils.createDefinedFunction(
     false,
     [
         {
             isNullable: false,
             isOptional: false,
-            maybeType: PQP.Language.Type.TypeKind.Text,
+            maybeType: Type.TypeKind.Text,
             nameLiteral: "txt",
         },
     ],
-    PQP.Language.Type.TextInstance,
+    Type.TextInstance,
 );
 
 export const SimpleLibraryDefinitions: Library.LibraryDefinitions = new Map<string, Library.TLibraryDefinition>([
@@ -102,7 +104,7 @@ export const SimpleLibraryDefinitions: Library.LibraryDefinitions = new Map<stri
         LibraryUtils.createConstantDefinition(
             TestLibraryName.Number,
             `The name is ${TestLibraryName.Number}`,
-            PQP.Language.Type.NumberInstance,
+            Type.NumberInstance,
             CompletionItemKind.Value,
         ),
     ],
@@ -119,14 +121,14 @@ export const SimpleLibraryDefinitions: Library.LibraryDefinitions = new Map<stri
                     isOptional: false,
                     label: "firstArg",
                     maybeDocumentation: undefined,
-                    typeKind: PQP.Language.Type.TypeKind.Number,
+                    typeKind: Type.TypeKind.Number,
                 },
                 {
                     isNullable: false,
                     isOptional: true,
                     label: "secondArg",
                     maybeDocumentation: undefined,
-                    typeKind: PQP.Language.Type.TypeKind.Text,
+                    typeKind: Type.TypeKind.Text,
                 },
             ],
         ),
@@ -136,7 +138,7 @@ export const SimpleLibraryDefinitions: Library.LibraryDefinitions = new Map<stri
         LibraryUtils.createConstantDefinition(
             TestLibraryName.NumberOne,
             `The name is ${TestLibraryName.NumberOne}`,
-            PQP.Language.TypeUtils.createNumberLiteral(false, "1"),
+            TypeUtils.createNumberLiteral(false, "1"),
             CompletionItemKind.Constant,
         ),
     ],
@@ -154,7 +156,7 @@ export const SimpleLibraryDefinitions: Library.LibraryDefinitions = new Map<stri
                     label: "x",
                     maybeDocumentation:
                         "If the argument is a number then multiply it by itself, otherwise return argument as-is.",
-                    typeKind: PQP.Language.Type.TypeKind.Any,
+                    typeKind: Type.TypeKind.Any,
                 },
             ],
         ),
@@ -169,21 +171,21 @@ export const SimpleExternalTypeResolver: Inspection.ExternalType.TExternalTypeRe
             switch (request.identifierLiteral) {
                 case TestLibraryName.SquareIfNumber: {
                     if (request.args.length !== 1) {
-                        return PQP.Language.Type.NoneInstance;
+                        return Type.NoneInstance;
                     }
-                    const arg: PQP.Language.Type.TPowerQueryType = Assert.asDefined(request.args[0]);
+                    const arg: Type.TPowerQueryType = Assert.asDefined(request.args[0]);
 
-                    if (PQP.Language.TypeUtils.isNumberLiteral(arg)) {
+                    if (TypeUtils.isNumberLiteral(arg)) {
                         const newNormalizedLiteral: number = arg.normalizedLiteral * arg.normalizedLiteral;
                         return {
                             ...arg,
                             literal: newNormalizedLiteral.toString(),
                             normalizedLiteral: newNormalizedLiteral,
                         };
-                    } else if (PQP.Language.TypeUtils.isNumber(arg)) {
-                        return PQP.Language.Type.NumberInstance;
+                    } else if (TypeUtils.isNumber(arg)) {
+                        return Type.NumberInstance;
                     } else {
-                        return PQP.Language.Type.AnyInstance;
+                        return Type.AnyInstance;
                     }
                 }
 
@@ -203,10 +205,10 @@ export const SimpleExternalTypeResolver: Inspection.ExternalType.TExternalTypeRe
                     return DuplicateTextDefinedFunction;
 
                 case TestLibraryName.Number:
-                    return PQP.Language.Type.NumberInstance;
+                    return Type.NumberInstance;
 
                 case TestLibraryName.NumberOne:
-                    return PQP.Language.TypeUtils.createNumberLiteral(false, "1");
+                    return TypeUtils.createNumberLiteral(false, "1");
 
                 case TestLibraryName.SquareIfNumber:
                     return SquareIfNumberDefinedFunction;

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,7 @@
 {
     "rulesDirectory": ["tslint-config-prettier", "tslint-microsoft-contrib", "tslint-plugin-prettier"],
     "rules": {
+        "no-submodule-imports": [true, "@microsoft/powerquery-parser", "chai", "mocha"],
         "no-angle-bracket-type-assertion": true,
         "no-internal-module": true,
         "no-namespace": true,


### PR DESCRIPTION
There's A LOT of changes due to a rework on the XorNode API [link](https://github.com/microsoft/powerquery-parser/pull/274). It simplifies validating node invariants, and with typing improvements there's more bugs discoverable during compile time.

Before incrementing the language-services package I'm going to make a second PR for non-functional code changes.