### PR TITLE
Bug fix scope generation for overlapping recursive and non-recursive identifiers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.2.17",
+    "version": "0.2.18",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.2.17",
+    "version": "0.2.18",
     "author": "Microsoft",
     "license": "MIT",
     "scripts": {

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteItem/autocompleteItemUtils.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteItem/autocompleteItemUtils.ts
@@ -100,7 +100,6 @@ export function maybeCreateFromScopeItem(
                 return undefined;
             }
 
-            label = scopeItem.isRecursive ? `@${label}` : label;
             break;
         }
 

--- a/src/powerquery-language-services/inspection/scope/scopeInspection.ts
+++ b/src/powerquery-language-services/inspection/scope/scopeInspection.ts
@@ -389,7 +389,7 @@ function inspectSection(state: ScopeInspectionState, section: TXorNode): void {
     }
 }
 
-// Expands the scope of the value portion for each key value pair.
+// Expands the scope on the value part of the key value pair.
 function inspectKeyValuePairs<T extends TScopeItem, KVP extends NodeIdMapIterator.TKeyValuePair>(
     state: ScopeInspectionState,
     parentScope: NodeScope,

--- a/src/powerquery-language-services/inspection/type/inspectType/common.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/common.ts
@@ -484,13 +484,17 @@ function recursiveIdentifierDereferenceHelper(state: InspectTypeState, xorNode: 
             throw Assert.isNever(scopeItem);
     }
 
-    return maybeNextXorNode !== undefined &&
+    const result: TXorNode | undefined =
+        maybeNextXorNode !== undefined &&
         XorNodeUtils.isAstXorChecked<Ast.Identifier | Ast.IdentifierExpression>(maybeNextXorNode, [
             Ast.NodeKind.Identifier,
             Ast.NodeKind.IdentifierExpression,
         ])
-        ? recursiveIdentifierDereferenceHelper(state, maybeNextXorNode)
-        : xorNode;
+            ? recursiveIdentifierDereferenceHelper(state, maybeNextXorNode)
+            : xorNode;
+    trace.exit();
+
+    return result;
 }
 
 export function createParameterType(parameter: ParameterScopeItem): Type.TPrimitiveType {

--- a/src/powerquery-language-services/inspection/type/inspectType/common.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/common.ts
@@ -352,7 +352,15 @@ export function maybeDereferencedIdentifierType(
     const deferencedLiteral: string = maybeDereferencedLiteral;
 
     const nodeScope: NodeScope = assertGetOrCreateNodeScope(state, deferenced.node.id);
-    const maybeScopeItem: TScopeItem | undefined = nodeScope.get(deferencedLiteral);
+
+    // When referencing an identifier as a recursive identifier there's no requirements
+    // for it to resolve to a recursive reference.
+    // This if it's a recursive identifier we need to also try the identifier without the recursive `@` prefix.
+    let maybeScopeItem: TScopeItem | undefined = nodeScope.get(deferencedLiteral);
+    if (deferencedLiteral.startsWith("@") && maybeScopeItem === undefined) {
+        maybeScopeItem = nodeScope.get(deferencedLiteral.slice(1));
+    }
+
     // The deferenced identifier can't be resolved within the local scope.
     // It either is either an invalid identifier or an external identifier (e.g `Odbc.Database`).
     if (maybeScopeItem === undefined) {
@@ -450,16 +458,10 @@ function recursiveIdentifierDereferenceHelper(state: InspectTypeState, xorNode: 
             throw Assert.isNever(identifier);
     }
 
-    // TODO: handle recursive identifiers
-    if (isRecursiveIdentifier === true) {
-        trace.exit({ [TraceConstant.Result]: "recursive identifier" });
-
-        return xorNode;
-    }
-
     const nodeScope: NodeScope = assertGetOrCreateNodeScope(state, identifierId);
-
-    const maybeScopeItem: TScopeItem | undefined = nodeScope.get(identifierLiteral);
+    const maybeScopeItem: TScopeItem | undefined = nodeScope.get(
+        isRecursiveIdentifier ? `@${identifierLiteral}` : identifierLiteral,
+    );
     if (maybeScopeItem === undefined) {
         return xorNode;
     }

--- a/src/test/inspection/scope.ts
+++ b/src/test/inspection/scope.ts
@@ -435,7 +435,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[a=1|]`);
                 const expected: AbridgedNodeScope = [
                     {
-                        identifier: "a",
+                        identifier: "@a",
                         kind: Inspection.ScopeItemKind.RecordField,
                         isRecursive: true,
                         keyNodeId: 8,
@@ -459,7 +459,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                         maybeValueNodeId: 12,
                     },
                     {
-                        identifier: "b",
+                        identifier: "@b",
                         kind: Inspection.ScopeItemKind.RecordField,
                         isRecursive: true,
                         keyNodeId: 16,
@@ -483,7 +483,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                         maybeValueNodeId: 12,
                     },
                     {
-                        identifier: "b",
+                        identifier: "@b",
                         kind: Inspection.ScopeItemKind.RecordField,
                         isRecursive: true,
                         keyNodeId: 16,
@@ -516,7 +516,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[a=[|b=1]]`);
                 const expected: AbridgedNodeScope = [
                     {
-                        identifier: "a",
+                        identifier: "@a",
                         kind: Inspection.ScopeItemKind.RecordField,
                         isRecursive: true,
                         keyNodeId: 8,
@@ -553,7 +553,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[a=|1`);
                 const expected: AbridgedNodeScope = [
                     {
-                        identifier: "a",
+                        identifier: "@a",
                         kind: Inspection.ScopeItemKind.RecordField,
                         isRecursive: true,
                         keyNodeId: 8,
@@ -570,7 +570,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[a=1|`);
                 const expected: AbridgedNodeScope = [
                     {
-                        identifier: "a",
+                        identifier: "@a",
                         kind: Inspection.ScopeItemKind.RecordField,
                         isRecursive: true,
                         keyNodeId: 8,
@@ -594,7 +594,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                         maybeValueNodeId: 12,
                     },
                     {
-                        identifier: "b",
+                        identifier: "@b",
                         kind: Inspection.ScopeItemKind.RecordField,
                         isRecursive: true,
                         keyNodeId: 16,
@@ -618,7 +618,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                         maybeValueNodeId: 12,
                     },
                     {
-                        identifier: "b",
+                        identifier: "@b",
                         kind: Inspection.ScopeItemKind.RecordField,
                         isRecursive: true,
                         keyNodeId: 16,
@@ -642,7 +642,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[a=[|b=1`);
                 const expected: AbridgedNodeScope = [
                     {
-                        identifier: "a",
+                        identifier: "@a",
                         kind: Inspection.ScopeItemKind.RecordField,
                         isRecursive: true,
                         keyNodeId: 8,
@@ -659,14 +659,14 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[a=[b=|`);
                 const expected: AbridgedNodeScope = [
                     {
-                        identifier: "a",
+                        identifier: "@a",
                         kind: Inspection.ScopeItemKind.RecordField,
                         isRecursive: true,
                         keyNodeId: 8,
                         maybeValueNodeId: 10,
                     },
                     {
-                        identifier: "b",
+                        identifier: "@b",
                         kind: Inspection.ScopeItemKind.RecordField,
                         isRecursive: true,
                         keyNodeId: 17,
@@ -696,7 +696,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                     TestUtils.assertGetTextWithPosition(`section foo; x = 1|; y = 2;`);
                 const expected: AbridgedNodeScope = [
                     {
-                        identifier: "x",
+                        identifier: "@x",
                         kind: Inspection.ScopeItemKind.SectionMember,
                         isRecursive: true,
                         keyNodeId: 8,
@@ -728,7 +728,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                         maybeValueNodeId: 12,
                     },
                     {
-                        identifier: "y",
+                        identifier: "@y",
                         kind: Inspection.ScopeItemKind.SectionMember,
                         isRecursive: true,
                         keyNodeId: 16,
@@ -771,7 +771,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                         maybeValueNodeId: 20,
                     },
                     {
-                        identifier: "z",
+                        identifier: "@z",
                         kind: Inspection.ScopeItemKind.SectionMember,
                         isRecursive: true,
                         keyNodeId: 24,
@@ -808,7 +808,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                     TestUtils.assertGetTextWithPosition(`section foo; x = 1|; y = 2`);
                 const expected: AbridgedNodeScope = [
                     {
-                        identifier: "x",
+                        identifier: "@x",
                         kind: Inspection.ScopeItemKind.SectionMember,
                         isRecursive: true,
                         keyNodeId: 8,
@@ -840,7 +840,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                         maybeValueNodeId: 12,
                     },
                     {
-                        identifier: "y",
+                        identifier: "@y",
                         kind: Inspection.ScopeItemKind.SectionMember,
                         isRecursive: true,
                         keyNodeId: 16,
@@ -866,7 +866,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                         maybeValueNodeId: 12,
                     },
                     {
-                        identifier: "y",
+                        identifier: "@y",
                         kind: Inspection.ScopeItemKind.SectionMember,
                         isRecursive: true,
                         keyNodeId: 16,
@@ -919,7 +919,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = |1 in x`);
                 const expected: AbridgedNodeScope = [
                     {
-                        identifier: "a",
+                        identifier: "@a",
                         kind: Inspection.ScopeItemKind.LetVariable,
                         isRecursive: true,
                         keyNodeId: 6,
@@ -962,7 +962,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                     TestUtils.assertGetTextWithPosition(`let a = 1|, b = 2 in x`);
                 const expected: AbridgedNodeScope = [
                     {
-                        identifier: "a",
+                        identifier: "@a",
                         kind: Inspection.ScopeItemKind.LetVariable,
                         isRecursive: true,
                         keyNodeId: 6,
@@ -1018,7 +1018,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                         maybeValueNodeId: 31,
                     },
                     {
-                        identifier: "c",
+                        identifier: "@c",
                         kind: Inspection.ScopeItemKind.LetVariable,
                         isRecursive: true,
                         keyNodeId: 35,
@@ -1070,7 +1070,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 );
                 const expected: AbridgedNodeScope = [
                     {
-                        identifier: "eggs",
+                        identifier: "@eggs",
                         kind: Inspection.ScopeItemKind.LetVariable,
                         isRecursive: true,
                         keyNodeId: 6,
@@ -1153,7 +1153,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                     TestUtils.assertGetTextWithPosition(`let a = 1|, b = 2 in `);
                 const expected: AbridgedNodeScope = [
                     {
-                        identifier: "a",
+                        identifier: "@a",
                         kind: Inspection.ScopeItemKind.LetVariable,
                         isRecursive: true,
                         keyNodeId: 6,
@@ -1178,7 +1178,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                     TestUtils.assertGetTextWithPosition(`let x = (let y = 1 in z|) in`);
                 const expected: AbridgedNodeScope = [
                     {
-                        identifier: "x",
+                        identifier: "@x",
                         kind: Inspection.ScopeItemKind.LetVariable,
                         isRecursive: true,
                         keyNodeId: 6,

--- a/src/test/inspection/type.ts
+++ b/src/test/inspection/type.ts
@@ -775,6 +775,46 @@ describe(`Inspection - Type`, () => {
             });
         });
 
+        describe(`Recursive identifiers`, () => {
+            it(`let foo = 1 in [foo = foo, bar = foo]`, () => {
+                const expression: string = `let foo = 1 in [foo = foo, bar = foo]`;
+                const expected: Type.DefinedRecord = TypeUtils.createDefinedRecord(
+                    false,
+                    new Map([
+                        ["foo", TypeUtils.createNumberLiteral(false, 1)],
+                        ["bar", TypeUtils.createNumberLiteral(false, 1)],
+                    ]),
+                    false,
+                );
+                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+            });
+
+            it(`let someIdentifier = 1, result = let someIdentifier = 2 in [ outer = someIdentifier, inner = @someIdentifier ] in result`, () => {
+                const expression: string = `
+    let
+        someIdentifier = 1,
+        result =
+            let
+                someIdentifier = 2
+            in
+                [
+                    outer = someIdentifier,
+                    inner = @someIdentifier
+                ]
+in
+    result`;
+                const expected: Type.DefinedRecord = TypeUtils.createDefinedRecord(
+                    false,
+                    new Map([
+                        ["outer", TypeUtils.createNumberLiteral(false, 2)],
+                        ["inner", TypeUtils.createNumberLiteral(false, 2)],
+                    ]),
+                    false,
+                );
+                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+            });
+        });
+
         describe(`${Ast.NodeKind.TableType}`, () => {
             it(`type table [foo]`, () => {
                 const expression: string = `type table [foo]`;

--- a/src/test/inspection/type.ts
+++ b/src/test/inspection/type.ts
@@ -616,6 +616,16 @@ describe(`Inspection - Type`, () => {
                 assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
+            it(`let foo = 1 in [foo = foo]`, () => {
+                const expression: string = `let foo = 1 in [foo = foo]`;
+                const expected: Type.DefinedRecord = TypeUtils.createDefinedRecord(
+                    false,
+                    new Map([["foo", TypeUtils.createNumberLiteral(false, "1")]]),
+                    false,
+                );
+                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+            });
+
             it(`[] & [bar = 2]`, () => {
                 const expression: string = `[] & [bar = 2]`;
                 const expected: Type.DefinedRecord = TypeUtils.createDefinedRecord(

--- a/src/test/inspection/type.ts
+++ b/src/test/inspection/type.ts
@@ -616,16 +616,6 @@ describe(`Inspection - Type`, () => {
                 assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`let foo = 1 in [foo = foo]`, () => {
-                const expression: string = `let foo = 1 in [foo = foo]`;
-                const expected: Type.DefinedRecord = TypeUtils.createDefinedRecord(
-                    false,
-                    new Map([["foo", TypeUtils.createNumberLiteral(false, "1")]]),
-                    false,
-                );
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
-            });
-
             it(`[] & [bar = 2]`, () => {
                 const expression: string = `[] & [bar = 2]`;
                 const expected: Type.DefinedRecord = TypeUtils.createDefinedRecord(
@@ -776,6 +766,16 @@ describe(`Inspection - Type`, () => {
         });
 
         describe(`Recursive identifiers`, () => {
+            it(`let foo = 1 in [foo = foo]`, () => {
+                const expression: string = `let foo = 1 in [foo = foo]`;
+                const expected: Type.DefinedRecord = TypeUtils.createDefinedRecord(
+                    false,
+                    new Map([["foo", TypeUtils.createNumberLiteral(false, "1")]]),
+                    false,
+                );
+                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+            });
+
             it(`let foo = 1 in [foo = foo, bar = foo]`, () => {
                 const expression: string = `let foo = 1 in [foo = foo, bar = foo]`;
                 const expected: Type.DefinedRecord = TypeUtils.createDefinedRecord(


### PR DESCRIPTION
`let foo = 1 in [foo = foo]` evaluates to the record `[foo = 1]`. Currently this creates an infinite recursion in the type inspection. This is a side effect of how recursive identifiers were partially disabled/not-yet-implemented.