### PR TITLE
Symbol provider timeouts

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,6 @@
             "name": "Run unit tests",
             "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
             "args": [
-                "--inspect",
                 "--colors",
                 "--timeout",
                 "999999",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.2.15",
+    "version": "0.2.16",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/powerquery-language-services",
-            "version": "0.2.15",
+            "version": "0.2.16",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/powerquery-formatter": "0.0.41",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.2.15",
+    "version": "0.2.16",
     "author": "Microsoft",
     "license": "MIT",
     "scripts": {

--- a/src/powerquery-language-services/analysis/analysisBase.ts
+++ b/src/powerquery-language-services/analysis/analysisBase.ts
@@ -161,7 +161,7 @@ export abstract class AnalysisBase implements Analysis {
     protected abstract getText(range?: Range): string;
 
     private static promiseWithTimeout<T>(promise: Promise<T>, timeoutReturnValue: T, timeoutInMS?: number): Promise<T> {
-        if (timeoutInMS) {
+        if (timeoutInMS !== undefined) {
             // TODO: Enabling trace entry when timeout occurs
             return Promise.race([
                 promise,

--- a/src/powerquery-language-services/analysis/analysisBase.ts
+++ b/src/powerquery-language-services/analysis/analysisBase.ts
@@ -80,11 +80,11 @@ export abstract class AnalysisBase implements Analysis {
         // - honor expected data type
         // - only include current query name after @
         const [languageResponse, libraryResponse, localDocumentResponse] = await Promise.all(
-            AnalysisBase.createAutocompleteItemCalls(context, [
-                this.languageAutocompleteItemProvider,
-                this.librarySymbolProvider,
-                this.localDocumentSymbolProvider,
-            ]),
+            AnalysisBase.createAutocompleteItemCalls(
+                context,
+                [this.languageAutocompleteItemProvider, this.librarySymbolProvider, this.localDocumentSymbolProvider],
+                this.analysisSettings.symbolProviderTimeoutInMS,
+            ),
         );
 
         const partial: AutocompleteItem[] = [];
@@ -146,10 +146,11 @@ export abstract class AnalysisBase implements Analysis {
 
         // Result priority is based on the order of the symbol providers
         return AnalysisBase.resolveProviders(
-            AnalysisBase.createSignatureHelpCalls(context, [
-                this.localDocumentSymbolProvider,
-                this.librarySymbolProvider,
-            ]),
+            AnalysisBase.createSignatureHelpCalls(
+                context,
+                [this.localDocumentSymbolProvider, this.librarySymbolProvider],
+                this.analysisSettings.symbolProviderTimeoutInMS,
+            ),
             EmptySignatureHelp,
         );
     }
@@ -161,6 +162,7 @@ export abstract class AnalysisBase implements Analysis {
 
     private static promiseWithTimeout<T>(promise: Promise<T>, timeoutReturnValue: T, timeoutInMS?: number): Promise<T> {
         if (timeoutInMS) {
+            // TODO: Enabling trace entry when timeout occurs
             return Promise.race([
                 promise,
                 new Promise<T>(resolve =>

--- a/src/powerquery-language-services/analysis/analysisBase.ts
+++ b/src/powerquery-language-services/analysis/analysisBase.ts
@@ -192,12 +192,17 @@ export abstract class AnalysisBase implements Analysis {
     private static createAutocompleteItemCalls(
         context: AutocompleteItemProviderContext,
         providers: ReadonlyArray<AutocompleteItemProvider>,
+        timeoutInMS?: number,
     ): ReadonlyArray<Promise<ReadonlyArray<AutocompleteItem>>> {
         // TODO: add tracing to the catch case
         return providers.map(provider =>
-            provider.getAutocompleteItems(context).catch(() => {
-                return [];
-            }),
+            this.promiseWithTimeout(
+                provider.getAutocompleteItems(context).catch(() => {
+                    return [];
+                }),
+                [],
+                timeoutInMS,
+            ),
         );
     }
 
@@ -221,12 +226,17 @@ export abstract class AnalysisBase implements Analysis {
     private static createSignatureHelpCalls(
         context: SignatureProviderContext,
         providers: SignatureHelpProvider[],
+        timeoutInMS?: number,
     ): ReadonlyArray<Promise<SignatureHelp | null>> {
         // TODO: add tracing to the catch case
         return providers.map(provider =>
-            provider.getSignatureHelp(context).catch(() => {
-                return null;
-            }),
+            this.promiseWithTimeout(
+                provider.getSignatureHelp(context).catch(() => {
+                    return null;
+                }),
+                null,
+                timeoutInMS,
+            ),
         );
     }
 

--- a/src/powerquery-language-services/analysis/analysisSettings.ts
+++ b/src/powerquery-language-services/analysis/analysisSettings.ts
@@ -17,4 +17,5 @@ export interface AnalysisSettings {
         maybeTriedInspection: WorkspaceCache.CacheItem | undefined,
         createInspectionSettingsFn: () => InspectionSettings,
     ) => ISymbolProvider;
+    readonly symbolProviderTimeoutInMS?: number;
 }

--- a/src/test/analysis.ts
+++ b/src/test/analysis.ts
@@ -36,7 +36,7 @@ describe("Analysis", () => {
             TestUtils.assertHover(`[let-variable] Test.SquareIfNumber: logical`, hover);
         });
 
-        it(`timeout`, () => {
+        it(`timeout`, async () => {
             const analysisSettings: AnalysisSettings = {
                 ...TestConstants.SimpleLibraryAnalysisSettings,
                 maybeCreateLocalDocumentSymbolProviderFn: (
@@ -48,16 +48,17 @@ describe("Analysis", () => {
 
             const startTime: number = new Date().getTime();
 
-            return TestUtils.createHover(`${TestConstants.TestLibraryName.SquareIfNumber}|`, analysisSettings).then(
-                hover => {
-                    const stopTime: number = new Date().getTime();
-                    const totalMS: number = stopTime - startTime;
-
-                    TestUtils.assertHover(`[library function] Test.SquareIfNumber: (x: any) => any`, hover);
-
-                    expect(totalMS).to.be.lessThanOrEqual(500, `Did we timeout the hover request? [${totalMS}ms]`);
-                },
+            const hover: Hover = await TestUtils.createHover(
+                `${TestConstants.TestLibraryName.SquareIfNumber}|`,
+                analysisSettings,
             );
+
+            const stopTime: number = new Date().getTime();
+            const totalMS: number = stopTime - startTime;
+
+            TestUtils.assertHover(`[library function] Test.SquareIfNumber: (x: any) => any`, hover);
+
+            expect(totalMS).to.be.lessThanOrEqual(500, `Did we timeout the hover request? [${totalMS}ms]`);
         });
     });
 

--- a/src/test/analysis.ts
+++ b/src/test/analysis.ts
@@ -33,6 +33,31 @@ describe("Analysis", () => {
             expect(autocompleteItem.label === TestConstants.TestLibraryName.SquareIfNumber);
             expect(autocompleteItem.documentation).to.equal(undefined, "local definition should have no documentation");
         });
+
+        it(`timeout providers`, async () => {
+            const analysisSettings: AnalysisSettings = {
+                ...TestConstants.SimpleLibraryAnalysisSettings,
+                symbolProviderTimeoutInMS: 0, // immediate timeout
+                maybeCreateLocalDocumentSymbolProviderFn: (
+                    library: ILibrary,
+                    _maybeTriedInspection: WorkspaceCache.CacheItem | undefined,
+                    _createInspectionSettingsFn: () => InspectionSettings,
+                ) => new SlowSymbolProvider(library, 1000),
+                maybeCreateLibrarySymbolProviderFn: (library: ILibrary) => new SlowSymbolProvider(library, 1000),
+            };
+
+            const autocompleteItems: ReadonlyArray<AutocompleteItem> = await TestUtils.createAutocompleteItems(
+                `let ${TestConstants.TestLibraryName.SquareIfNumber} = true in ${TestConstants.TestLibraryName.SquareIfNumber}|`,
+                analysisSettings,
+            );
+
+            // TODO: The keyword/autocomplete provider runs synchronously and doesn't timeout.
+            const autocompleteItem: AutocompleteItem | undefined = autocompleteItems.find(
+                (item: AutocompleteItem) => item.label === TestConstants.TestLibraryName.SquareIfNumber,
+            );
+
+            expect(autocompleteItem).equals(undefined, "Didn't expect to find symbol");
+        });
     });
 
     describe(`getHoverItems`, () => {

--- a/src/test/analysis.ts
+++ b/src/test/analysis.ts
@@ -98,6 +98,23 @@ describe("Analysis", () => {
             };
             expect(actual).to.deep.equal(expected);
         });
+
+        it(`timeout`, async () => {
+            const analysisSettings: AnalysisSettings = {
+                ...TestConstants.SimpleLibraryAnalysisSettings,
+                symbolProviderTimeoutInMS: 0, // immediate timeout
+                maybeCreateLibrarySymbolProviderFn: (library: ILibrary) => new SlowSymbolProvider(library, 1000),
+            };
+
+            const signatureHelp: SignatureHelp = await TestUtils.createSignatureHelp(
+                `${TestConstants.TestLibraryName.SquareIfNumber}(|`,
+                analysisSettings,
+            );
+
+            // tslint:disable-next-line: no-null-keyword
+            expect(signatureHelp.activeParameter).equals(null, "Didn't expect to find symbol");
+            expect(signatureHelp.signatures.length).equals(0, "Didn't expect to find symbol");
+        });
     });
 });
 

--- a/src/test/providers/slowSymbolProvider.ts
+++ b/src/test/providers/slowSymbolProvider.ts
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import {
+    AutocompleteItemProviderContext,
+    Hover,
+    HoverProviderContext,
+    LibrarySymbolProvider,
+    SignatureHelp,
+    SignatureProviderContext,
+} from "../../powerquery-language-services";
+import { AutocompleteItem } from "../../powerquery-language-services/inspection";
+import { ILibrary } from "../../powerquery-language-services/library/library";
+
+export class SlowSymbolProvider extends LibrarySymbolProvider {
+    private readonly delayInMS: number;
+
+    constructor(library: ILibrary, delayInMS: number) {
+        super(library);
+        this.delayInMS = delayInMS;
+    }
+
+    public override async getAutocompleteItems(
+        context: AutocompleteItemProviderContext,
+    ): Promise<ReadonlyArray<AutocompleteItem>> {
+        await this.delay();
+        return super.getAutocompleteItems(context);
+    }
+
+    public async getHover(context: HoverProviderContext): Promise<Hover | null> {
+        await this.delay();
+        return super.getHover(context);
+    }
+
+    public async getSignatureHelp(context: SignatureProviderContext): Promise<SignatureHelp | null> {
+        await this.delay();
+        return super.getSignatureHelp(context);
+    }
+
+    private async delay(): Promise<void> {
+        return new Promise(resolve => {
+            setTimeout(() => {
+                resolve();
+            }, this.delayInMS);
+        });
+    }
+}


### PR DESCRIPTION
The symbol provider model was created with the following assumptions:

- We'll need to get symbols from multiple sources
- Certain sources will benefit from async calls
- Certain sources will take longer to resolve than others
- Sources might take longer to resolve than is reasonable for a decent intellisense experience

However, the current implementation using `Promise.all()` ensures that we'll wait until every symbol provider completes its work. We're currently hitting issues with intellisense for large/complex M files (ex. ~16s to resolve a Hover request for a library symbol), 

This change allows the consumer to set a timeout (`AnalysisSettings.symbolProviderTimeoutInMS`) for symbol provider activities. When the timeout is reached, the symbol provider returns an empty result. This allows the base analysis class to return symbols from providers that completed in time. 

Further improvements in this area would include:

- Tracing events when timeouts occur
- Preventing the timeout from occurring until at least one symbol provider has returned
- Better support for cancellation all around