### PR TITLE
Explicit argument generic in XChecked functions

### DIFF
--- a/src/powerquery-language-services/inspection/activeNode/activeNodeUtils.ts
+++ b/src/powerquery-language-services/inspection/activeNode/activeNodeUtils.ts
@@ -260,17 +260,15 @@ function maybeFindAstNodes(nodeIdMapCollection: NodeIdMap.Collection, position: 
                 | Ast.RecordLiteral
                 | Ast.ListExpression
                 | Ast.ListLiteral
-                | Ast.InvokeExpression = NodeIdMapUtils.assertUnboxParentAstChecked(
-                nodeIdMapCollection,
-                currentOnOrBefore.id,
-                [
-                    Ast.NodeKind.RecordExpression,
-                    Ast.NodeKind.RecordLiteral,
-                    Ast.NodeKind.ListExpression,
-                    Ast.NodeKind.ListLiteral,
-                    Ast.NodeKind.InvokeExpression,
-                ],
-            );
+                | Ast.InvokeExpression = NodeIdMapUtils.assertUnboxParentAstChecked<
+                Ast.RecordExpression | Ast.RecordLiteral | Ast.ListExpression | Ast.ListLiteral | Ast.InvokeExpression
+            >(nodeIdMapCollection, currentOnOrBefore.id, [
+                Ast.NodeKind.RecordExpression,
+                Ast.NodeKind.RecordLiteral,
+                Ast.NodeKind.ListExpression,
+                Ast.NodeKind.ListLiteral,
+                Ast.NodeKind.InvokeExpression,
+            ]);
 
             const arrayWrapper: Ast.TArrayWrapper = NodeIdMapUtils.assertUnboxArrayWrapperAst(
                 nodeIdMapCollection,

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteFieldAccess.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteFieldAccess.ts
@@ -237,11 +237,12 @@ function inspectFieldSelector(
 
     const generalizedIdentifierId: number = childIds[1];
 
-    const generalizedIdentifierXor: XorNode<Ast.GeneralizedIdentifier> = NodeIdMapUtils.assertGetXorChecked(
-        nodeIdMapCollection,
-        generalizedIdentifierId,
-        Ast.NodeKind.GeneralizedIdentifier,
-    );
+    const generalizedIdentifierXor: XorNode<Ast.GeneralizedIdentifier> =
+        NodeIdMapUtils.assertGetXorChecked<Ast.GeneralizedIdentifier>(
+            nodeIdMapCollection,
+            generalizedIdentifierId,
+            Ast.NodeKind.GeneralizedIdentifier,
+        );
 
     switch (generalizedIdentifierXor.kind) {
         case PQP.Parser.XorNodeKind.Ast: {
@@ -259,7 +260,7 @@ function inspectFieldSelector(
             // TODO [Autocomplete]:
             // This doesn't take into account of generalized identifiers consisting of multiple tokens.
             // Eg. `foo[bar baz]` or `foo[#"bar baz"].
-            const openBracketConstant: Ast.TConstant = NodeIdMapUtils.assertUnboxNthChildAsAstChecked(
+            const openBracketConstant: Ast.TConstant = NodeIdMapUtils.assertUnboxNthChildAsAstChecked<Ast.TConstant>(
                 nodeIdMapCollection,
                 fieldSelector.node.id,
                 0,

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordIdentifierPairedExpression.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordIdentifierPairedExpression.ts
@@ -16,7 +16,11 @@ export function autocompleteKeywordIdentifierPairedExpression(
     // `section; [] |`
     if (
         childAttributeIndex === 0 &&
-        AncestryUtils.maybeNextXorChecked(state.activeNode.ancestry, state.ancestryIndex, Ast.NodeKind.SectionMember)
+        AncestryUtils.maybeNextXorChecked<Ast.SectionMember>(
+            state.activeNode.ancestry,
+            state.ancestryIndex,
+            Ast.NodeKind.SectionMember,
+        )
     ) {
         return [Keyword.KeywordKind.Shared];
     } else if (childAttributeIndex !== 2) {

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordSectionMember.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordSectionMember.ts
@@ -61,7 +61,7 @@ export function autocompleteKeywordSectionMember(
     // The autocomplete should be for the IdentifierPairedExpression found on the previous child index.
     else if (maybeChildAttributeIndex === 3 && XorNodeUtils.isContextXor(state.child)) {
         const identifierPairedExpression: Ast.IdentifierPairedExpression =
-            NodeIdMapUtils.assertUnboxNthChildAsAstChecked(
+            NodeIdMapUtils.assertUnboxNthChildAsAstChecked<Ast.IdentifierPairedExpression>(
                 state.nodeIdMapCollection,
                 state.parent.node.id,
                 2,

--- a/src/powerquery-language-services/inspection/autocomplete/autocompletePrimitiveType.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompletePrimitiveType.ts
@@ -69,7 +69,7 @@ function traverseAncestors(activeNode: ActiveNode): ReadonlyArray<Constant.Primi
         // If the node is a context PrimitiveType node,
         // which is created only when a primitive type was expected but there was nothing to parse.
         // `x as |`
-        if (XorNodeUtils.isContextXorChecked(parent, Ast.NodeKind.PrimitiveType)) {
+        if (XorNodeUtils.isContextXorChecked<Ast.PrimitiveType>(parent, Ast.NodeKind.PrimitiveType)) {
             return Constant.PrimitiveTypeConstants;
         }
         // If on the second attribute for TypePrimaryType.
@@ -88,7 +88,12 @@ function traverseAncestors(activeNode: ActiveNode): ReadonlyArray<Constant.Primi
         // If on a FunctionExpression parameter.
         else if (
             parent.node.kind === Ast.NodeKind.Parameter &&
-            AncestryUtils.maybeNthNextXorChecked(ancestry, index, 4, Ast.NodeKind.FunctionExpression) !== undefined
+            AncestryUtils.maybeNthNextXorChecked<Ast.FunctionExpression>(
+                ancestry,
+                index,
+                4,
+                Ast.NodeKind.FunctionExpression,
+            ) !== undefined
         ) {
             // Things get messy when testing if it's on a nullable primitive type OR a primitive type.
             const maybeGrandchild: TXorNode | undefined = AncestryUtils.maybeNthPreviousXor(ancestry, index, 2);
@@ -110,7 +115,12 @@ function traverseAncestors(activeNode: ActiveNode): ReadonlyArray<Constant.Primi
             else if (
                 maybeGrandchild.node.kind === Ast.NodeKind.NullablePrimitiveType &&
                 // Check the great grandchild
-                AncestryUtils.maybeNthPreviousXorChecked(ancestry, index, 3, Ast.NodeKind.PrimitiveType)
+                AncestryUtils.maybeNthPreviousXorChecked<Ast.PrimitiveType>(
+                    ancestry,
+                    index,
+                    3,
+                    Ast.NodeKind.PrimitiveType,
+                )
             ) {
                 return Constant.PrimitiveTypeConstants;
             }

--- a/src/powerquery-language-services/inspection/invokeExpression/currentInvokeExpression.ts
+++ b/src/powerquery-language-services/inspection/invokeExpression/currentInvokeExpression.ts
@@ -115,7 +115,7 @@ function getArgumentOrdinal(
     invokeExpressionXorNode: TXorNode,
 ): number {
     // `foo(1|)
-    const maybeAncestoryCsv: TXorNode | undefined = AncestryUtils.maybeNthPreviousXorChecked(
+    const maybeAncestoryCsv: TXorNode | undefined = AncestryUtils.maybeNthPreviousXorChecked<Ast.TCsv>(
         activeNode.ancestry,
         ancestryIndex,
         2,
@@ -126,22 +126,20 @@ function getArgumentOrdinal(
         return maybeAncestoryCsv.node.maybeAttributeIndex ?? 0;
     }
 
-    const maybePreviousXor: TXorNode | undefined = AncestryUtils.maybePreviousXorChecked(
-        activeNode.ancestry,
-        ancestryIndex,
-        [
-            // `foo(|)`
-            Ast.NodeKind.ArrayWrapper,
-            // `foo(1|`
-            Ast.NodeKind.Constant,
-        ],
-    );
+    const maybePreviousXor: TXorNode | undefined = AncestryUtils.maybePreviousXorChecked<
+        Ast.TArrayWrapper | Ast.TConstant
+    >(activeNode.ancestry, ancestryIndex, [
+        // `foo(|)`
+        Ast.NodeKind.ArrayWrapper,
+        // `foo(1|`
+        Ast.NodeKind.Constant,
+    ]);
 
     let arrayWrapperXorNode: TXorNode;
 
     switch (maybePreviousXor?.node.kind) {
         case Ast.NodeKind.Constant: {
-            arrayWrapperXorNode = NodeIdMapUtils.assertGetNthChildChecked(
+            arrayWrapperXorNode = NodeIdMapUtils.assertGetNthChildChecked<Ast.TArrayWrapper>(
                 nodeIdMapCollection,
                 invokeExpressionXorNode.node.id,
                 1,

--- a/src/powerquery-language-services/inspection/pseudoFunctionExpressionType.ts
+++ b/src/powerquery-language-services/inspection/pseudoFunctionExpressionType.ts
@@ -59,12 +59,13 @@ export function pseudoFunctionExpressionType(
         }
     }
 
-    const maybeReturnType: Ast.AsNullablePrimitiveType | undefined = NodeIdMapUtils.maybeUnboxNthChildIfAstChecked(
-        nodeIdMapCollection,
-        fnExpr.node.id,
-        1,
-        Ast.NodeKind.AsNullablePrimitiveType,
-    );
+    const maybeReturnType: Ast.AsNullablePrimitiveType | undefined =
+        NodeIdMapUtils.maybeUnboxNthChildIfAstChecked<Ast.AsNullablePrimitiveType>(
+            nodeIdMapCollection,
+            fnExpr.node.id,
+            1,
+            Ast.NodeKind.AsNullablePrimitiveType,
+        );
 
     let isReturnNullable: boolean;
     let returnType: Type.TypeKind;

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFieldProjection.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFieldProjection.ts
@@ -37,7 +37,7 @@ export function inspectTypeFieldProjection(state: InspectTypeState, xorNode: TXo
     const previousSiblingType: Type.TPowerQueryType = inspectXor(state, previousSibling);
 
     const isOptional: boolean =
-        NodeIdMapUtils.maybeUnboxNthChildIfAstChecked(
+        NodeIdMapUtils.maybeUnboxNthChildIfAstChecked<Ast.TConstant>(
             state.nodeIdMapCollection,
             xorNode.node.id,
             3,

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFieldSelector.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFieldSelector.ts
@@ -19,11 +19,12 @@ export function inspectTypeFieldSelector(state: InspectTypeState, xorNode: TXorN
     state.maybeCancellationToken?.throwIfCancelled();
     XorNodeUtils.assertIsNodeKind<Ast.FieldSelector>(xorNode, Ast.NodeKind.FieldSelector);
 
-    const maybeFieldName: Ast.GeneralizedIdentifier | undefined = NodeIdMapUtils.maybeUnboxWrappedContentIfAstChecked(
-        state.nodeIdMapCollection,
-        xorNode.node.id,
-        Ast.NodeKind.GeneralizedIdentifier,
-    );
+    const maybeFieldName: Ast.GeneralizedIdentifier | undefined =
+        NodeIdMapUtils.maybeUnboxWrappedContentIfAstChecked<Ast.GeneralizedIdentifier>(
+            state.nodeIdMapCollection,
+            xorNode.node.id,
+            Ast.NodeKind.GeneralizedIdentifier,
+        );
 
     if (maybeFieldName === undefined) {
         trace.exit({ [TraceConstant.Result]: TraceUtils.createTypeDetails(Type.UnknownInstance) });
@@ -41,7 +42,7 @@ export function inspectTypeFieldSelector(state: InspectTypeState, xorNode: TXorN
     const previousSiblingType: Type.TPowerQueryType = inspectXor(state, previousSibling);
 
     const isOptional: boolean =
-        NodeIdMapUtils.maybeUnboxNthChildIfAstChecked(
+        NodeIdMapUtils.maybeUnboxNthChildIfAstChecked<Ast.TConstant>(
             state.nodeIdMapCollection,
             xorNode.node.id,
             3,

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeInvokeExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeInvokeExpression.ts
@@ -8,6 +8,7 @@ import {
     NodeIdMapIterator,
     NodeIdMapUtils,
     TXorNode,
+    XorNode,
     XorNodeUtils,
 } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 import { Trace, TraceConstant } from "@microsoft/powerquery-parser/lib/powerquery-parser/common/trace";
@@ -70,10 +71,8 @@ function maybeExternalInvokeRequest(
     state: InspectTypeState,
     xorNode: TXorNode,
 ): ExternalType.ExternalInvocationTypeRequest | undefined {
-    const maybeIdentifier: TXorNode | undefined = NodeIdMapUtils.maybeInvokeExpressionIdentifier(
-        state.nodeIdMapCollection,
-        xorNode.node.id,
-    );
+    const maybeIdentifier: XorNode<Ast.IdentifierExpression> | undefined =
+        NodeIdMapUtils.maybeInvokeExpressionIdentifier(state.nodeIdMapCollection, xorNode.node.id);
 
     if (maybeIdentifier === undefined) {
         return undefined;

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeNullCoalescingExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeNullCoalescingExpression.ts
@@ -20,12 +20,13 @@ export function inspectTypeNullCoalescingExpression(state: InspectTypeState, xor
 
     const maybeLeftType: Type.TPowerQueryType = inspectTypeFromChildAttributeIndex(state, xorNode, 0);
 
-    const maybeNullCoalescingOperator: Ast.TConstant | undefined = NodeIdMapUtils.maybeUnboxNthChildIfAstChecked(
-        state.nodeIdMapCollection,
-        xorNode.node.id,
-        1,
-        Ast.NodeKind.Constant,
-    );
+    const maybeNullCoalescingOperator: Ast.TConstant | undefined =
+        NodeIdMapUtils.maybeUnboxNthChildIfAstChecked<Ast.TConstant>(
+            state.nodeIdMapCollection,
+            xorNode.node.id,
+            1,
+            Ast.NodeKind.Constant,
+        );
 
     let result: Type.TPowerQueryType;
 

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeParameter.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeParameter.ts
@@ -18,12 +18,13 @@ export function inspectTypeParameter(state: InspectTypeState, xorNode: TXorNode)
     state.maybeCancellationToken?.throwIfCancelled();
     XorNodeUtils.assertIsNodeKind<Ast.TParameter>(xorNode, Ast.NodeKind.Parameter);
 
-    const maybeOptionalConstant: Ast.TConstant | undefined = NodeIdMapUtils.maybeUnboxNthChildIfAstChecked(
-        state.nodeIdMapCollection,
-        xorNode.node.id,
-        0,
-        Ast.NodeKind.Constant,
-    );
+    const maybeOptionalConstant: Ast.TConstant | undefined =
+        NodeIdMapUtils.maybeUnboxNthChildIfAstChecked<Ast.TConstant>(
+            state.nodeIdMapCollection,
+            xorNode.node.id,
+            0,
+            Ast.NodeKind.Constant,
+        );
 
     const maybeParameterType: Type.TPowerQueryType | undefined = TypeUtils.assertAsTPrimitiveType(
         inspectTypeFromChildAttributeIndex(state, xorNode, 2),

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRecordType.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRecordType.ts
@@ -19,7 +19,7 @@ export function inspectTypeRecordType(state: InspectTypeState, xorNode: TXorNode
     state.maybeCancellationToken?.throwIfCancelled();
     XorNodeUtils.assertIsNodeKind<Ast.RecordType>(xorNode, Ast.NodeKind.RecordType);
 
-    const maybeFields: TXorNode | undefined = NodeIdMapUtils.maybeNthChildChecked(
+    const maybeFields: TXorNode | undefined = NodeIdMapUtils.maybeNthChildChecked<Ast.FieldSpecificationList>(
         state.nodeIdMapCollection,
         xorNode.node.id,
         0,

--- a/src/powerquery-language-services/providers/localDocumentSymbolProvider.ts
+++ b/src/powerquery-language-services/providers/localDocumentSymbolProvider.ts
@@ -130,15 +130,15 @@ export class LocalDocumentSymbolProvider implements ISymbolProvider {
             return undefined;
         }
 
-        const maybeIdentifierPairedExpression: TXorNode | undefined = AncestryUtils.maybeNthXorChecked(
-            activeNode.ancestry,
-            1,
-            [
-                Ast.NodeKind.GeneralizedIdentifierPairedAnyLiteral,
-                Ast.NodeKind.GeneralizedIdentifierPairedExpression,
-                Ast.NodeKind.IdentifierPairedExpression,
-            ],
-        );
+        const maybeIdentifierPairedExpression: TXorNode | undefined = AncestryUtils.maybeNthXorChecked<
+            | Ast.GeneralizedIdentifierPairedAnyLiteral
+            | Ast.GeneralizedIdentifierPairedExpression
+            | Ast.IdentifierPairedExpression
+        >(activeNode.ancestry, 1, [
+            Ast.NodeKind.GeneralizedIdentifierPairedAnyLiteral,
+            Ast.NodeKind.GeneralizedIdentifierPairedExpression,
+            Ast.NodeKind.IdentifierPairedExpression,
+        ]);
 
         // We're on an identifier in some other context which we don't support.
         if (maybeIdentifierPairedExpression === undefined) {


### PR DESCRIPTION
This has no functional differences and currently only makes things uglier, but it provides more type safety. Ideally this should be a linting rule.