### PR TITLE
Add setting to control invocation validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.2.14",
+    "version": "0.2.15",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/powerquery-language-services",
-            "version": "0.2.14",
+            "version": "0.2.15",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/powerquery-formatter": "0.0.41",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.2.14",
+    "version": "0.2.15",
     "author": "Microsoft",
     "license": "MIT",
     "scripts": {

--- a/src/powerquery-language-services/validate/validate.ts
+++ b/src/powerquery-language-services/validate/validate.ts
@@ -20,7 +20,10 @@ export function validate(textDocument: TextDocument, validationSettings: Validat
     );
 
     let invokeExpressionDiagnostics: Diagnostic[];
-    if (PQP.TaskUtils.isParseStageOk(cacheItem) || PQP.TaskUtils.isParseStageParseError(cacheItem)) {
+    if (
+        validationSettings.checkInvokeExpressions &&
+        (PQP.TaskUtils.isParseStageOk(cacheItem) || PQP.TaskUtils.isParseStageParseError(cacheItem))
+    ) {
         invokeExpressionDiagnostics = validateInvokeExpression(
             validationSettings,
             cacheItem.nodeIdMapCollection,

--- a/src/powerquery-language-services/validate/validationSettings/validationSettings.ts
+++ b/src/powerquery-language-services/validate/validationSettings/validationSettings.ts
@@ -6,4 +6,5 @@ import { InspectionSettings } from "../../inspectionSettings";
 export interface ValidationSettings extends InspectionSettings {
     readonly source: string;
     readonly checkForDuplicateIdentifiers: boolean;
+    readonly checkInvokeExpressions: boolean;
 }

--- a/src/powerquery-language-services/validate/validationSettings/validationSettingsUtils.ts
+++ b/src/powerquery-language-services/validate/validationSettings/validationSettingsUtils.ts
@@ -8,10 +8,12 @@ export function createValidationSettings(
     inspectionSettings: InspectionSettings,
     source: string,
     checkForDuplicateIdentifiers?: boolean,
+    checkInvokeExpressions?: boolean,
 ): ValidationSettings {
     return {
         ...inspectionSettings,
         checkForDuplicateIdentifiers: checkForDuplicateIdentifiers ?? true,
+        checkInvokeExpressions: checkInvokeExpressions ?? true,
         source,
     };
 }

--- a/src/test/testConstants.ts
+++ b/src/test/testConstants.ts
@@ -230,6 +230,7 @@ export const SimpleInspectionSettings: InspectionSettings = {
 export const SimpleValidationSettings: ValidationSettings = {
     ...SimpleInspectionSettings,
     checkForDuplicateIdentifiers: true,
+    checkInvokeExpressions: true,
     source: "UNIT-TEST-SOURCE",
 };
 

--- a/src/test/validation/invokeExpression.ts
+++ b/src/test/validation/invokeExpression.ts
@@ -7,9 +7,18 @@ import { Assert } from "@microsoft/powerquery-parser";
 import { expect } from "chai";
 import "mocha";
 
+import * as PQLS from "../../powerquery-language-services";
+
 import { TestConstants, TestUtils } from "..";
-import { Diagnostic, DiagnosticErrorCode, Position, TextDocument } from "../../powerquery-language-services";
+import {
+    Diagnostic,
+    DiagnosticErrorCode,
+    Position,
+    TextDocument,
+    ValidationSettings,
+} from "../../powerquery-language-services";
 import { ValidationResult } from "../../powerquery-language-services/validate/validationResult";
+import { SimpleValidationSettings } from "../testConstants";
 
 interface AbridgedInvocationDiagnostic {
     readonly message: string;
@@ -89,14 +98,29 @@ function expectInvocationDiagnosticPositions(
 }
 
 describe("Validation - InvokeExpression", () => {
+    describe(`checkInvokeExpressions = false`, () => {
+        const validationSettings: ValidationSettings = {
+            ...SimpleValidationSettings,
+            checkInvokeExpressions: false,
+        };
+
+        it(`argument count suppressed`, () => {
+            const textDocument: TextDocument = TestUtils.createTextMockDocument(
+                `${TestConstants.TestLibraryName.SquareIfNumber}()`,
+            );
+
+            const validationResult: ValidationResult = PQLS.validate(textDocument, validationSettings);
+            expect(validationResult.diagnostics.length).to.equal(0);
+        });
+    });
+
     describe(`single invocation`, () => {
         it(`expects [1, 1] arguments, 0 given`, () => {
             const textDocument: TextDocument = TestUtils.createTextMockDocument(
                 `${TestConstants.TestLibraryName.SquareIfNumber}()`,
             );
-            const invocationDiagnostics: ReadonlyArray<AbridgedInvocationDiagnostic> = expectGetInvokeExpressionDiagnostics(
-                textDocument,
-            );
+            const invocationDiagnostics: ReadonlyArray<AbridgedInvocationDiagnostic> =
+                expectGetInvokeExpressionDiagnostics(textDocument);
             expectArgumentCountMismatch(invocationDiagnostics, 1, 1, 0);
         });
 
@@ -104,9 +128,8 @@ describe("Validation - InvokeExpression", () => {
             const textDocument: TextDocument = TestUtils.createTextMockDocument(
                 `${TestConstants.TestLibraryName.CombineNumberAndOptionalText}()`,
             );
-            const invocationDiagnostics: ReadonlyArray<AbridgedInvocationDiagnostic> = expectGetInvokeExpressionDiagnostics(
-                textDocument,
-            );
+            const invocationDiagnostics: ReadonlyArray<AbridgedInvocationDiagnostic> =
+                expectGetInvokeExpressionDiagnostics(textDocument);
             expectArgumentCountMismatch(invocationDiagnostics, 1, 2, 0);
         });
 
@@ -114,9 +137,8 @@ describe("Validation - InvokeExpression", () => {
             const textDocument: TextDocument = TestUtils.createTextMockDocument(
                 `${TestConstants.TestLibraryName.CombineNumberAndOptionalText}(0, "")`,
             );
-            const invocationDiagnostics: ReadonlyArray<AbridgedInvocationDiagnostic> = expectGetInvokeExpressionDiagnostics(
-                textDocument,
-            );
+            const invocationDiagnostics: ReadonlyArray<AbridgedInvocationDiagnostic> =
+                expectGetInvokeExpressionDiagnostics(textDocument);
             expect(invocationDiagnostics.length).to.equal(0);
         });
     });
@@ -131,9 +153,8 @@ let
 in
     _`,
             );
-            const invocationDiagnostics: ReadonlyArray<AbridgedInvocationDiagnostic> = expectGetInvokeExpressionDiagnostics(
-                textDocument,
-            );
+            const invocationDiagnostics: ReadonlyArray<AbridgedInvocationDiagnostic> =
+                expectGetInvokeExpressionDiagnostics(textDocument);
 
             expect(invocationDiagnostics.length).to.equal(2);
 


### PR DESCRIPTION
This change adds a new `checkInvokeExpressions` flag to `ValidationSettings`. This lets us make the setting optional in VS Code (and off by default) to avoid the false positives we're currently seeing while the feature is still being worked on.

As a general design pattern, we should have configuration flags for validation logic that is still under development, has a change of reporting false positives, or is expensive to run. 

I think the right long term design is to allow the caller to pass in a list of diagnostic codes they want to enable/disable, rather than having multiple flags in `ValidationSettings`. Certain consumers might want to disable specific checks if they haven't implemented all of the right interfaces yet (i.e. identifying unknown identifiers/symbols that come from other places). It also makes the API contract more flexible. 