### PR TITLE
Make inspection async

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
         "@typescript-eslint/await-thenable": "error",
         "@typescript-eslint/consistent-type-assertions": ["warn", { assertionStyle: "as" }],
         "@typescript-eslint/explicit-function-return-type": "error",
+        "@typescript-eslint/no-floating-promises": "error",
         "@typescript-eslint/no-inferrable-types": "off",
         "@typescript-eslint/no-namespace": "error",
         "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,9 @@
                 "999999",
                 "-r",
                 "ts-node/register",
-                "${workspaceFolder}/src/test/**/*.ts"
+                "${workspaceFolder}/src/test/**/*.ts",
+                "-g",
+                "WIP"
             ],
             "internalConsoleOptions": "openOnSessionStart"
         }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,9 +15,7 @@
                 "999999",
                 "-r",
                 "ts-node/register",
-                "${workspaceFolder}/src/test/**/*.ts",
-                "-g",
-                "WIP"
+                "${workspaceFolder}/src/test/**/*.ts"
             ],
             "internalConsoleOptions": "openOnSessionStart"
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
             "license": "MIT",
             "dependencies": {
                 "@microsoft/powerquery-formatter": "0.0.44",
-                "@microsoft/powerquery-parser": "0.5.22",
                 "vscode-languageserver-textdocument": "1.0.3",
                 "vscode-languageserver-types": "3.16.0"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
             "version": "0.2.20",
             "license": "MIT",
             "dependencies": {
-                "@microsoft/powerquery-formatter": "0.0.44",
+                "@microsoft/powerquery-formatter": "0.0.45",
+                "@microsoft/powerquery-parser": "0.6.2",
                 "vscode-languageserver-textdocument": "1.0.3",
                 "vscode-languageserver-types": "3.16.0"
             },
@@ -123,17 +124,17 @@
             "dev": true
         },
         "node_modules/@microsoft/powerquery-formatter": {
-            "version": "0.0.44",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.0.44.tgz",
-            "integrity": "sha512-0TaLY7ESZpGl93EmjX2xwe54JrJCzOLx6ocSiEqzvipDsKSDMByPNwbwAjLQBRtAOneHnIFeie/Yij/TKX3FWw==",
+            "version": "0.0.45",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.0.45.tgz",
+            "integrity": "sha512-TxSkbLLESPnRSNhQzegVvNRilQbYU/Ian8+NdauWzoa8V2WUZwYoJKKBWQ7ElKUNTUXhFPfveXJCLt1DvFA2lQ==",
             "dependencies": {
-                "@microsoft/powerquery-parser": "0.5.22"
+                "@microsoft/powerquery-parser": "0.6.2"
             }
         },
         "node_modules/@microsoft/powerquery-parser": {
-            "version": "0.5.22",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.5.22.tgz",
-            "integrity": "sha512-g95pCUYpPp+iLF+le5UKhXmo88Baerw1sxCTKNXUw7bl5i7vMpr8xm8WIQn/bGiBOjnM7QFvO9GQb2j3/ePawA==",
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.6.2.tgz",
+            "integrity": "sha512-iy1CGdPmkSlZyZktaH5p0+CQWTOGj4JHhrEWu6qVJOOSXFImG8amSgLbWszZ07KniWQpvqyg50PWlMVC4+b58Q==",
             "dependencies": {
                 "grapheme-splitter": "^1.0.4",
                 "performance-now": "^2.1.0"
@@ -2926,17 +2927,17 @@
             "dev": true
         },
         "@microsoft/powerquery-formatter": {
-            "version": "0.0.44",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.0.44.tgz",
-            "integrity": "sha512-0TaLY7ESZpGl93EmjX2xwe54JrJCzOLx6ocSiEqzvipDsKSDMByPNwbwAjLQBRtAOneHnIFeie/Yij/TKX3FWw==",
+            "version": "0.0.45",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.0.45.tgz",
+            "integrity": "sha512-TxSkbLLESPnRSNhQzegVvNRilQbYU/Ian8+NdauWzoa8V2WUZwYoJKKBWQ7ElKUNTUXhFPfveXJCLt1DvFA2lQ==",
             "requires": {
-                "@microsoft/powerquery-parser": "0.5.22"
+                "@microsoft/powerquery-parser": "0.6.2"
             }
         },
         "@microsoft/powerquery-parser": {
-            "version": "0.5.22",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.5.22.tgz",
-            "integrity": "sha512-g95pCUYpPp+iLF+le5UKhXmo88Baerw1sxCTKNXUw7bl5i7vMpr8xm8WIQn/bGiBOjnM7QFvO9GQb2j3/ePawA==",
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.6.2.tgz",
+            "integrity": "sha512-iy1CGdPmkSlZyZktaH5p0+CQWTOGj4JHhrEWu6qVJOOSXFImG8amSgLbWszZ07KniWQpvqyg50PWlMVC4+b58Q==",
             "requires": {
                 "grapheme-splitter": "^1.0.4",
                 "performance-now": "^2.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.2.20",
+    "version": "0.3.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/powerquery-language-services",
-            "version": "0.2.20",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/powerquery-formatter": "0.0.45",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.2.20",
+    "version": "0.3.0",
     "author": "Microsoft",
     "license": "MIT",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
         "typescript": "4.5.4"
     },
     "dependencies": {
-        "@microsoft/powerquery-formatter": "0.0.44",
+        "@microsoft/powerquery-formatter": "0.0.45",
+        "@microsoft/powerquery-parser": "0.6.2",
         "vscode-languageserver-textdocument": "1.0.3",
         "vscode-languageserver-types": "3.16.0"
     },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     },
     "dependencies": {
         "@microsoft/powerquery-formatter": "0.0.44",
-        "@microsoft/powerquery-parser": "0.5.22",
         "vscode-languageserver-textdocument": "1.0.3",
         "vscode-languageserver-types": "3.16.0"
     },

--- a/src/powerquery-language-services/analysis/analysisSettings.ts
+++ b/src/powerquery-language-services/analysis/analysisSettings.ts
@@ -3,8 +3,8 @@
 
 import { AutocompleteItemProvider, ISymbolProvider } from "../providers/commonTypes";
 import { ILibrary } from "../library/library";
+import { Inspection } from "..";
 import { InspectionSettings } from "../inspectionSettings";
-import { WorkspaceCache } from "../workspaceCache";
 
 export interface AnalysisSettings {
     readonly createInspectionSettingsFn: () => InspectionSettings;
@@ -14,7 +14,7 @@ export interface AnalysisSettings {
     readonly maybeCreateLibrarySymbolProviderFn?: (library: ILibrary) => ISymbolProvider;
     readonly maybeCreateLocalDocumentSymbolProviderFn?: (
         library: ILibrary,
-        maybeTriedInspection: WorkspaceCache.CacheItem | undefined,
+        promiseMaybeInspection: Promise<Inspection.Inspection | undefined>,
         createInspectionSettingsFn: () => InspectionSettings,
     ) => ISymbolProvider;
     readonly symbolProviderTimeoutInMS?: number;

--- a/src/powerquery-language-services/analysis/documentAnalysis.ts
+++ b/src/powerquery-language-services/analysis/documentAnalysis.ts
@@ -4,20 +4,19 @@
 import type { Position, Range } from "vscode-languageserver-types";
 import type { TextDocument } from "vscode-languageserver-textdocument";
 
-import { WorkspaceCache, WorkspaceCacheUtils } from "../workspaceCache";
 import { AnalysisBase } from "./analysisBase";
 import { AnalysisSettings } from "./analysisSettings";
+import { WorkspaceCacheUtils } from "../workspaceCache";
 
 export class DocumentAnalysis extends AnalysisBase {
     constructor(private readonly textDocument: TextDocument, analysisSettings: AnalysisSettings, position: Position) {
         super(
             analysisSettings,
-            WorkspaceCacheUtils.getOrCreateInspection(
+            WorkspaceCacheUtils.getOrCreateInspectionPromise(
                 textDocument,
                 analysisSettings.createInspectionSettingsFn(),
                 position,
             ),
-            position,
         );
     }
 
@@ -25,13 +24,6 @@ export class DocumentAnalysis extends AnalysisBase {
         if (!this.analysisSettings.maintainWorkspaceCache) {
             WorkspaceCacheUtils.close(this.textDocument);
         }
-    }
-
-    protected getLexerState(): WorkspaceCache.LexCacheItem {
-        return WorkspaceCacheUtils.getOrCreateLex(
-            this.textDocument,
-            this.analysisSettings.createInspectionSettingsFn(),
-        );
     }
 
     protected getText(range?: Range): string {

--- a/src/powerquery-language-services/documentSymbols.ts
+++ b/src/powerquery-language-services/documentSymbols.ts
@@ -14,12 +14,12 @@ import * as InspectionUtils from "./inspectionUtils";
 import { DocumentSymbol, SymbolKind, TextDocument } from "./commonTypes";
 import { WorkspaceCache, WorkspaceCacheUtils } from "./workspaceCache";
 
-export function getDocumentSymbols(
+export async function getDocumentSymbols(
     textDocument: TextDocument,
     lexAndParseSettings: PQP.LexSettings & PQP.ParseSettings,
     maintainWorkspaceCache: boolean,
-): DocumentSymbol[] {
-    const cacheItem: WorkspaceCache.ParseCacheItem = WorkspaceCacheUtils.getOrCreateParse(
+): Promise<DocumentSymbol[]> {
+    const cacheItem: WorkspaceCache.ParseCacheItem = await WorkspaceCacheUtils.getOrCreateParse(
         textDocument,
         lexAndParseSettings,
     );

--- a/src/powerquery-language-services/documentSymbols.ts
+++ b/src/powerquery-language-services/documentSymbols.ts
@@ -12,23 +12,23 @@ import { Ast } from "@microsoft/powerquery-parser/lib/powerquery-parser/language
 
 import * as InspectionUtils from "./inspectionUtils";
 import { DocumentSymbol, SymbolKind, TextDocument } from "./commonTypes";
-import { WorkspaceCache, WorkspaceCacheUtils } from "./workspaceCache";
+import { WorkspaceCacheUtils } from "./workspaceCache";
 
 export async function getDocumentSymbols(
     textDocument: TextDocument,
     lexAndParseSettings: PQP.LexSettings & PQP.ParseSettings,
     maintainWorkspaceCache: boolean,
 ): Promise<DocumentSymbol[]> {
-    const cacheItem: WorkspaceCache.ParseCacheItem = await WorkspaceCacheUtils.getOrCreateParse(
+    const maybeTriedParse: PQP.Task.TriedParseTask | undefined = await WorkspaceCacheUtils.getOrCreateParsePromise(
         textDocument,
         lexAndParseSettings,
     );
 
-    if (!PQP.TaskUtils.isParseStageOk(cacheItem) && !PQP.TaskUtils.isParseStageParseError(cacheItem)) {
+    if (maybeTriedParse === undefined || PQP.TaskUtils.isParseStageCommonError(maybeTriedParse)) {
         return [];
     }
 
-    const nodeIdMapCollection: NodeIdMap.Collection = cacheItem.nodeIdMapCollection;
+    const nodeIdMapCollection: NodeIdMap.Collection = maybeTriedParse.nodeIdMapCollection;
     const currentSymbols: DocumentSymbol[] = [];
     const parentSymbolById: Map<number, DocumentSymbol> = new Map();
 

--- a/src/powerquery-language-services/formatter.ts
+++ b/src/powerquery-language-services/formatter.ts
@@ -7,7 +7,11 @@ import { FormattingOptions, Range, TextEdit } from "vscode-languageserver-types"
 import { ResultUtils } from "@microsoft/powerquery-parser";
 import { TextDocument } from "vscode-languageserver-textdocument";
 
-export function tryFormat(document: TextDocument, formattingOptions: FormattingOptions, locale: string): TextEdit[] {
+export async function tryFormat(
+    document: TextDocument,
+    formattingOptions: FormattingOptions,
+    locale: string,
+): Promise<TextEdit[]> {
     let indentationLiteral: PQF.IndentationLiteral;
 
     if (formattingOptions.insertSpaces) {
@@ -22,7 +26,7 @@ export function tryFormat(document: TextDocument, formattingOptions: FormattingO
         indentationLiteral,
     };
 
-    const triedFormat: PQF.TriedFormat = PQF.tryFormat(formatSettings, document.getText());
+    const triedFormat: PQF.TriedFormat = await PQF.tryFormat(formatSettings, document.getText());
 
     if (ResultUtils.isOk(triedFormat)) {
         return [TextEdit.replace(fullDocumentRange(document), triedFormat.value)];

--- a/src/powerquery-language-services/index.ts
+++ b/src/powerquery-language-services/index.ts
@@ -26,11 +26,12 @@ export function createTextDocument(id: string, version: number, content: string)
 }
 
 export function documentUpdated(
-    _document: TextDocument,
-    _changes: ReadonlyArray<TextDocumentContentChangeEvent>,
-    _version: number,
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-): void {}
+    document: TextDocument,
+    changes: ReadonlyArray<TextDocumentContentChangeEvent>,
+    version: number,
+): void {
+    WorkspaceCacheUtils.update(document, changes, version);
+}
 
 export function documentClosed(document: TextDocument): void {
     WorkspaceCacheUtils.close(document);

--- a/src/powerquery-language-services/index.ts
+++ b/src/powerquery-language-services/index.ts
@@ -26,12 +26,11 @@ export function createTextDocument(id: string, version: number, content: string)
 }
 
 export function documentUpdated(
-    document: TextDocument,
-    changes: ReadonlyArray<TextDocumentContentChangeEvent>,
-    version: number,
-): void {
-    WorkspaceCacheUtils.update(document, changes, version);
-}
+    _document: TextDocument,
+    _changes: ReadonlyArray<TextDocumentContentChangeEvent>,
+    _version: number,
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+): void {}
 
 export function documentClosed(document: TextDocument): void {
     WorkspaceCacheUtils.close(document);

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteFieldAccess.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteFieldAccess.ts
@@ -24,12 +24,12 @@ import { TriedType, tryType } from "../type";
 import { InspectionSettings } from "../../inspectionSettings";
 import { TypeCache } from "../typeCache";
 
-export function tryAutocompleteFieldAccess(
+export async function tryAutocompleteFieldAccess(
     settings: InspectionSettings,
     parseState: PQP.Parser.ParseState,
     maybeActiveNode: TMaybeActiveNode,
     typeCache: TypeCache,
-): TriedAutocompleteFieldAccess {
+): Promise<TriedAutocompleteFieldAccess> {
     const trace: Trace = settings.traceManager.entry(
         AutocompleteTraceConstant.FieldAccess,
         tryAutocompleteFieldAccess.name,
@@ -40,7 +40,7 @@ export function tryAutocompleteFieldAccess(
     if (!ActiveNodeUtils.isPositionInBounds(maybeActiveNode)) {
         result = ResultUtils.boxOk(undefined);
     } else {
-        result = ResultUtils.ensureResult(settings.locale, () =>
+        result = await ResultUtils.ensureAsyncResult(settings.locale, () =>
             autocompleteFieldAccess(settings, parseState, maybeActiveNode, typeCache),
         );
     }
@@ -56,12 +56,12 @@ const AllowedExtendedTypeKindsForFieldEntries: ReadonlyArray<Type.ExtendedTypeKi
     Type.ExtendedTypeKind.DefinedTable,
 ];
 
-function autocompleteFieldAccess(
+async function autocompleteFieldAccess(
     settings: InspectionSettings,
     parseState: PQP.Parser.ParseState,
     activeNode: ActiveNode,
     typeCache: TypeCache,
-): AutocompleteFieldAccess | undefined {
+): Promise<AutocompleteFieldAccess | undefined> {
     let maybeInspectedFieldAccess: InspectedFieldAccess | undefined = undefined;
 
     // Option 1: Find a field access node in the ancestry.
@@ -113,7 +113,7 @@ function autocompleteFieldAccess(
 
     const field: TXorNode = maybeField;
 
-    const triedFieldType: TriedType = tryType(settings, nodeIdMapCollection, field.node.id, typeCache);
+    const triedFieldType: TriedType = await tryType(settings, nodeIdMapCollection, field.node.id, typeCache);
 
     if (ResultUtils.isError(triedFieldType)) {
         throw triedFieldType.error;

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteFieldAccess.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteFieldAccess.ts
@@ -40,7 +40,7 @@ export async function tryAutocompleteFieldAccess(
     if (!ActiveNodeUtils.isPositionInBounds(maybeActiveNode)) {
         result = ResultUtils.boxOk(undefined);
     } else {
-        result = await ResultUtils.ensureAsyncResult(settings.locale, () =>
+        result = await ResultUtils.ensureResultAsync(settings.locale, () =>
             autocompleteFieldAccess(settings, parseState, maybeActiveNode, typeCache),
         );
     }

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeyword.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeyword.ts
@@ -36,7 +36,7 @@ export function tryAutocompleteKeyword(
         );
     }
 
-    return ResultUtils.ensureAsyncResult(settings.locale, () =>
+    return ResultUtils.ensureResultAsync(settings.locale, () =>
         autocompleteKeyword(nodeIdMapCollection, maybeActiveNode, maybeTrailingToken),
     );
 }

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordLetExpression.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordLetExpression.ts
@@ -10,9 +10,9 @@ import { autocompleteKeywordTrailingText } from "./autocompleteKeywordTrailingTe
 import { InspectAutocompleteKeywordState } from "./commonTypes";
 import { PositionUtils } from "../../..";
 
-export function autocompleteKeywordLetExpression(
+export async function autocompleteKeywordLetExpression(
     state: InspectAutocompleteKeywordState,
-): ReadonlyArray<Keyword.KeywordKind> | undefined {
+): Promise<ReadonlyArray<Keyword.KeywordKind> | undefined> {
     // LetExpressions can trigger another inspection which will always hit the same LetExpression.
     // Make sure that it doesn't trigger an infinite recursive call.
     const child: TXorNode = state.child;
@@ -21,7 +21,7 @@ export function autocompleteKeywordLetExpression(
     // Might be either `in` or whatever the autocomplete is for the the last child of the variableList.
     // `let x = 1 |`
     if (child.node.maybeAttributeIndex === 2 && XorNodeUtils.isContextXor(child)) {
-        maybeInspected = autocompleteLastKeyValuePair(
+        maybeInspected = await autocompleteLastKeyValuePair(
             state,
             NodeIdMapIterator.iterLetExpression(
                 state.nodeIdMapCollection,
@@ -60,16 +60,16 @@ export function autocompleteKeywordLetExpression(
 function autocompleteLastKeyValuePair(
     state: InspectAutocompleteKeywordState,
     keyValuePairs: ReadonlyArray<NodeIdMapIterator.TKeyValuePair>,
-): ReadonlyArray<Keyword.KeywordKind> | undefined {
+): Promise<ReadonlyArray<Keyword.KeywordKind> | undefined> {
     if (keyValuePairs.length === 0) {
-        return undefined;
+        return Promise.resolve(undefined);
     }
 
     // Grab the last value (if one exists)
     const maybeLastValue: TXorNode | undefined = keyValuePairs[keyValuePairs.length - 1].maybeValue;
 
     if (maybeLastValue === undefined) {
-        return undefined;
+        return Promise.resolve(undefined);
     }
 
     return autocompleteKeywordRightMostLeaf(state, maybeLastValue.node.id);

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordSectionMember.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordSectionMember.ts
@@ -15,7 +15,7 @@ import { InspectAutocompleteKeywordState } from "./commonTypes";
 
 export function autocompleteKeywordSectionMember(
     state: InspectAutocompleteKeywordState,
-): ReadonlyArray<Keyword.KeywordKind> | undefined {
+): Promise<ReadonlyArray<Keyword.KeywordKind> | undefined> {
     const maybeChildAttributeIndex: number | undefined = state.child.node.maybeAttributeIndex;
 
     // SectionMember.namePairedExpression
@@ -31,7 +31,7 @@ export function autocompleteKeywordSectionMember(
 
         // 'shared' was parsed so we can exit.
         if (maybeSharedConstant !== undefined) {
-            return undefined;
+            return Promise.resolve(undefined);
         }
 
         // SectionMember -> IdentifierPairedExpression -> Identifier
@@ -48,14 +48,14 @@ export function autocompleteKeywordSectionMember(
                 Ast.NodeKind.IdentifierPairedExpression,
             ])
         ) {
-            return undefined;
+            return Promise.resolve(undefined);
         }
 
         if (Keyword.KeywordKind.Shared.startsWith(maybeName.node.key.literal)) {
-            return [Keyword.KeywordKind.Shared];
+            return Promise.resolve([Keyword.KeywordKind.Shared]);
         }
 
-        return undefined;
+        return Promise.resolve(undefined);
     }
     // `section foo; bar = 1 |` would be expecting a semicolon.
     // The autocomplete should be for the IdentifierPairedExpression found on the previous child index.
@@ -70,6 +70,6 @@ export function autocompleteKeywordSectionMember(
 
         return autocompleteKeywordRightMostLeaf(state, identifierPairedExpression.id);
     } else {
-        return undefined;
+        return Promise.resolve(undefined);
     }
 }

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/common.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/common.ts
@@ -10,12 +10,12 @@ import { AutocompleteItem } from "../autocompleteItem";
 import { autocompleteKeyword } from "./autocompleteKeyword";
 import { InspectAutocompleteKeywordState } from "./commonTypes";
 
-export function autocompleteKeywordRightMostLeaf(
+export async function autocompleteKeywordRightMostLeaf(
     state: InspectAutocompleteKeywordState,
     xorNodeId: number,
-): ReadonlyArray<Keyword.KeywordKind> | undefined {
+): Promise<ReadonlyArray<Keyword.KeywordKind> | undefined> {
     // Grab the right-most Ast node in the last value.
-    const maybeRightMostAstLeafForLastValue: Ast.TNode | undefined = NodeIdMapUtils.maybeRightMostLeaf(
+    const maybeRightMostAstLeafForLastValue: Ast.TNode | undefined = await NodeIdMapUtils.maybeRightMostLeaf(
         state.nodeIdMapCollection,
         xorNodeId,
         undefined,
@@ -38,7 +38,7 @@ export function autocompleteKeywordRightMostLeaf(
         ancestry: shiftedAncestry,
     };
 
-    const inspected: ReadonlyArray<AutocompleteItem> = autocompleteKeyword(
+    const inspected: ReadonlyArray<AutocompleteItem> = await autocompleteKeyword(
         state.nodeIdMapCollection,
         shiftedActiveNode,
         state.maybeTrailingToken,

--- a/src/powerquery-language-services/inspection/autocomplete/commonTypes.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/commonTypes.ts
@@ -35,6 +35,8 @@ export interface InspectedFieldAccess {
     readonly fieldNames: ReadonlyArray<string>;
 }
 
+// A ParseError includes the token it failed to parse.
+// This is that token plus a flag for where it is in relation to a Position.
 export interface TrailingToken extends PQP.Language.Token.Token {
     readonly isInOrOnPosition: boolean;
 }

--- a/src/powerquery-language-services/inspection/autocomplete/task.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/task.ts
@@ -23,13 +23,13 @@ import { tryAutocompleteLanguageConstant } from "./autocompleteLanguageConstant"
 import { tryAutocompletePrimitiveType } from "./autocompletePrimitiveType";
 import { TypeCache } from "../typeCache";
 
-export function autocomplete(
+export async function autocomplete(
     settings: InspectionSettings,
     parseState: PQP.Parser.ParseState,
     typeCache: TypeCache,
     maybeActiveNode: TMaybeActiveNode,
     maybeParseError: PQP.Parser.ParseError.ParseError | undefined,
-): Autocomplete {
+): Promise<Autocomplete> {
     const trace: Trace = settings.traceManager.entry(AutocompleteTraceConstant.Autocomplete, autocomplete.name);
 
     const nodeIdMapCollection: NodeIdMap.Collection = parseState.contextState.nodeIdMapCollection;
@@ -46,7 +46,7 @@ export function autocomplete(
         }
     }
 
-    const triedFieldAccess: TriedAutocompleteFieldAccess = tryAutocompleteFieldAccess(
+    const triedFieldAccess: TriedAutocompleteFieldAccess = await tryAutocompleteFieldAccess(
         settings,
         parseState,
         maybeActiveNode,

--- a/src/powerquery-language-services/inspection/autocomplete/task.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/task.ts
@@ -53,7 +53,7 @@ export async function autocomplete(
         typeCache,
     );
 
-    const triedKeyword: TriedAutocompleteKeyword = tryAutocompleteKeyword(
+    const triedKeyword: TriedAutocompleteKeyword = await tryAutocompleteKeyword(
         settings,
         nodeIdMapCollection,
         maybeActiveNode,

--- a/src/powerquery-language-services/inspection/commonTypes.ts
+++ b/src/powerquery-language-services/inspection/commonTypes.ts
@@ -18,4 +18,5 @@ export interface Inspection {
     readonly triedScopeType: Inspection.TriedScopeType;
     readonly triedExpectedType: TriedExpectedType;
     readonly typeCache: TypeCache;
+    readonly parseState: PQP.Parser.ParseState;
 }

--- a/src/powerquery-language-services/inspection/externalType/externalType.ts
+++ b/src/powerquery-language-services/inspection/externalType/externalType.ts
@@ -26,9 +26,11 @@ export type TExternalTypeResolverFn = (request: TExternalTypeRequest) => Type.TP
 
 export type TExternalInvocationTypeResolverFn = (
     request: ExternalInvocationTypeRequest,
-) => Type.TPowerQueryType | undefined;
+) => Promise<Type.TPowerQueryType | undefined>;
 
-export type TExternalValueTypeResolverFn = (request: ExternalValueTypeRequest) => Type.TPowerQueryType | undefined;
+export type TExternalValueTypeResolverFn = (
+    request: ExternalValueTypeRequest,
+) => Promise<Type.TPowerQueryType | undefined>;
 
 export const enum ExternalTypeRequestKind {
     Invocation = "Invocation",

--- a/src/powerquery-language-services/inspection/invokeExpression/currentInvokeExpression.ts
+++ b/src/powerquery-language-services/inspection/invokeExpression/currentInvokeExpression.ts
@@ -29,24 +29,24 @@ export interface CurrentInvokeExpressionArguments extends InvokeExpressionArgume
     readonly argumentOrdinal: number;
 }
 
-export function tryCurrentInvokeExpression(
+export async function tryCurrentInvokeExpression(
     settings: InspectionSettings,
     nodeIdMapCollection: NodeIdMap.Collection,
     maybeActiveNode: TMaybeActiveNode,
     // If a TypeCache is given, then potentially add to its values and include it as part of the return,
     // Else create a new TypeCache and include it in the return.
     typeCache: TypeCache = TypeCacheUtils.createEmptyCache(),
-): TriedCurrentInvokeExpression {
+): Promise<TriedCurrentInvokeExpression> {
     const trace: Trace = settings.traceManager.entry(
         LanguageServiceTraceConstant.CurrentInvokeExpression,
         tryCurrentInvokeExpression.name,
     );
 
     if (!ActiveNodeUtils.isPositionInBounds(maybeActiveNode)) {
-        return ResultUtils.boxOk(undefined);
+        return Promise.resolve(ResultUtils.boxOk(undefined));
     }
 
-    const result: TriedCurrentInvokeExpression = ResultUtils.ensureResult(settings.locale, () =>
+    const result: TriedCurrentInvokeExpression = await ResultUtils.ensureAsyncResult(settings.locale, () =>
         inspectInvokeExpression(settings, nodeIdMapCollection, maybeActiveNode, typeCache),
     );
 
@@ -55,12 +55,12 @@ export function tryCurrentInvokeExpression(
     return result;
 }
 
-function inspectInvokeExpression(
+async function inspectInvokeExpression(
     settings: InspectionSettings,
     nodeIdMapCollection: NodeIdMap.Collection,
     activeNode: ActiveNode,
     typeCache: TypeCache,
-): CurrentInvokeExpression | undefined {
+): Promise<CurrentInvokeExpression | undefined> {
     const ancestry: ReadonlyArray<TXorNode> = activeNode.ancestry;
 
     const maybeInvokeExpression: [TXorNode, number] | undefined = AncestryUtils.maybeFirstXorAndIndexOfNodeKind(
@@ -74,7 +74,7 @@ function inspectInvokeExpression(
 
     const [invokeExpressionXorNode, ancestryIndex]: [TXorNode, number] = maybeInvokeExpression;
 
-    const triedInvokeExpression: TriedInvokeExpression = tryInvokeExpression(
+    const triedInvokeExpression: TriedInvokeExpression = await tryInvokeExpression(
         settings,
         nodeIdMapCollection,
         invokeExpressionXorNode.node.id,

--- a/src/powerquery-language-services/inspection/invokeExpression/currentInvokeExpression.ts
+++ b/src/powerquery-language-services/inspection/invokeExpression/currentInvokeExpression.ts
@@ -46,7 +46,7 @@ export async function tryCurrentInvokeExpression(
         return Promise.resolve(ResultUtils.boxOk(undefined));
     }
 
-    const result: TriedCurrentInvokeExpression = await ResultUtils.ensureAsyncResult(settings.locale, () =>
+    const result: TriedCurrentInvokeExpression = await ResultUtils.ensureResultAsync(settings.locale, () =>
         inspectInvokeExpression(settings, nodeIdMapCollection, maybeActiveNode, typeCache),
     );
 

--- a/src/powerquery-language-services/inspection/invokeExpression/invokeExpression.ts
+++ b/src/powerquery-language-services/inspection/invokeExpression/invokeExpression.ts
@@ -30,18 +30,18 @@ export function tryInvokeExpression(
     // If a TypeCache is given, then potentially add to its values and include it as part of the return,
     // Else create a new TypeCache and include it in the return.
     typeCache: TypeCache = TypeCacheUtils.createEmptyCache(),
-): TriedInvokeExpression {
-    return ResultUtils.ensureResult(settings.locale, () =>
+): Promise<TriedInvokeExpression> {
+    return ResultUtils.ensureAsyncResult(settings.locale, () =>
         inspectInvokeExpression(settings, nodeIdMapCollection, invokeExpressionId, typeCache),
     );
 }
 
-function inspectInvokeExpression(
+async function inspectInvokeExpression(
     settings: InspectionSettings,
     nodeIdMapCollection: NodeIdMap.Collection,
     invokeExpressionId: number,
     typeCache: TypeCache,
-): InvokeExpression {
+): Promise<InvokeExpression> {
     settings.maybeCancellationToken?.throwIfCancelled();
 
     const maybeInvokeExpressionXorNode: TXorNode | undefined = NodeIdMapUtils.maybeXor(
@@ -65,7 +65,7 @@ function inspectInvokeExpression(
     );
 
     const functionType: Type.TPowerQueryType = Assert.unboxOk(
-        tryType(settings, nodeIdMapCollection, previousNode.node.id, typeCache),
+        await tryType(settings, nodeIdMapCollection, previousNode.node.id, typeCache),
     );
 
     const maybeName: string | undefined = NodeIdMapUtils.maybeInvokeExpressionIdentifierLiteral(
@@ -81,7 +81,7 @@ function inspectInvokeExpression(
             invokeExpressionXorNode,
         );
 
-        const givenArgumentTypes: ReadonlyArray<Type.TPowerQueryType> = getArgumentTypes(
+        const givenArgumentTypes: ReadonlyArray<Type.TPowerQueryType> = await getArgumentTypes(
             settings,
             nodeIdMapCollection,
             typeCache,
@@ -155,16 +155,17 @@ function getNumExpectedArguments(functionType: Type.DefinedFunction): [number, n
     return [numMinExpectedArguments, numMaxExpectedArguments];
 }
 
-function getArgumentTypes(
+async function getArgumentTypes(
     settings: InspectionSettings,
     nodeIdMapCollection: NodeIdMap.Collection,
     typeCache: TypeCache,
     argXorNodes: ReadonlyArray<TXorNode>,
-): ReadonlyArray<Type.TPowerQueryType> {
+): Promise<ReadonlyArray<Type.TPowerQueryType>> {
     const result: Type.TPowerQueryType[] = [];
 
     for (const xorNode of argXorNodes) {
-        const triedArgType: TriedType = tryType(settings, nodeIdMapCollection, xorNode.node.id, typeCache);
+        // eslint-disable-next-line no-await-in-loop
+        const triedArgType: TriedType = await tryType(settings, nodeIdMapCollection, xorNode.node.id, typeCache);
 
         if (ResultUtils.isError(triedArgType)) {
             throw triedArgType;

--- a/src/powerquery-language-services/inspection/invokeExpression/invokeExpression.ts
+++ b/src/powerquery-language-services/inspection/invokeExpression/invokeExpression.ts
@@ -31,7 +31,7 @@ export function tryInvokeExpression(
     // Else create a new TypeCache and include it in the return.
     typeCache: TypeCache = TypeCacheUtils.createEmptyCache(),
 ): Promise<TriedInvokeExpression> {
-    return ResultUtils.ensureAsyncResult(settings.locale, () =>
+    return ResultUtils.ensureResultAsync(settings.locale, () =>
         inspectInvokeExpression(settings, nodeIdMapCollection, invokeExpressionId, typeCache),
     );
 }

--- a/src/powerquery-language-services/inspection/task.ts
+++ b/src/powerquery-language-services/inspection/task.ts
@@ -16,7 +16,7 @@ import { InspectionSettings } from "../inspectionSettings";
 import { TriedCurrentInvokeExpression } from "./invokeExpression";
 import { tryCurrentInvokeExpression } from "./invokeExpression/currentInvokeExpression";
 
-export function inspection(
+export async function inspection(
     settings: InspectionSettings,
     parseState: PQP.Parser.ParseState,
     maybeParseError: PQP.Parser.ParseError.ParseError | undefined,
@@ -24,13 +24,13 @@ export function inspection(
     // If a TypeCache is given, then potentially add to its values and include it as part of the return,
     // Else create a new TypeCache and include it in the return.
     typeCache: TypeCache = TypeCacheUtils.createEmptyCache(),
-): Inspection {
+): Promise<Inspection> {
     const nodeIdMapCollection: NodeIdMap.Collection = parseState.contextState.nodeIdMapCollection;
 
     // We should only get an undefined for activeNode iff the document is empty
     const maybeActiveNode: TMaybeActiveNode = ActiveNodeUtils.maybeActiveNode(nodeIdMapCollection, position);
 
-    const triedCurrentInvokeExpression: TriedCurrentInvokeExpression = tryCurrentInvokeExpression(
+    const triedCurrentInvokeExpression: TriedCurrentInvokeExpression = await tryCurrentInvokeExpression(
         settings,
         nodeIdMapCollection,
         maybeActiveNode,
@@ -52,7 +52,7 @@ export function inspection(
         );
 
         const ancestryLeaf: TXorNode = PQP.Parser.AncestryUtils.assertGetLeaf(activeNode.ancestry);
-        triedScopeType = tryScopeType(settings, nodeIdMapCollection, ancestryLeaf.node.id, typeCache);
+        triedScopeType = await tryScopeType(settings, nodeIdMapCollection, ancestryLeaf.node.id, typeCache);
 
         triedExpectedType = tryExpectedType(settings, activeNode);
     } else {

--- a/src/powerquery-language-services/inspection/task.ts
+++ b/src/powerquery-language-services/inspection/task.ts
@@ -63,7 +63,7 @@ export async function inspection(
 
     return {
         maybeActiveNode,
-        autocomplete: autocomplete(settings, parseState, typeCache, maybeActiveNode, maybeParseError),
+        autocomplete: await autocomplete(settings, parseState, typeCache, maybeActiveNode, maybeParseError),
         triedCurrentInvokeExpression,
         triedNodeScope,
         triedScopeType,

--- a/src/powerquery-language-services/inspection/task.ts
+++ b/src/powerquery-language-services/inspection/task.ts
@@ -69,5 +69,6 @@ export async function inspection(
         triedScopeType,
         triedExpectedType,
         typeCache,
+        parseState,
     };
 }

--- a/src/powerquery-language-services/inspection/type/inspectType/examineFieldSpecificationList.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/examineFieldSpecificationList.ts
@@ -21,10 +21,10 @@ export interface ExaminedFieldSpecificationList {
 }
 
 // It's called an examination instead of inspection because it doesn't return TType.
-export function examineFieldSpecificationList(
+export async function examineFieldSpecificationList(
     state: InspectTypeState,
     xorNode: TXorNode,
-): ExaminedFieldSpecificationList {
+): Promise<ExaminedFieldSpecificationList> {
     const trace: Trace = state.traceManager.entry(
         LanguageServiceTraceConstant.Type,
         examineFieldSpecificationList.name,
@@ -52,7 +52,8 @@ export function examineFieldSpecificationList(
             break;
         }
 
-        const type: Type.TPowerQueryType = inspectTypeFieldSpecification(state, fieldSpecification);
+        // eslint-disable-next-line no-await-in-loop
+        const type: Type.TPowerQueryType = await inspectTypeFieldSpecification(state, fieldSpecification);
         fields.push([maybeName.literal, type]);
     }
 

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeEachExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeEachExpression.ts
@@ -8,7 +8,10 @@ import { TXorNode, XorNodeUtils } from "@microsoft/powerquery-parser/lib/powerqu
 import { inspectTypeFromChildAttributeIndex, InspectTypeState } from "./common";
 import { LanguageServiceTraceConstant, TraceUtils } from "../../..";
 
-export function inspectTypeEachExpression(state: InspectTypeState, xorNode: TXorNode): Type.TPowerQueryType {
+export async function inspectTypeEachExpression(
+    state: InspectTypeState,
+    xorNode: TXorNode,
+): Promise<Type.TPowerQueryType> {
     const trace: Trace = state.traceManager.entry(
         LanguageServiceTraceConstant.Type,
         inspectTypeEachExpression.name,
@@ -18,7 +21,7 @@ export function inspectTypeEachExpression(state: InspectTypeState, xorNode: TXor
     state.maybeCancellationToken?.throwIfCancelled();
     XorNodeUtils.assertIsNodeKind<Ast.EachExpression>(xorNode, Ast.NodeKind.EachExpression);
 
-    const expressionType: Type.TPowerQueryType = inspectTypeFromChildAttributeIndex(state, xorNode, 1);
+    const expressionType: Type.TPowerQueryType = await inspectTypeFromChildAttributeIndex(state, xorNode, 1);
 
     const result: Type.TPowerQueryType = TypeUtils.createDefinedFunction(
         false,

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeErrorHandlingExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeErrorHandlingExpression.ts
@@ -13,7 +13,10 @@ import { Trace, TraceConstant } from "@microsoft/powerquery-parser/lib/powerquer
 import { inspectTypeFromChildAttributeIndex, InspectTypeState, inspectXor } from "./common";
 import { LanguageServiceTraceConstant, TraceUtils } from "../../..";
 
-export function inspectTypeErrorHandlingExpression(state: InspectTypeState, xorNode: TXorNode): Type.TPowerQueryType {
+export async function inspectTypeErrorHandlingExpression(
+    state: InspectTypeState,
+    xorNode: TXorNode,
+): Promise<Type.TPowerQueryType> {
     const trace: Trace = state.traceManager.entry(
         LanguageServiceTraceConstant.Type,
         inspectTypeErrorHandlingExpression.name,
@@ -32,9 +35,9 @@ export function inspectTypeErrorHandlingExpression(state: InspectTypeState, xorN
         );
 
     const result: Type.TPowerQueryType = TypeUtils.createAnyUnion([
-        inspectTypeFromChildAttributeIndex(state, xorNode, 1),
+        await inspectTypeFromChildAttributeIndex(state, xorNode, 1),
         maybeOtherwiseExpression !== undefined
-            ? inspectXor(state, maybeOtherwiseExpression)
+            ? await inspectXor(state, maybeOtherwiseExpression)
             : TypeUtils.createPrimitiveType(false, Type.TypeKind.Record),
     ]);
 

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeField/common.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeField/common.ts
@@ -24,7 +24,7 @@ import { LanguageServiceTraceConstant, TraceUtils } from "../../../..";
 // In the case of RecursivePrimaryExpression:
 //  the scope is the previous sibling's type, so use NodeUtils.assertGetRecursiveExpressionPreviousSibling
 
-export function inspectFieldType(state: InspectTypeState, xorNode: TXorNode): Type.TPowerQueryType {
+export async function inspectFieldType(state: InspectTypeState, xorNode: TXorNode): Promise<Type.TPowerQueryType> {
     const trace: Trace = state.traceManager.entry(
         LanguageServiceTraceConstant.Type,
         inspectFieldType.name,
@@ -53,7 +53,7 @@ export function inspectFieldType(state: InspectTypeState, xorNode: TXorNode): Ty
             xorNode.node.id,
         );
 
-        fieldType = inspectXor(state, previousSibling);
+        fieldType = await inspectXor(state, previousSibling);
     }
 
     trace.exit({ [TraceConstant.Result]: TraceUtils.createTypeDetails(fieldType) });

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeField/inspectTypeFieldProjection.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeField/inspectTypeFieldProjection.ts
@@ -15,7 +15,10 @@ import { LanguageServiceTraceConstant, TraceUtils } from "../../../..";
 import { inspectFieldType } from "./common";
 import { InspectTypeState } from "../common";
 
-export function inspectTypeFieldProjection(state: InspectTypeState, xorNode: TXorNode): Type.TPowerQueryType {
+export async function inspectTypeFieldProjection(
+    state: InspectTypeState,
+    xorNode: TXorNode,
+): Promise<Type.TPowerQueryType> {
     const trace: Trace = state.traceManager.entry(
         LanguageServiceTraceConstant.Type,
         inspectTypeFieldProjection.name,
@@ -30,7 +33,7 @@ export function inspectTypeFieldProjection(state: InspectTypeState, xorNode: TXo
         xorNode,
     );
 
-    const fieldType: Type.TPowerQueryType = inspectFieldType(state, xorNode);
+    const fieldType: Type.TPowerQueryType = await inspectFieldType(state, xorNode);
 
     const isOptional: boolean =
         NodeIdMapUtils.maybeUnboxNthChildIfAstChecked<Ast.TConstant>(

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeField/inspectTypeFieldSelector.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeField/inspectTypeFieldSelector.ts
@@ -19,7 +19,10 @@ import { InspectTypeState } from "../common";
 // In the case of RecursivePrimaryExpression:
 //  the scope is the previous sibling's type, so use NodeUtils.assertGetRecursiveExpressionPreviousSibling
 
-export function inspectTypeFieldSelector(state: InspectTypeState, xorNode: TXorNode): Type.TPowerQueryType {
+export async function inspectTypeFieldSelector(
+    state: InspectTypeState,
+    xorNode: TXorNode,
+): Promise<Type.TPowerQueryType> {
     const trace: Trace = state.traceManager.entry(
         LanguageServiceTraceConstant.Type,
         inspectTypeFieldSelector.name,
@@ -43,7 +46,7 @@ export function inspectTypeFieldSelector(state: InspectTypeState, xorNode: TXorN
     }
 
     const fieldName: string = maybeFieldName.literal;
-    const fieldType: Type.TPowerQueryType = inspectFieldType(state, xorNode);
+    const fieldType: Type.TPowerQueryType = await inspectFieldType(state, xorNode);
 
     const isOptional: boolean =
         NodeIdMapUtils.maybeUnboxNthChildIfAstChecked<Ast.TConstant>(

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFieldSpecification.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFieldSpecification.ts
@@ -8,7 +8,10 @@ import { Trace, TraceConstant } from "@microsoft/powerquery-parser/lib/powerquer
 import { InspectTypeState, inspectXor } from "./common";
 import { LanguageServiceTraceConstant, TraceUtils } from "../../..";
 
-export function inspectTypeFieldSpecification(state: InspectTypeState, xorNode: TXorNode): Type.TPowerQueryType {
+export async function inspectTypeFieldSpecification(
+    state: InspectTypeState,
+    xorNode: TXorNode,
+): Promise<Type.TPowerQueryType> {
     const trace: Trace = state.traceManager.entry(
         LanguageServiceTraceConstant.Type,
         inspectTypeFieldSpecification.name,
@@ -25,7 +28,9 @@ export function inspectTypeFieldSpecification(state: InspectTypeState, xorNode: 
     );
 
     const result: Type.TPowerQueryType =
-        maybeFieldTypeSpecification !== undefined ? inspectXor(state, maybeFieldTypeSpecification) : Type.AnyInstance;
+        maybeFieldTypeSpecification !== undefined
+            ? await inspectXor(state, maybeFieldTypeSpecification)
+            : Type.AnyInstance;
 
     trace.exit({ [TraceConstant.Result]: TraceUtils.createTypeDetails(result) });
 

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFunctionExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFunctionExpression.ts
@@ -13,7 +13,10 @@ import {
     PseudoFunctionParameterType,
 } from "../../pseudoFunctionExpressionType";
 
-export function inspectTypeFunctionExpression(state: InspectTypeState, xorNode: TXorNode): Type.TPowerQueryType {
+export async function inspectTypeFunctionExpression(
+    state: InspectTypeState,
+    xorNode: TXorNode,
+): Promise<Type.TPowerQueryType> {
     const trace: Trace = state.traceManager.entry(
         LanguageServiceTraceConstant.Type,
         inspectTypeFunctionExpression.name,
@@ -25,7 +28,7 @@ export function inspectTypeFunctionExpression(state: InspectTypeState, xorNode: 
 
     const pseudoType: PseduoFunctionExpressionType = pseudoFunctionExpressionType(state.nodeIdMapCollection, xorNode);
     const pseudoReturnType: Type.TPowerQueryType = pseudoType.returnType;
-    const expressionType: Type.TPowerQueryType = inspectTypeFromChildAttributeIndex(state, xorNode, 3);
+    const expressionType: Type.TPowerQueryType = await inspectTypeFromChildAttributeIndex(state, xorNode, 3);
 
     // FunctionExpression.maybeFunctionReturnType doesn't always match FunctionExpression.expression.
     // By examining the expression we might get a more accurate return type (eg. Function vs DefinedFunction),

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFunctionType.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeFunctionType.ts
@@ -15,7 +15,10 @@ import { Trace, TraceConstant } from "@microsoft/powerquery-parser/lib/powerquer
 
 import { inspectTypeFromChildAttributeIndex, InspectTypeState } from "./common";
 
-export function inspectTypeFunctionType(state: InspectTypeState, xorNode: TXorNode): Type.FunctionType | Type.Unknown {
+export async function inspectTypeFunctionType(
+    state: InspectTypeState,
+    xorNode: TXorNode,
+): Promise<Type.FunctionType | Type.Unknown> {
     const trace: Trace = state.traceManager.entry(
         LanguageServiceTraceConstant.Type,
         inspectTypeFunctionType.name,
@@ -59,7 +62,7 @@ export function inspectTypeFunctionType(state: InspectTypeState, xorNode: TXorNo
         )
         .filter(PQP.TypeScriptUtils.isDefined);
 
-    const returnType: Type.TPowerQueryType = inspectTypeFromChildAttributeIndex(state, xorNode, 2);
+    const returnType: Type.TPowerQueryType = await inspectTypeFromChildAttributeIndex(state, xorNode, 2);
 
     const result: Type.TPowerQueryType = {
         kind: Type.TypeKind.Type,

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIdentifier.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIdentifier.ts
@@ -8,7 +8,7 @@ import { TXorNode, XorNodeUtils } from "@microsoft/powerquery-parser/lib/powerqu
 import { InspectTypeState, maybeDereferencedIdentifierType } from "./common";
 import { LanguageServiceTraceConstant, TraceUtils } from "../../..";
 
-export function inspectTypeIdentifier(state: InspectTypeState, xorNode: TXorNode): Type.TPowerQueryType {
+export async function inspectTypeIdentifier(state: InspectTypeState, xorNode: TXorNode): Promise<Type.TPowerQueryType> {
     const trace: Trace = state.traceManager.entry(
         LanguageServiceTraceConstant.Type,
         inspectTypeIdentifier.name,
@@ -23,7 +23,11 @@ export function inspectTypeIdentifier(state: InspectTypeState, xorNode: TXorNode
     if (XorNodeUtils.isContextXor(xorNode)) {
         result = Type.UnknownInstance;
     } else {
-        const dereferencedType: Type.TPowerQueryType | undefined = maybeDereferencedIdentifierType(state, xorNode);
+        const dereferencedType: Type.TPowerQueryType | undefined = await maybeDereferencedIdentifierType(
+            state,
+            xorNode,
+        );
+
         result = dereferencedType ?? Type.UnknownInstance;
     }
 

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIdentifierExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIdentifierExpression.ts
@@ -8,7 +8,10 @@ import { TXorNode, XorNodeUtils } from "@microsoft/powerquery-parser/lib/powerqu
 import { InspectTypeState, maybeDereferencedIdentifierType } from "./common";
 import { LanguageServiceTraceConstant, TraceUtils } from "../../..";
 
-export function inspectTypeIdentifierExpression(state: InspectTypeState, xorNode: TXorNode): Type.TPowerQueryType {
+export async function inspectTypeIdentifierExpression(
+    state: InspectTypeState,
+    xorNode: TXorNode,
+): Promise<Type.TPowerQueryType> {
     const trace: Trace = state.traceManager.entry(
         LanguageServiceTraceConstant.Type,
         inspectTypeIdentifierExpression.name,
@@ -23,7 +26,11 @@ export function inspectTypeIdentifierExpression(state: InspectTypeState, xorNode
     if (XorNodeUtils.isContextXor(xorNode)) {
         result = Type.UnknownInstance;
     } else {
-        const dereferencedType: Type.TPowerQueryType | undefined = maybeDereferencedIdentifierType(state, xorNode);
+        const dereferencedType: Type.TPowerQueryType | undefined = await maybeDereferencedIdentifierType(
+            state,
+            xorNode,
+        );
+
         result = dereferencedType ?? Type.UnknownInstance;
     }
 

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeList.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeList.ts
@@ -8,7 +8,7 @@ import { Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/languag
 import { InspectTypeState, inspectXor } from "./common";
 import { LanguageServiceTraceConstant, TraceUtils } from "../../..";
 
-export function inspectTypeList(state: InspectTypeState, xorNode: TXorNode): Type.DefinedList {
+export async function inspectTypeList(state: InspectTypeState, xorNode: TXorNode): Promise<Type.DefinedList> {
     const trace: Trace = state.traceManager.entry(
         LanguageServiceTraceConstant.Type,
         inspectTypeList.name,
@@ -17,7 +17,10 @@ export function inspectTypeList(state: InspectTypeState, xorNode: TXorNode): Typ
 
     state.maybeCancellationToken?.throwIfCancelled();
     const items: ReadonlyArray<TXorNode> = NodeIdMapIterator.iterListItems(state.nodeIdMapCollection, xorNode);
-    const elements: ReadonlyArray<Type.TPowerQueryType> = items.map((item: TXorNode) => inspectXor(state, item));
+
+    const elements: ReadonlyArray<Type.TPowerQueryType> = await Promise.all(
+        items.map((item: TXorNode) => inspectXor(state, item)),
+    );
 
     const result: Type.TPowerQueryType = {
         kind: Type.TypeKind.List,

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeListType.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeListType.ts
@@ -8,7 +8,10 @@ import { Trace, TraceConstant } from "@microsoft/powerquery-parser/lib/powerquer
 import { InspectTypeState, inspectXor } from "./common";
 import { LanguageServiceTraceConstant, TraceUtils } from "../../..";
 
-export function inspectTypeListType(state: InspectTypeState, xorNode: TXorNode): Type.ListType | Type.Unknown {
+export async function inspectTypeListType(
+    state: InspectTypeState,
+    xorNode: TXorNode,
+): Promise<Type.ListType | Type.Unknown> {
     const trace: Trace = state.traceManager.entry(
         LanguageServiceTraceConstant.Type,
         inspectTypeListType.name,
@@ -29,7 +32,7 @@ export function inspectTypeListType(state: InspectTypeState, xorNode: TXorNode):
     if (maybeListItem === undefined) {
         result = Type.UnknownInstance;
     } else {
-        const itemType: Type.TPowerQueryType = inspectXor(state, maybeListItem);
+        const itemType: Type.TPowerQueryType = await inspectXor(state, maybeListItem);
 
         result = {
             kind: Type.TypeKind.Type,

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeNullCoalescingExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeNullCoalescingExpression.ts
@@ -8,7 +8,10 @@ import { Trace, TraceConstant } from "@microsoft/powerquery-parser/lib/powerquer
 import { inspectTypeFromChildAttributeIndex, InspectTypeState } from "./common";
 import { LanguageServiceTraceConstant, TraceUtils } from "../../..";
 
-export function inspectTypeNullCoalescingExpression(state: InspectTypeState, xorNode: TXorNode): Type.TPowerQueryType {
+export async function inspectTypeNullCoalescingExpression(
+    state: InspectTypeState,
+    xorNode: TXorNode,
+): Promise<Type.TPowerQueryType> {
     const trace: Trace = state.traceManager.entry(
         LanguageServiceTraceConstant.Type,
         inspectTypeNullCoalescingExpression.name,
@@ -18,7 +21,7 @@ export function inspectTypeNullCoalescingExpression(state: InspectTypeState, xor
     state.maybeCancellationToken?.throwIfCancelled();
     XorNodeUtils.assertIsNodeKind<Ast.NullCoalescingExpression>(xorNode, Ast.NodeKind.NullCoalescingExpression);
 
-    const maybeLeftType: Type.TPowerQueryType = inspectTypeFromChildAttributeIndex(state, xorNode, 0);
+    const maybeLeftType: Type.TPowerQueryType = await inspectTypeFromChildAttributeIndex(state, xorNode, 0);
 
     const maybeNullCoalescingOperator: Ast.TConstant | undefined =
         NodeIdMapUtils.maybeUnboxNthChildIfAstChecked<Ast.TConstant>(
@@ -34,7 +37,7 @@ export function inspectTypeNullCoalescingExpression(state: InspectTypeState, xor
     if (maybeNullCoalescingOperator === undefined) {
         result = maybeLeftType;
     } else {
-        const maybeRightType: Type.TPowerQueryType = inspectTypeFromChildAttributeIndex(state, xorNode, 2);
+        const maybeRightType: Type.TPowerQueryType = await inspectTypeFromChildAttributeIndex(state, xorNode, 2);
 
         if (maybeLeftType.kind === Type.TypeKind.None || maybeRightType.kind === Type.TypeKind.None) {
             result = Type.NoneInstance;

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeParameter.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeParameter.ts
@@ -8,7 +8,7 @@ import { Trace, TraceConstant } from "@microsoft/powerquery-parser/lib/powerquer
 import { inspectTypeFromChildAttributeIndex, InspectTypeState } from "./common";
 import { LanguageServiceTraceConstant, TraceUtils } from "../../..";
 
-export function inspectTypeParameter(state: InspectTypeState, xorNode: TXorNode): Type.TPowerQueryType {
+export async function inspectTypeParameter(state: InspectTypeState, xorNode: TXorNode): Promise<Type.TPowerQueryType> {
     const trace: Trace = state.traceManager.entry(
         LanguageServiceTraceConstant.Type,
         inspectTypeParameter.name,
@@ -27,7 +27,7 @@ export function inspectTypeParameter(state: InspectTypeState, xorNode: TXorNode)
         );
 
     const maybeParameterType: Type.TPowerQueryType | undefined = TypeUtils.assertAsTPrimitiveType(
-        inspectTypeFromChildAttributeIndex(state, xorNode, 2),
+        await inspectTypeFromChildAttributeIndex(state, xorNode, 2),
     );
 
     const result: Type.TPowerQueryType = {

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRangeExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRangeExpression.ts
@@ -9,7 +9,10 @@ import { LanguageServiceTraceConstant, TraceUtils } from "../../..";
 
 import { inspectTypeFromChildAttributeIndex, InspectTypeState } from "./common";
 
-export function inspectTypeRangeExpression(state: InspectTypeState, xorNode: TXorNode): Type.TPowerQueryType {
+export async function inspectTypeRangeExpression(
+    state: InspectTypeState,
+    xorNode: TXorNode,
+): Promise<Type.TPowerQueryType> {
     const trace: Trace = state.traceManager.entry(
         LanguageServiceTraceConstant.Type,
         inspectTypeRangeExpression.name,
@@ -19,8 +22,13 @@ export function inspectTypeRangeExpression(state: InspectTypeState, xorNode: TXo
     state.maybeCancellationToken?.throwIfCancelled();
     XorNodeUtils.assertIsNodeKind<Ast.RangeExpression>(xorNode, Ast.NodeKind.RangeExpression);
 
-    const maybeLeftType: Type.TPowerQueryType | undefined = inspectTypeFromChildAttributeIndex(state, xorNode, 0);
-    const maybeRightType: Type.TPowerQueryType | undefined = inspectTypeFromChildAttributeIndex(state, xorNode, 2);
+    const maybeLeftType: Type.TPowerQueryType | undefined = await inspectTypeFromChildAttributeIndex(state, xorNode, 0);
+
+    const maybeRightType: Type.TPowerQueryType | undefined = await inspectTypeFromChildAttributeIndex(
+        state,
+        xorNode,
+        2,
+    );
 
     let result: Type.TPowerQueryType;
 

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRecord.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRecord.ts
@@ -8,7 +8,7 @@ import { InspectTypeState, inspectXor } from "./common";
 import { LanguageServiceTraceConstant, TraceUtils } from "../../..";
 import { Trace, TraceConstant } from "@microsoft/powerquery-parser/lib/powerquery-parser/common/trace";
 
-export function inspectTypeRecord(state: InspectTypeState, xorNode: TXorNode): Type.DefinedRecord {
+export async function inspectTypeRecord(state: InspectTypeState, xorNode: TXorNode): Promise<Type.DefinedRecord> {
     const trace: Trace = state.traceManager.entry(
         LanguageServiceTraceConstant.Type,
         inspectTypeRecord.name,
@@ -22,7 +22,8 @@ export function inspectTypeRecord(state: InspectTypeState, xorNode: TXorNode): T
 
     for (const keyValuePair of NodeIdMapIterator.iterRecord(state.nodeIdMapCollection, xorNode)) {
         if (keyValuePair.maybeValue) {
-            fields.set(keyValuePair.keyLiteral, inspectXor(state, keyValuePair.maybeValue));
+            // eslint-disable-next-line no-await-in-loop
+            fields.set(keyValuePair.keyLiteral, await inspectXor(state, keyValuePair.maybeValue));
         } else {
             fields.set(keyValuePair.keyLiteral, Type.UnknownInstance);
         }

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRecordType.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRecordType.ts
@@ -9,7 +9,10 @@ import { LanguageServiceTraceConstant, TraceUtils } from "../../..";
 import { examineFieldSpecificationList } from "./examineFieldSpecificationList";
 import { InspectTypeState } from "./common";
 
-export function inspectTypeRecordType(state: InspectTypeState, xorNode: TXorNode): Type.RecordType | Type.Unknown {
+export async function inspectTypeRecordType(
+    state: InspectTypeState,
+    xorNode: TXorNode,
+): Promise<Type.RecordType | Type.Unknown> {
     const trace: Trace = state.traceManager.entry(
         LanguageServiceTraceConstant.Type,
         inspectTypeRecordType.name,
@@ -35,7 +38,7 @@ export function inspectTypeRecordType(state: InspectTypeState, xorNode: TXorNode
             kind: Type.TypeKind.Type,
             maybeExtendedKind: Type.ExtendedTypeKind.RecordType,
             isNullable: false,
-            ...examineFieldSpecificationList(state, maybeFields),
+            ...(await examineFieldSpecificationList(state, maybeFields)),
         };
     }
 

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRecursivePrimaryExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRecursivePrimaryExpression.ts
@@ -14,10 +14,10 @@ import { Trace, TraceConstant } from "@microsoft/powerquery-parser/lib/powerquer
 
 import { inspectTypeFromChildAttributeIndex, InspectTypeState, inspectXor } from "./common";
 
-export function inspectTypeRecursivePrimaryExpression(
+export async function inspectTypeRecursivePrimaryExpression(
     state: InspectTypeState,
     xorNode: TXorNode,
-): Type.TPowerQueryType {
+): Promise<Type.TPowerQueryType> {
     const trace: Trace = state.traceManager.entry(
         LanguageServiceTraceConstant.Type,
         inspectTypeRecursivePrimaryExpression.name,
@@ -35,7 +35,7 @@ export function inspectTypeRecursivePrimaryExpression(
         return Type.UnknownInstance;
     }
 
-    const headType: Type.TPowerQueryType = inspectTypeFromChildAttributeIndex(state, xorNode, 0);
+    const headType: Type.TPowerQueryType = await inspectTypeFromChildAttributeIndex(state, xorNode, 0);
 
     if (headType.kind === Type.TypeKind.None || headType.kind === Type.TypeKind.Unknown) {
         trace.exit({ [TraceConstant.Result]: TraceUtils.createTypeDetails(headType) });
@@ -71,7 +71,8 @@ export function inspectTypeRecursivePrimaryExpression(
     let leftType: Type.TPowerQueryType = headType;
 
     for (const right of maybeExpressions) {
-        const rightType: Type.TPowerQueryType = inspectXor(state, right);
+        // eslint-disable-next-line no-await-in-loop
+        const rightType: Type.TPowerQueryType = await inspectXor(state, right);
         leftType = rightType;
     }
 

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeTBinOpExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeTBinOpExpression.ts
@@ -10,9 +10,12 @@ import { InspectTypeState, inspectXor } from "./common";
 import { LanguageServiceTraceConstant, TraceUtils } from "../../..";
 import { Trace, TraceConstant } from "@microsoft/powerquery-parser/lib/powerquery-parser/common/trace";
 
-type TRecordOrTable = Type.Record | Type.Table | Type.DefinedRecord | Type.DefinedTable;
+type TRecordOrTable = Type.TRecord | Type.TTable;
 
-export function inspectTypeTBinOpExpression(state: InspectTypeState, xorNode: TXorNode): Type.TPowerQueryType {
+export async function inspectTypeTBinOpExpression(
+    state: InspectTypeState,
+    xorNode: TXorNode,
+): Promise<Type.TPowerQueryType> {
     const trace: Trace = state.traceManager.entry(
         LanguageServiceTraceConstant.Type,
         inspectTypeTBinOpExpression.name,
@@ -50,11 +53,11 @@ export function inspectTypeTBinOpExpression(state: InspectTypeState, xorNode: TX
     }
     // '1'
     else if (maybeOperatorKind === undefined) {
-        result = inspectXor(state, maybeLeft);
+        result = await inspectXor(state, maybeLeft);
     }
     // '1 +'
     else if (maybeRight === undefined || XorNodeUtils.isContextXor(maybeRight)) {
-        const leftType: Type.TPowerQueryType = inspectXor(state, maybeLeft);
+        const leftType: Type.TPowerQueryType = await inspectXor(state, maybeLeft);
         const operatorKind: Constant.TBinOpExpressionOperator = maybeOperatorKind;
 
         const key: string = partialLookupKey(leftType.kind, operatorKind);
@@ -80,9 +83,9 @@ export function inspectTypeTBinOpExpression(state: InspectTypeState, xorNode: TX
     }
     // '1 + 1'
     else {
-        const leftType: Type.TPowerQueryType = inspectXor(state, maybeLeft);
+        const leftType: Type.TPowerQueryType = await inspectXor(state, maybeLeft);
         const operatorKind: Constant.TBinOpExpressionOperator = maybeOperatorKind;
-        const rightType: Type.TPowerQueryType = inspectXor(state, maybeRight);
+        const rightType: Type.TPowerQueryType = await inspectXor(state, maybeRight);
 
         const key: string = lookupKey(leftType.kind, operatorKind, rightType.kind);
         const maybeResultTypeKind: Type.TypeKind | undefined = Lookup.get(key);

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeTableType.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeTableType.ts
@@ -9,10 +9,10 @@ import { InspectTypeState, inspectXor } from "./common";
 import { LanguageServiceTraceConstant, TraceUtils } from "../../..";
 import { examineFieldSpecificationList } from "./examineFieldSpecificationList";
 
-export function inspectTypeTableType(
+export async function inspectTypeTableType(
     state: InspectTypeState,
     xorNode: TXorNode,
-): Type.TableType | Type.TableTypePrimaryExpression | Type.Unknown {
+): Promise<Type.TableType | Type.TableTypePrimaryExpression | Type.Unknown> {
     const trace: Trace = state.traceManager.entry(
         LanguageServiceTraceConstant.Type,
         inspectTypeTableType.name,
@@ -37,14 +37,14 @@ export function inspectTypeTableType(
             kind: Type.TypeKind.Type,
             maybeExtendedKind: Type.ExtendedTypeKind.TableType,
             isNullable: false,
-            ...examineFieldSpecificationList(state, maybeRowType),
+            ...(await examineFieldSpecificationList(state, maybeRowType)),
         };
     } else {
         result = {
             kind: Type.TypeKind.Type,
             maybeExtendedKind: Type.ExtendedTypeKind.TableTypePrimaryExpression,
             isNullable: false,
-            primaryExpression: inspectXor(state, maybeRowType),
+            primaryExpression: await inspectXor(state, maybeRowType),
         };
     }
 

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeUnaryExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeUnaryExpression.ts
@@ -16,7 +16,10 @@ import { Assert } from "@microsoft/powerquery-parser";
 import { InspectTypeState, inspectXor } from "./common";
 import { LanguageServiceTraceConstant, TraceUtils } from "../../..";
 
-export function inspectTypeUnaryExpression(state: InspectTypeState, xorNode: TXorNode): Type.TPowerQueryType {
+export async function inspectTypeUnaryExpression(
+    state: InspectTypeState,
+    xorNode: TXorNode,
+): Promise<Type.TPowerQueryType> {
     const trace: Trace = state.traceManager.entry(
         LanguageServiceTraceConstant.Type,
         inspectTypeUnaryExpression.name,
@@ -51,7 +54,7 @@ export function inspectTypeUnaryExpression(state: InspectTypeState, xorNode: TXo
         result = Type.UnknownInstance;
     } else {
         const expression: TXorNode = maybeExpression;
-        const expressionType: Type.TPowerQueryType = inspectXor(state, expression);
+        const expressionType: Type.TPowerQueryType = await inspectXor(state, expression);
 
         if (expressionType.kind === Type.TypeKind.Number) {
             result = inspectTypeUnaryNumber(state, expressionType, unaryOperatorWrapper.node.id);

--- a/src/powerquery-language-services/inspection/type/task.ts
+++ b/src/powerquery-language-services/inspection/type/task.ts
@@ -38,7 +38,7 @@ export async function tryScopeType(
         scopeById: typeCache.scopeById,
     };
 
-    const result: TriedScopeType = await ResultUtils.ensureAsyncResult(settings.locale, () =>
+    const result: TriedScopeType = await ResultUtils.ensureResultAsync(settings.locale, () =>
         inspectScopeType(state, nodeId),
     );
 
@@ -67,7 +67,7 @@ export async function tryType(
         scopeById: typeCache.scopeById,
     };
 
-    const result: TriedType = await ResultUtils.ensureAsyncResult(settings.locale, () =>
+    const result: TriedType = await ResultUtils.ensureResultAsync(settings.locale, () =>
         inspectXor(state, NodeIdMapUtils.assertGetXor(nodeIdMapCollection, nodeId)),
     );
 

--- a/src/powerquery-language-services/providers/languageCompletionItemProvider.ts
+++ b/src/powerquery-language-services/providers/languageCompletionItemProvider.ts
@@ -5,7 +5,6 @@ import { KeywordKind } from "@microsoft/powerquery-parser/lib/powerquery-parser/
 import { ResultUtils } from "@microsoft/powerquery-parser";
 
 import { AutocompleteItemProvider, AutocompleteItemProviderContext } from "./commonTypes";
-import { WorkspaceCache, WorkspaceCacheUtils } from "../workspaceCache";
 import { AutocompleteItem } from "../inspection/autocomplete/autocompleteItem";
 import { Inspection } from "..";
 
@@ -26,17 +25,19 @@ export class LanguageAutocompleteItemProvider implements AutocompleteItemProvide
         KeywordKind.HashTime,
     ];
 
-    constructor(private readonly maybeTriedInspection: WorkspaceCache.InspectionCacheItem) {}
+    constructor(private readonly maybePromiseInspection: Promise<Inspection.Inspection | undefined>) {}
 
     // eslint-disable-next-line require-await
     public async getAutocompleteItems(
         _context: AutocompleteItemProviderContext,
     ): Promise<ReadonlyArray<AutocompleteItem>> {
-        if (!WorkspaceCacheUtils.isInspectionTask(this.maybeTriedInspection)) {
+        const maybeInspection: Inspection.Inspection | undefined = await this.maybePromiseInspection;
+
+        if (maybeInspection === undefined) {
             return [];
         }
 
-        const autocomplete: Inspection.Autocomplete = this.maybeTriedInspection.autocomplete;
+        const autocomplete: Inspection.Autocomplete = maybeInspection.autocomplete;
 
         return [
             ...this.getKeywords(autocomplete.triedKeyword),

--- a/src/powerquery-language-services/providers/localDocumentSymbolProvider.ts
+++ b/src/powerquery-language-services/providers/localDocumentSymbolProvider.ts
@@ -65,7 +65,7 @@ export class LocalDocumentSymbolProvider implements ISymbolProvider {
 
         const inspection: WorkspaceCache.InspectionCacheItem = this.maybeTriedInspection;
 
-        let maybeHover: Hover | undefined = LocalDocumentSymbolProvider.getHoverForIdentifierPairedExpression(
+        let maybeHover: Hover | undefined = await LocalDocumentSymbolProvider.getHoverForIdentifierPairedExpression(
             context,
             this.createInspectionSettingsFn(),
             this.maybeTriedInspection,
@@ -112,12 +112,12 @@ export class LocalDocumentSymbolProvider implements ISymbolProvider {
     //  * GeneralizedIdentifierPairedAnyLiteral
     //  * GeneralizedIdentifierPairedExpression
     //  * IdentifierPairedExpression
-    protected static getHoverForIdentifierPairedExpression(
+    protected static async getHoverForIdentifierPairedExpression(
         context: HoverProviderContext,
         inspectionSettings: InspectionSettings,
         inspectionTask: WorkspaceCache.InspectionTask,
         activeNode: Inspection.ActiveNode,
-    ): Hover | undefined {
+    ): Promise<Hover | undefined> {
         const parseState: ParseState = inspectionTask.parseState;
         const ancestry: ReadonlyArray<TXorNode> = activeNode.ancestry;
         const maybeLeafKind: Ast.NodeKind | undefined = ancestry[0]?.node.kind;
@@ -156,7 +156,7 @@ export class LocalDocumentSymbolProvider implements ISymbolProvider {
             return undefined;
         }
 
-        const triedExpressionType: Inspection.TriedType = Inspection.tryType(
+        const triedExpressionType: Inspection.TriedType = await Inspection.tryType(
             inspectionSettings,
             parseState.contextState.nodeIdMapCollection,
             maybeExpression.node.id,

--- a/src/powerquery-language-services/validate/validate.ts
+++ b/src/powerquery-language-services/validate/validate.ts
@@ -12,7 +12,10 @@ import { validateLexAndParse } from "./validateLexAndParse";
 import type { ValidationResult } from "./validationResult";
 import type { ValidationSettings } from "./validationSettings";
 
-export function validate(textDocument: TextDocument, validationSettings: ValidationSettings): ValidationResult {
+export async function validate(
+    textDocument: TextDocument,
+    validationSettings: ValidationSettings,
+): Promise<ValidationResult> {
     const cacheItem: WorkspaceCache.ParseCacheItem = WorkspaceCacheUtils.getOrCreateParse(
         textDocument,
         validationSettings,
@@ -24,7 +27,7 @@ export function validate(textDocument: TextDocument, validationSettings: Validat
         validationSettings.checkInvokeExpressions &&
         (PQP.TaskUtils.isParseStageOk(cacheItem) || PQP.TaskUtils.isParseStageParseError(cacheItem))
     ) {
-        invokeExpressionDiagnostics = validateInvokeExpression(
+        invokeExpressionDiagnostics = await validateInvokeExpression(
             validationSettings,
             cacheItem.nodeIdMapCollection,
             WorkspaceCacheUtils.getOrCreateTypeCache(textDocument),

--- a/src/powerquery-language-services/validate/validate.ts
+++ b/src/powerquery-language-services/validate/validate.ts
@@ -16,7 +16,7 @@ export async function validate(
     textDocument: TextDocument,
     validationSettings: ValidationSettings,
 ): Promise<ValidationResult> {
-    const cacheItem: WorkspaceCache.ParseCacheItem = WorkspaceCacheUtils.getOrCreateParse(
+    const cacheItem: WorkspaceCache.ParseCacheItem = await WorkspaceCacheUtils.getOrCreateParse(
         textDocument,
         validationSettings,
     );
@@ -38,8 +38,8 @@ export async function validate(
 
     return {
         diagnostics: [
-            ...validateDuplicateIdentifiers(textDocument, validationSettings),
-            ...validateLexAndParse(textDocument, validationSettings),
+            ...(await validateDuplicateIdentifiers(textDocument, validationSettings)),
+            ...(await validateLexAndParse(textDocument, validationSettings)),
             ...invokeExpressionDiagnostics,
         ],
         hasSyntaxError: PQP.TaskUtils.isLexStageError(cacheItem) || PQP.TaskUtils.isParseStageError(cacheItem),

--- a/src/powerquery-language-services/validate/validateDuplicateIdentifiers.ts
+++ b/src/powerquery-language-services/validate/validateDuplicateIdentifiers.ts
@@ -13,10 +13,10 @@ import { Ast } from "@microsoft/powerquery-parser/lib/powerquery-parser/language
 import { TextDocument } from "vscode-languageserver-textdocument";
 
 import { Localization, LocalizationUtils } from "../localization";
-import { WorkspaceCache, WorkspaceCacheUtils } from "../workspaceCache";
 import { DiagnosticErrorCode } from "../diagnosticErrorCode";
 import { PositionUtils } from "..";
 import { ValidationSettings } from "./validationSettings";
+import { WorkspaceCacheUtils } from "../workspaceCache";
 
 export async function validateDuplicateIdentifiers(
     textDocument: TextDocument,
@@ -26,17 +26,15 @@ export async function validateDuplicateIdentifiers(
         return [];
     }
 
-    const cacheItem: WorkspaceCache.ParseCacheItem = await WorkspaceCacheUtils.getOrCreateParse(
-        textDocument,
-        validationSettings,
-    );
+    const parsePromise: PQP.Task.TriedLexTask | PQP.Task.TriedParseTask =
+        await WorkspaceCacheUtils.getOrCreateParsePromise(textDocument, validationSettings);
 
     let maybeNodeIdMapCollection: NodeIdMap.Collection | undefined;
 
-    if (PQP.TaskUtils.isParseStageOk(cacheItem)) {
-        maybeNodeIdMapCollection = cacheItem.nodeIdMapCollection;
-    } else if (PQP.TaskUtils.isParseStageParseError(cacheItem)) {
-        maybeNodeIdMapCollection = cacheItem.nodeIdMapCollection;
+    if (PQP.TaskUtils.isParseStageOk(parsePromise)) {
+        maybeNodeIdMapCollection = parsePromise.nodeIdMapCollection;
+    } else if (PQP.TaskUtils.isParseStageParseError(parsePromise)) {
+        maybeNodeIdMapCollection = parsePromise.nodeIdMapCollection;
     }
 
     if (maybeNodeIdMapCollection === undefined) {

--- a/src/powerquery-language-services/validate/validateDuplicateIdentifiers.ts
+++ b/src/powerquery-language-services/validate/validateDuplicateIdentifiers.ts
@@ -26,15 +26,22 @@ export async function validateDuplicateIdentifiers(
         return [];
     }
 
-    const parsePromise: PQP.Task.TriedLexTask | PQP.Task.TriedParseTask =
-        await WorkspaceCacheUtils.getOrCreateParsePromise(textDocument, validationSettings);
+    const maybeParsePromise: PQP.Task.TriedParseTask | undefined = await WorkspaceCacheUtils.getOrCreateParsePromise(
+        textDocument,
+        validationSettings,
+    );
 
+    if (maybeParsePromise === undefined) {
+        return [];
+    }
+
+    const triedParse: PQP.Task.TriedParseTask = maybeParsePromise;
     let maybeNodeIdMapCollection: NodeIdMap.Collection | undefined;
 
-    if (PQP.TaskUtils.isParseStageOk(parsePromise)) {
-        maybeNodeIdMapCollection = parsePromise.nodeIdMapCollection;
-    } else if (PQP.TaskUtils.isParseStageParseError(parsePromise)) {
-        maybeNodeIdMapCollection = parsePromise.nodeIdMapCollection;
+    if (PQP.TaskUtils.isParseStageOk(triedParse)) {
+        maybeNodeIdMapCollection = triedParse.nodeIdMapCollection;
+    } else if (PQP.TaskUtils.isParseStageParseError(triedParse)) {
+        maybeNodeIdMapCollection = triedParse.nodeIdMapCollection;
     }
 
     if (maybeNodeIdMapCollection === undefined) {

--- a/src/powerquery-language-services/validate/validateDuplicateIdentifiers.ts
+++ b/src/powerquery-language-services/validate/validateDuplicateIdentifiers.ts
@@ -18,15 +18,15 @@ import { DiagnosticErrorCode } from "../diagnosticErrorCode";
 import { PositionUtils } from "..";
 import { ValidationSettings } from "./validationSettings";
 
-export function validateDuplicateIdentifiers(
+export async function validateDuplicateIdentifiers(
     textDocument: TextDocument,
     validationSettings: ValidationSettings,
-): ReadonlyArray<Diagnostic> {
+): Promise<ReadonlyArray<Diagnostic>> {
     if (!validationSettings.checkForDuplicateIdentifiers) {
         return [];
     }
 
-    const cacheItem: WorkspaceCache.ParseCacheItem = WorkspaceCacheUtils.getOrCreateParse(
+    const cacheItem: WorkspaceCache.ParseCacheItem = await WorkspaceCacheUtils.getOrCreateParse(
         textDocument,
         validationSettings,
     );

--- a/src/powerquery-language-services/validate/validateFunctionExpression.ts
+++ b/src/powerquery-language-services/validate/validateFunctionExpression.ts
@@ -13,11 +13,11 @@ import { DiagnosticErrorCode } from "../diagnosticErrorCode";
 import { ILocalizationTemplates } from "../localization/templates";
 import { ValidationSettings } from "./validationSettings";
 
-export function validateFunctionExpression(
+export async function validateFunctionExpression(
     validationSettings: ValidationSettings,
     nodeIdMapCollection: NodeIdMap.Collection,
     maybeCache?: Inspection.TypeCache,
-): Diagnostic[] {
+): Promise<Diagnostic[]> {
     const maybeInvokeExpressionIds: Set<number> | undefined = nodeIdMapCollection.idsByNodeKind.get(
         Ast.NodeKind.FunctionExpression,
     );
@@ -26,23 +26,24 @@ export function validateFunctionExpression(
         return [];
     }
 
-    const result: Diagnostic[] = [];
+    const inspectionTasks: Promise<Inspection.TriedInvokeExpression>[] = [];
 
     for (const nodeId of maybeInvokeExpressionIds) {
-        const triedInvokeExpression: Inspection.TriedInvokeExpression = Inspection.tryInvokeExpression(
-            validationSettings,
-            nodeIdMapCollection,
-            nodeId,
-            maybeCache,
+        inspectionTasks.push(
+            Inspection.tryInvokeExpression(validationSettings, nodeIdMapCollection, nodeId, maybeCache),
         );
+    }
 
-        if (ResultUtils.isError(triedInvokeExpression)) {
+    const result: Diagnostic[] = [];
+
+    for (const triedInvokeExpression of await Promise.all(inspectionTasks)) {
+        if (ResultUtils.isOk(triedInvokeExpression)) {
+            result.push(
+                ...invokeExpressionToDiagnostics(validationSettings, nodeIdMapCollection, triedInvokeExpression.value),
+            );
+        } else {
             throw triedInvokeExpression;
         }
-
-        result.push(
-            ...invokeExpressionToDiagnostics(validationSettings, nodeIdMapCollection, triedInvokeExpression.value),
-        );
     }
 
     return result;

--- a/src/powerquery-language-services/validate/validateFunctionExpression.ts
+++ b/src/powerquery-language-services/validate/validateFunctionExpression.ts
@@ -74,7 +74,7 @@ async function invokeExpressionToDiagnostics(
         let result: Diagnostic[] = [];
 
         result = result.concat(
-            await ArrayUtils.asyncMap(
+            await ArrayUtils.mapAsync(
                 [...invokeExpressionArguments.typeChecked.invalid.entries()],
                 async ([argIndex, mismatch]: [number, TypeUtils.InvocationMismatch]) => {
                     const maybeGivenArgumentRange: Range | undefined = await PositionUtils.createRangeFromXorNode(

--- a/src/powerquery-language-services/validate/validateLexAndParse.ts
+++ b/src/powerquery-language-services/validate/validateLexAndParse.ts
@@ -21,7 +21,7 @@ export async function validateLexAndParse(
     );
 
     if (parsePromise !== undefined) {
-        return validateParse(parsePromise, validationSettings);
+        return await validateParse(parsePromise, validationSettings);
     }
 
     const lexPromise: PQP.Task.TriedLexTask | undefined = await WorkspaceCacheUtils.getOrCreateLexPromise(

--- a/src/powerquery-language-services/validate/validateLexAndParse.ts
+++ b/src/powerquery-language-services/validate/validateLexAndParse.ts
@@ -7,23 +7,21 @@ import { NodeIdMapUtils, ParseContext } from "@microsoft/powerquery-parser/lib/p
 import { Ast } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 import { TextDocument } from "vscode-languageserver-textdocument";
 
-import { WorkspaceCache, WorkspaceCacheUtils } from "../workspaceCache";
 import { DiagnosticErrorCode } from "../diagnosticErrorCode";
 import { ValidationSettings } from "./validationSettings";
+import { WorkspaceCacheUtils } from "../workspaceCache";
 
 export async function validateLexAndParse(
     textDocument: TextDocument,
     validationSettings: ValidationSettings,
 ): Promise<Diagnostic[]> {
-    const cacheItem: WorkspaceCache.ParseCacheItem = await WorkspaceCacheUtils.getOrCreateParse(
-        textDocument,
-        validationSettings,
-    );
+    const parsePromise: PQP.Task.TriedLexTask | PQP.Task.TriedParseTask =
+        await WorkspaceCacheUtils.getOrCreateParsePromise(textDocument, validationSettings);
 
-    if (PQP.TaskUtils.isLexStage(cacheItem)) {
-        return validateLex(cacheItem, validationSettings);
-    } else if (PQP.TaskUtils.isParseStage(cacheItem)) {
-        return validateParse(cacheItem, validationSettings);
+    if (PQP.TaskUtils.isLexStage(parsePromise)) {
+        return validateLex(parsePromise, validationSettings);
+    } else if (PQP.TaskUtils.isParseStage(parsePromise)) {
+        return validateParse(parsePromise, validationSettings);
     } else {
         return [];
     }

--- a/src/powerquery-language-services/validate/validateLexAndParse.ts
+++ b/src/powerquery-language-services/validate/validateLexAndParse.ts
@@ -15,16 +15,25 @@ export async function validateLexAndParse(
     textDocument: TextDocument,
     validationSettings: ValidationSettings,
 ): Promise<Diagnostic[]> {
-    const parsePromise: PQP.Task.TriedLexTask | PQP.Task.TriedParseTask =
-        await WorkspaceCacheUtils.getOrCreateParsePromise(textDocument, validationSettings);
+    const parsePromise: PQP.Task.TriedParseTask | undefined = await WorkspaceCacheUtils.getOrCreateParsePromise(
+        textDocument,
+        validationSettings,
+    );
 
-    if (PQP.TaskUtils.isLexStage(parsePromise)) {
-        return validateLex(parsePromise, validationSettings);
-    } else if (PQP.TaskUtils.isParseStage(parsePromise)) {
+    if (parsePromise !== undefined) {
         return validateParse(parsePromise, validationSettings);
-    } else {
-        return [];
     }
+
+    const lexPromise: PQP.Task.TriedLexTask | undefined = await WorkspaceCacheUtils.getOrCreateLexPromise(
+        textDocument,
+        validationSettings,
+    );
+
+    if (lexPromise !== undefined) {
+        return validateLex(lexPromise, validationSettings);
+    }
+
+    return [];
 }
 
 function validateLex(triedLex: PQP.Task.TriedLexTask, validationSettings: ValidationSettings): Diagnostic[] {

--- a/src/powerquery-language-services/validate/validateLexAndParse.ts
+++ b/src/powerquery-language-services/validate/validateLexAndParse.ts
@@ -11,8 +11,11 @@ import { WorkspaceCache, WorkspaceCacheUtils } from "../workspaceCache";
 import { DiagnosticErrorCode } from "../diagnosticErrorCode";
 import { ValidationSettings } from "./validationSettings";
 
-export function validateLexAndParse(textDocument: TextDocument, validationSettings: ValidationSettings): Diagnostic[] {
-    const cacheItem: WorkspaceCache.ParseCacheItem = WorkspaceCacheUtils.getOrCreateParse(
+export async function validateLexAndParse(
+    textDocument: TextDocument,
+    validationSettings: ValidationSettings,
+): Promise<Diagnostic[]> {
+    const cacheItem: WorkspaceCache.ParseCacheItem = await WorkspaceCacheUtils.getOrCreateParse(
         textDocument,
         validationSettings,
     );
@@ -68,7 +71,10 @@ function validateLex(triedLex: PQP.Task.TriedLexTask, validationSettings: Valida
     return diagnostics;
 }
 
-function validateParse(triedParse: PQP.Task.TriedParseTask, validationSettings: ValidationSettings): Diagnostic[] {
+async function validateParse(
+    triedParse: PQP.Task.TriedParseTask,
+    validationSettings: ValidationSettings,
+): Promise<Diagnostic[]> {
     if (PQP.TaskUtils.isOk(triedParse) || !PQP.Parser.ParseError.isParseError(triedParse.error)) {
         return [];
     }
@@ -116,7 +122,9 @@ function validateParse(triedParse: PQP.Task.TriedParseTask, validationSettings: 
             return [];
         }
 
-        const maybeLeaf: Ast.TNode | undefined = NodeIdMapUtils.maybeRightMostLeaf(
+        // TODO: figure out why this exception is needed
+        // eslint-disable-next-line @typescript-eslint/await-thenable
+        const maybeLeaf: Ast.TNode | undefined = await NodeIdMapUtils.maybeRightMostLeaf(
             error.state.contextState.nodeIdMapCollection,
             maybeRoot.id,
         );

--- a/src/powerquery-language-services/workspaceCache/workspaceCache.ts
+++ b/src/powerquery-language-services/workspaceCache/workspaceCache.ts
@@ -2,29 +2,15 @@
 // Licensed under the MIT license.
 
 import * as PQP from "@microsoft/powerquery-parser";
-import { Position } from "vscode-languageserver-textdocument";
-
 import { Inspection } from "..";
 
-export type InspectionTask = Inspection.Inspection & {
-    readonly stage: "Inspection";
-    readonly version: number;
-    readonly parseState: PQP.Parser.ParseState;
-};
+export type PromiseParse = Promise<PQP.Task.TriedLexTask | PQP.Task.TriedParseTask>;
 
-export type CacheItem = LexCacheItem | ParseCacheItem | InspectionCacheItem;
-
-export type LexCacheItem = PQP.Task.TriedLexTask;
-
-export type ParseCacheItem = LexCacheItem | PQP.Task.TriedParseTask;
-
-export type InspectionCacheItem = ParseCacheItem | InspectionTask | undefined;
-
-// A collection for a given TextDocument.uri
+// A collection of cached promises for a given TextDocument.uri
 export interface CacheCollection {
-    readonly maybeLex: LexCacheItem | undefined;
-    readonly maybeParse: ParseCacheItem | undefined;
-    readonly maybeInspectionByPosition: Map<Position, InspectionCacheItem> | undefined;
-    readonly typeCache: Inspection.TypeCache;
-    readonly version: number;
+    maybeLex: Promise<PQP.Task.TriedLexTask> | undefined;
+    maybeParse: PromiseParse | undefined;
+    // Inspections are done on a given position so it requires a map for inspection promises.
+    inspectionByPosition: Map<string, Promise<Inspection.Inspection> | undefined>;
+    typeCache: Inspection.TypeCache;
 }

--- a/src/powerquery-language-services/workspaceCache/workspaceCache.ts
+++ b/src/powerquery-language-services/workspaceCache/workspaceCache.ts
@@ -14,5 +14,6 @@ export interface CacheCollection {
     maybeParse: Promise<PQP.Task.TriedParseTask | undefined> | undefined;
     // Inspections are done on a given position so it requires a map for inspection promises.
     inspectionByPosition: Map<string, Promise<Inspection.Inspection> | undefined>;
-    typeCache: Inspection.TypeCache;
+    readonly typeCache: Inspection.TypeCache;
+    readonly version: number;
 }

--- a/src/powerquery-language-services/workspaceCache/workspaceCache.ts
+++ b/src/powerquery-language-services/workspaceCache/workspaceCache.ts
@@ -13,7 +13,7 @@ export interface CacheCollection {
     maybeLex: Promise<PQP.Task.TriedLexTask> | undefined;
     maybeParse: Promise<PQP.Task.TriedParseTask | undefined> | undefined;
     // Inspections are done on a given position so it requires a map for inspection promises.
-    inspectionByPosition: Map<string, Promise<Inspection.Inspection> | undefined>;
+    readonly inspectionByPosition: Map<string, Promise<Inspection.Inspection> | undefined>;
     readonly typeCache: Inspection.TypeCache;
     readonly version: number;
 }

--- a/src/powerquery-language-services/workspaceCache/workspaceCache.ts
+++ b/src/powerquery-language-services/workspaceCache/workspaceCache.ts
@@ -4,11 +4,6 @@
 import * as PQP from "@microsoft/powerquery-parser";
 import { Inspection } from "..";
 
-export interface InspectionTask {
-    readonly stage: "Inspection";
-    readonly result: Inspection.Inspection;
-}
-
 // A collection of cached promises for a given TextDocument.uri
 //
 // If maybeLex or maybeParse is undefined, then those promises hasn't been evaluated yet.

--- a/src/powerquery-language-services/workspaceCache/workspaceCache.ts
+++ b/src/powerquery-language-services/workspaceCache/workspaceCache.ts
@@ -4,12 +4,19 @@
 import * as PQP from "@microsoft/powerquery-parser";
 import { Inspection } from "..";
 
-export type PromiseParse = Promise<PQP.Task.TriedLexTask | PQP.Task.TriedParseTask>;
+export interface InspectionTask {
+    readonly stage: "Inspection";
+    readonly result: Inspection.Inspection;
+}
 
 // A collection of cached promises for a given TextDocument.uri
+//
+// If maybeLex or maybeParse is undefined, then those promises hasn't been evaluated yet.
+// If maybeParse resolves to undefined, then its dependency (lex) couldn't be completed.
+// If inspectionByPosition is undefined for a given Position, then its dependency (parse) couldn't be completed.
 export interface CacheCollection {
     maybeLex: Promise<PQP.Task.TriedLexTask> | undefined;
-    maybeParse: PromiseParse | undefined;
+    maybeParse: Promise<PQP.Task.TriedParseTask | undefined> | undefined;
     // Inspections are done on a given position so it requires a map for inspection promises.
     inspectionByPosition: Map<string, Promise<Inspection.Inspection> | undefined>;
     typeCache: Inspection.TypeCache;

--- a/src/powerquery-language-services/workspaceCache/workspaceCacheUtils.ts
+++ b/src/powerquery-language-services/workspaceCache/workspaceCacheUtils.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 
 import * as PQP from "@microsoft/powerquery-parser";
+import type { TextDocument, TextDocumentContentChangeEvent } from "vscode-languageserver-textdocument";
 import type { Position } from "vscode-languageserver-types";
-import type { TextDocument } from "vscode-languageserver-textdocument";
 
 import { CacheCollection } from "./workspaceCache";
 import { Inspection } from "..";
@@ -116,6 +116,14 @@ export async function getOrCreateInspectionPromise(
         position,
         cacheCollection.typeCache,
     );
+}
+
+export function update(
+    textDocument: TextDocument,
+    _changes: ReadonlyArray<TextDocumentContentChangeEvent>,
+    _version: number,
+): void {
+    close(textDocument);
 }
 
 function createCollectionCacheKey(textDocument: TextDocument): string {

--- a/src/powerquery-language-services/workspaceCache/workspaceCacheUtils.ts
+++ b/src/powerquery-language-services/workspaceCache/workspaceCacheUtils.ts
@@ -69,17 +69,17 @@ export function getOrCreateParse(
     return parseCacheItem;
 }
 
-export function getOrCreateInspection(
+export async function getOrCreateInspection(
     textDocument: TextDocument,
     inspectionSettings: InspectionSettings,
     position: Position,
-): InspectionCacheItem {
+): Promise<InspectionCacheItem> {
     const cacheKey: string = createCacheKey(textDocument);
     const cacheVersion: number = textDocument.version;
     const cacheCollection: CacheCollection = getOrCreateCacheCollection(cacheKey, cacheVersion);
 
     const [updatedCacheCollection, inspectionCacheItem]: [CacheCollection, InspectionCacheItem] =
-        getOrCreateInspectionCacheItem(cacheCollection, textDocument, inspectionSettings, position);
+        await getOrCreateInspectionCacheItem(cacheCollection, textDocument, inspectionSettings, position);
 
     CacheCollectionByCacheKey.set(cacheKey, updatedCacheCollection);
 
@@ -171,12 +171,12 @@ function getOrCreateParseCacheItem(
     return [updateCacheCollectionAttribute(updatedCacheCollection, "maybeParse", parseCacheItem), parseCacheItem];
 }
 
-function getOrCreateInspectionCacheItem(
+async function getOrCreateInspectionCacheItem(
     cacheCollection: CacheCollection,
     textDocument: TextDocument,
     inspectionSettings: InspectionSettings,
     position: Position,
-): [CacheCollection, InspectionCacheItem] {
+): Promise<[CacheCollection, InspectionCacheItem]> {
     if (cacheCollection.maybeInspectionByPosition) {
         const maybeInspectionByPosition: Map<Position, InspectionCacheItem> = cacheCollection.maybeInspectionByPosition;
         const maybeInspection: InspectionCacheItem | undefined = maybeInspectionByPosition.get(position);
@@ -204,7 +204,7 @@ function getOrCreateInspectionCacheItem(
         throw new PQP.CommonError.InvariantError(`this should never be reached, but 'never' doesn't catch it.`);
     }
 
-    const inspection: Inspection.Inspection = Inspection.inspection(
+    const inspection: Inspection.Inspection = await Inspection.inspection(
         inspectionSettings,
         parseState,
         PQP.TaskUtils.isParseStageParseError(parseCacheItem) ? parseCacheItem.error : undefined,

--- a/src/powerquery-language-services/workspaceCache/workspaceCacheUtils.ts
+++ b/src/powerquery-language-services/workspaceCache/workspaceCacheUtils.ts
@@ -12,6 +12,11 @@ import { TypeCacheUtils } from "../inspection";
 
 const CacheCollectionByCacheKey: Map<string, CacheCollection> = new Map();
 
+export function close(textDocument: TextDocument): void {
+    const collectionCacheKey: string = createCollectionCacheKey(textDocument);
+    CacheCollectionByCacheKey.delete(collectionCacheKey);
+}
+
 export function getTypeCache(textDocument: TextDocument): Inspection.TypeCache {
     const cacheCollection: CacheCollection = getOrCreateCacheCollection(textDocument);
 
@@ -113,7 +118,7 @@ export async function getOrCreateInspectionPromise(
     );
 }
 
-function createCacheKey(textDocument: TextDocument): string {
+function createCollectionCacheKey(textDocument: TextDocument): string {
     return `${textDocument.uri}`;
 }
 
@@ -131,7 +136,7 @@ function createInspectionByPositionKey(position: Position): string {
 }
 
 function getOrCreateCacheCollection(textDocument: TextDocument): CacheCollection {
-    const cacheKey: string = createCacheKey(textDocument);
+    const cacheKey: string = createCollectionCacheKey(textDocument);
     const maybeCollection: CacheCollection | undefined = CacheCollectionByCacheKey.get(cacheKey);
 
     if (maybeCollection !== undefined) {

--- a/src/powerquery-language-services/workspaceCache/workspaceCacheUtils.ts
+++ b/src/powerquery-language-services/workspaceCache/workspaceCacheUtils.ts
@@ -5,7 +5,7 @@ import * as PQP from "@microsoft/powerquery-parser";
 import type { Position } from "vscode-languageserver-types";
 import type { TextDocument } from "vscode-languageserver-textdocument";
 
-import { CacheCollection } from "./workspaceCache";
+import { CacheCollection, PromiseParse } from "./workspaceCache";
 import { Inspection } from "..";
 import { InspectionSettings } from "../inspectionSettings";
 import { TypeCacheUtils } from "../inspection";
@@ -49,7 +49,7 @@ export function getOrCreateLexPromise(
 export async function getOrCreateParsePromise(
     textDocument: TextDocument,
     lexAndParseSettings: PQP.LexSettings & PQP.ParseSettings,
-): Promise<PQP.Task.TriedLexTask | PQP.Task.TriedParseTask> {
+): PromiseParse {
     const cacheCollection: CacheCollection = getCacheCollection(textDocument);
 
     if (cacheCollection.maybeParse) {

--- a/src/test/analysis.ts
+++ b/src/test/analysis.ts
@@ -8,9 +8,9 @@ import { expect } from "chai";
 import {
     AnalysisSettings,
     Hover,
+    Inspection,
     InspectionSettings,
     SignatureHelp,
-    WorkspaceCache,
 } from "../powerquery-language-services";
 import { TestConstants, TestUtils } from ".";
 import type { AutocompleteItem } from "../powerquery-language-services/inspection";
@@ -41,7 +41,7 @@ describe("Analysis", () => {
                 symbolProviderTimeoutInMS: 0, // immediate timeout
                 maybeCreateLocalDocumentSymbolProviderFn: (
                     library: ILibrary,
-                    _maybeTriedInspection: WorkspaceCache.CacheItem | undefined,
+                    _maybePromiseInspection: Promise<Inspection.Inspection | undefined>,
                     _createInspectionSettingsFn: () => InspectionSettings,
                 ) => new SlowSymbolProvider(library, 1000),
                 maybeCreateLibrarySymbolProviderFn: (library: ILibrary) => new SlowSymbolProvider(library, 1000),
@@ -127,7 +127,7 @@ async function runHoverTimeoutTest(provider: "local" | "library", expectedHoverT
             ? {
                   maybeCreateLocalDocumentSymbolProviderFn: (
                       library: ILibrary,
-                      _maybeTriedInspection: WorkspaceCache.CacheItem | undefined,
+                      _maybePromiseInspection: Promise<Inspection.Inspection> | undefined,
                       _createInspectionSettingsFn: () => InspectionSettings,
                   ): ISymbolProvider => new SlowSymbolProvider(library, 1000),
               }

--- a/src/test/documentSymbols.ts
+++ b/src/test/documentSymbols.ts
@@ -11,12 +11,12 @@ import { AbridgedDocumentSymbol } from "./testUtils";
 import { MockDocument } from "./mockDocument";
 
 // Used to check entire symbol heirarchy returned by getDocumentSymbols()
-function expectSymbolsForDocument(
+async function expectSymbolsForDocument(
     document: TextDocument,
     expectedSymbols: ReadonlyArray<AbridgedDocumentSymbol>,
-): void {
+): Promise<void> {
     const actualSymbols: ReadonlyArray<AbridgedDocumentSymbol> = TestUtils.createAbridgedDocumentSymbols(
-        DocumentSymbols.getDocumentSymbols(document, TestConstants.SimpleInspectionSettings, false),
+        await DocumentSymbols.getDocumentSymbols(document, TestConstants.SimpleInspectionSettings, false),
     );
 
     assert.isDefined(actualSymbols);

--- a/src/test/documentSymbols.ts
+++ b/src/test/documentSymbols.ts
@@ -28,36 +28,36 @@ async function expectSymbolsForDocument(
 }
 
 describe("getDocumentSymbols", () => {
-    it(`section foo; shared a = 1;`, () => {
+    it(`section foo; shared a = 1;`, async () => {
         const document: MockDocument = TestUtils.createTextMockDocument(`section foo; shared a = 1;`);
 
-        expectSymbolsForDocument(document, [{ name: "a", kind: SymbolKind.Number }]);
+        await expectSymbolsForDocument(document, [{ name: "a", kind: SymbolKind.Number }]);
     });
 
-    it(`section foo; shared query = let a = 1 in a;`, () => {
+    it(`section foo; shared query = let a = 1 in a;`, async () => {
         const document: MockDocument = TestUtils.createTextMockDocument(`section foo; shared query = let a = 1 in a;`);
 
-        expectSymbolsForDocument(document, [
+        await expectSymbolsForDocument(document, [
             { name: "query", kind: SymbolKind.Variable, maybeChildren: [{ name: "a", kind: SymbolKind.Number }] },
         ]);
     });
 
-    it(`let a = 1, b = "hello", c = () => 1 in c`, () => {
+    it(`let a = 1, b = "hello", c = () => 1 in c`, async () => {
         const document: MockDocument = TestUtils.createTextMockDocument(`let a = 1, b = "hello", c = () => 1 in c`);
 
-        expectSymbolsForDocument(document, [
+        await expectSymbolsForDocument(document, [
             { name: "a", kind: SymbolKind.Number },
             { name: "b", kind: SymbolKind.String },
             { name: "c", kind: SymbolKind.Function },
         ]);
     });
 
-    it(`let a = let b = 1, c = let d = 1 in d in c in a`, () => {
+    it(`let a = let b = 1, c = let d = 1 in d in c in a`, async () => {
         const document: MockDocument = TestUtils.createTextMockDocument(
             `let a = let b = 1, c = let d = 1 in d in c in a`,
         );
 
-        expectSymbolsForDocument(document, [
+        await expectSymbolsForDocument(document, [
             {
                 name: "a",
                 kind: SymbolKind.Variable,
@@ -70,21 +70,21 @@ describe("getDocumentSymbols", () => {
     });
 
     // with syntax error
-    it(`section foo; shared a = 1; b = "hello"; c = let a1`, () => {
+    it(`section foo; shared a = 1; b = "hello"; c = let a1`, async () => {
         const document: MockDocument = TestUtils.createTextMockDocument(
             `section foo; shared a = 1; b = "hello"; c = let a1`,
         );
 
-        expectSymbolsForDocument(document, [
+        await expectSymbolsForDocument(document, [
             { name: "a", kind: SymbolKind.Number },
             { name: "b", kind: SymbolKind.String },
         ]);
     });
 
-    it(`HelloWorldWithDocs.pq`, () => {
+    it(`HelloWorldWithDocs.pq`, async () => {
         const document: MockDocument = TestUtils.createFileMockDocument("HelloWorldWithDocs.pq");
 
-        expectSymbolsForDocument(document, [
+        await expectSymbolsForDocument(document, [
             // HelloWorldWithDocs.Contents comes back as a Variable because of the use of Value.ReplaceType
             { name: "HelloWorldWithDocs.Contents", kind: SymbolKind.Variable },
             { name: "HelloWorldType", kind: SymbolKind.TypeParameter },

--- a/src/test/externalConsumption.ts
+++ b/src/test/externalConsumption.ts
@@ -34,8 +34,8 @@ describe("External consumption", () => {
         };
 
         const analysis: Analysis = AnalysisUtils.createAnalysis(textDocument, analysisSettings, position);
-        const hover: Hover = await analysis.getHover();
 
+        const hover: Hover = await analysis.getHover();
         expect(hover.range === undefined);
         expect(hover.contents === null);
 

--- a/src/test/inspection.ts
+++ b/src/test/inspection.ts
@@ -35,12 +35,12 @@ function assertIsPostionInBounds(
 // Unit testing for analysis operations related to power query parser inspection results.
 describe("InspectedInvokeExpression", () => {
     describe("getContextForInspected", () => {
-        it(`${TestConstants.TestLibraryName.SquareIfNumber}(1|,`, () => {
+        it(`${TestConstants.TestLibraryName.SquareIfNumber}(1|,`, async () => {
             const [document, position]: [MockDocument, Position] = TestUtils.createMockDocumentAndPosition(
                 `${TestConstants.TestLibraryName.SquareIfNumber}(1|,`,
             );
 
-            const inspected: Inspection.Inspection = TestUtils.assertGetInspectionCacheItem(document, position);
+            const inspected: Inspection.Inspection = await TestUtils.assertGetInspectionCacheItem(document, position);
 
             const maybeContext: SignatureProviderContext | undefined =
                 InspectionUtils.getMaybeContextForSignatureProvider(inspected);
@@ -52,12 +52,12 @@ describe("InspectedInvokeExpression", () => {
             expect(context.argumentOrdinal).to.equal(0);
         });
 
-        it(`${TestConstants.TestLibraryName.SquareIfNumber}(d,|`, () => {
+        it(`${TestConstants.TestLibraryName.SquareIfNumber}(d,|`, async () => {
             const [document, position]: [MockDocument, Position] = TestUtils.createMockDocumentAndPosition(
                 `${TestConstants.TestLibraryName.SquareIfNumber}(d,|`,
             );
 
-            const inspected: Inspection.Inspection = TestUtils.assertGetInspectionCacheItem(document, position);
+            const inspected: Inspection.Inspection = await TestUtils.assertGetInspectionCacheItem(document, position);
 
             const maybeContext: SignatureProviderContext | undefined =
                 InspectionUtils.getMaybeContextForSignatureProvider(inspected);
@@ -69,12 +69,12 @@ describe("InspectedInvokeExpression", () => {
             expect(context.argumentOrdinal).to.equal(1);
         });
 
-        it(`${TestConstants.TestLibraryName.SquareIfNumber}(d,1|`, () => {
+        it(`${TestConstants.TestLibraryName.SquareIfNumber}(d,1|`, async () => {
             const [document, position]: [MockDocument, Position] = TestUtils.createMockDocumentAndPosition(
                 `${TestConstants.TestLibraryName.SquareIfNumber}(d,1|`,
             );
 
-            const inspected: Inspection.Inspection = TestUtils.assertGetInspectionCacheItem(document, position);
+            const inspected: Inspection.Inspection = await TestUtils.assertGetInspectionCacheItem(document, position);
 
             const maybeContext: SignatureProviderContext | undefined =
                 InspectionUtils.getMaybeContextForSignatureProvider(inspected);
@@ -87,7 +87,7 @@ describe("InspectedInvokeExpression", () => {
         });
 
         describe("file", () => {
-            it("DirectQueryForSQL file", () => {
+            it("DirectQueryForSQL file", async () => {
                 const document: MockDocument = TestUtils.createFileMockDocument("DirectQueryForSQL.pq");
 
                 const position: Position = {
@@ -95,7 +95,10 @@ describe("InspectedInvokeExpression", () => {
                     character: 23,
                 };
 
-                const inspected: Inspection.Inspection = TestUtils.assertGetInspectionCacheItem(document, position);
+                const inspected: Inspection.Inspection = await TestUtils.assertGetInspectionCacheItem(
+                    document,
+                    position,
+                );
 
                 expectScope(inspected, [
                     "ConnectionString",

--- a/src/test/inspection.ts
+++ b/src/test/inspection.ts
@@ -40,7 +40,7 @@ describe("InspectedInvokeExpression", () => {
                 `${TestConstants.TestLibraryName.SquareIfNumber}(1|,`,
             );
 
-            const inspected: Inspection.Inspection = await TestUtils.assertGetInspectionCacheItem(document, position);
+            const inspected: Inspection.Inspection = await TestUtils.assertGetInspection(document, position);
 
             const maybeContext: SignatureProviderContext | undefined =
                 InspectionUtils.getMaybeContextForSignatureProvider(inspected);
@@ -57,7 +57,7 @@ describe("InspectedInvokeExpression", () => {
                 `${TestConstants.TestLibraryName.SquareIfNumber}(d,|`,
             );
 
-            const inspected: Inspection.Inspection = await TestUtils.assertGetInspectionCacheItem(document, position);
+            const inspected: Inspection.Inspection = await TestUtils.assertGetInspection(document, position);
 
             const maybeContext: SignatureProviderContext | undefined =
                 InspectionUtils.getMaybeContextForSignatureProvider(inspected);
@@ -74,7 +74,7 @@ describe("InspectedInvokeExpression", () => {
                 `${TestConstants.TestLibraryName.SquareIfNumber}(d,1|`,
             );
 
-            const inspected: Inspection.Inspection = await TestUtils.assertGetInspectionCacheItem(document, position);
+            const inspected: Inspection.Inspection = await TestUtils.assertGetInspection(document, position);
 
             const maybeContext: SignatureProviderContext | undefined =
                 InspectionUtils.getMaybeContextForSignatureProvider(inspected);
@@ -95,10 +95,7 @@ describe("InspectedInvokeExpression", () => {
                     character: 23,
                 };
 
-                const inspected: Inspection.Inspection = await TestUtils.assertGetInspectionCacheItem(
-                    document,
-                    position,
-                );
+                const inspected: Inspection.Inspection = await TestUtils.assertGetInspection(document, position);
 
                 expectScope(inspected, [
                     "ConnectionString",

--- a/src/test/inspection/autocomplete/autocompleteFieldAccess.ts
+++ b/src/test/inspection/autocomplete/autocompleteFieldAccess.ts
@@ -8,12 +8,12 @@ import type { Position } from "vscode-languageserver-types";
 import { Inspection, InspectionSettings } from "../../../powerquery-language-services";
 import { TestConstants, TestUtils } from "../..";
 
-function assertGetFieldAccessAutocomplete(
+async function assertGetFieldAccessAutocomplete(
     settings: InspectionSettings,
     text: string,
     position: Position,
-): ReadonlyArray<Inspection.AutocompleteItem> {
-    const actual: Inspection.Autocomplete = TestUtils.assertGetAutocomplete(settings, text, position);
+): Promise<ReadonlyArray<Inspection.AutocompleteItem>> {
+    const actual: Inspection.Autocomplete = await TestUtils.assertGetAutocomplete(settings, text, position);
     Assert.isOk(actual.triedFieldAccess);
 
     return actual.triedFieldAccess.value ? actual.triedFieldAccess.value.autocompleteItems : [];
@@ -22,13 +22,13 @@ function assertGetFieldAccessAutocomplete(
 describe(`Inspection - Autocomplete - FieldSelection`, () => {
     describe(`Selection`, () => {
         describe(`ParseOk`, () => {
-            it(`[cat = 1, car = 2][x|]`, () => {
+            it(`[cat = 1, car = 2][x|]`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`[cat = 1, car = 2][x|]`);
 
                 const expected: ReadonlyArray<string> = [];
 
-                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultInspectionSettings,
                     text,
                     position,
@@ -37,13 +37,13 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
                 TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
-            it(`[cat = 1, car = 2][c|]`, () => {
+            it(`[cat = 1, car = 2][c|]`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`[cat = 1, car = 2][c|]`);
 
                 const expected: ReadonlyArray<string> = ["cat", "car"];
 
-                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultInspectionSettings,
                     text,
                     position,
@@ -52,13 +52,13 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
                 TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
-            it(`[cat = 1, car = 2][| c]`, () => {
+            it(`[cat = 1, car = 2][| c]`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`[cat = 1, car = 2][| c]`);
 
                 const expected: ReadonlyArray<string> = [];
 
-                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultInspectionSettings,
                     text,
                     position,
@@ -67,13 +67,13 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
                 TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
-            it(`[cat = 1, car = 2][c |]`, () => {
+            it(`[cat = 1, car = 2][c |]`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`[cat = 1, car = 2][c |]`);
 
                 const expected: ReadonlyArray<string> = [];
 
-                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultInspectionSettings,
                     text,
                     position,
@@ -82,14 +82,14 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
                 TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
-            it(`section x; value = [foo = 1, bar = 2, foobar = 3]; valueAccess = value[f|];`, () => {
+            it(`section x; value = [foo = 1, bar = 2, foobar = 3]; valueAccess = value[f|];`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `section x; value = [foo = 1, bar = 2, foobar = 3]; valueAccess = value[f|];`,
                 );
 
                 const expected: ReadonlyArray<string> = ["foo", "foobar"];
 
-                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultInspectionSettings,
                     text,
                     position,
@@ -100,13 +100,13 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
         });
 
         describe(`ParseErr`, () => {
-            it(`[cat = 1, car = 2][|]`, () => {
+            it(`[cat = 1, car = 2][|]`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`[cat = 1, car = 2][|]`);
 
                 const expected: ReadonlyArray<string> = ["cat", "car"];
 
-                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultInspectionSettings,
                     text,
                     position,
@@ -115,13 +115,13 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
                 TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
-            it(`[cat = 1, car = 2]|[`, () => {
+            it(`[cat = 1, car = 2]|[`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`[cat = 1, car = 2]|[`);
 
                 const expected: ReadonlyArray<string> = [];
 
-                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultInspectionSettings,
                     text,
                     position,
@@ -130,13 +130,13 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
                 TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
-            it(`[cat = 1, car = 2][|`, () => {
+            it(`[cat = 1, car = 2][|`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`[cat = 1, car = 2][|`);
 
                 const expected: ReadonlyArray<string> = ["cat", "car"];
 
-                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultInspectionSettings,
                     text,
                     position,
@@ -145,13 +145,13 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
                 TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
-            it(`[cat = 1, car = 2][x|`, () => {
+            it(`[cat = 1, car = 2][x|`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`[cat = 1, car = 2][x|`);
 
                 const expected: ReadonlyArray<string> = [];
 
-                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultInspectionSettings,
                     text,
                     position,
@@ -160,13 +160,13 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
                 TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
-            it(`[cat = 1, car = 2][c|`, () => {
+            it(`[cat = 1, car = 2][c|`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`[cat = 1, car = 2][c|`);
 
                 const expected: ReadonlyArray<string> = ["cat", "car"];
 
-                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultInspectionSettings,
                     text,
                     position,
@@ -175,13 +175,13 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
                 TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
-            it(`[cat = 1, car = 2][c |`, () => {
+            it(`[cat = 1, car = 2][c |`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`[cat = 1, car = 2][c |`);
 
                 const expected: ReadonlyArray<string> = [];
 
-                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultInspectionSettings,
                     text,
                     position,
@@ -190,14 +190,14 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
                 TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
-            it(`section x; value = [foo = 1, bar = 2, foobar = 3]; valueAccess = value[|`, () => {
+            it(`section x; value = [foo = 1, bar = 2, foobar = 3]; valueAccess = value[|`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `section x; value = [foo = 1, bar = 2, foobar = 3]; valueAccess = value[|`,
                 );
 
                 const expected: ReadonlyArray<string> = ["foo", "bar", "foobar"];
 
-                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultInspectionSettings,
                     text,
                     position,
@@ -210,13 +210,13 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
 
     describe("Projection", () => {
         describe("ParseOk", () => {
-            it(`[cat = 1, car = 2][ [x|] ]`, () => {
+            it(`[cat = 1, car = 2][ [x|] ]`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`[cat = 1, car = 2][ [x|] ]`);
 
                 const expected: ReadonlyArray<string> = [];
 
-                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultInspectionSettings,
                     text,
                     position,
@@ -225,13 +225,13 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
                 TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
-            it(`[cat = 1, car = 2][ [c|] ]`, () => {
+            it(`[cat = 1, car = 2][ [c|] ]`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`[cat = 1, car = 2][ [c|] ]`);
 
                 const expected: ReadonlyArray<string> = ["cat", "car"];
 
-                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultInspectionSettings,
                     text,
                     position,
@@ -241,13 +241,13 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
                 TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
-            it(`[cat = 1, car = 2][ [c |] ]`, () => {
+            it(`[cat = 1, car = 2][ [c |] ]`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`[cat = 1, car = 2][ [c |] ]`);
 
                 const expected: ReadonlyArray<string> = [];
 
-                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultInspectionSettings,
                     text,
                     position,
@@ -256,14 +256,14 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
                 TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
-            it(`[cat = 1, car = 2][ [x], [c|] ]`, () => {
+            it(`[cat = 1, car = 2][ [x], [c|] ]`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [x], [c|] ]`,
                 );
 
                 const expected: ReadonlyArray<string> = ["cat", "car"];
 
-                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultInspectionSettings,
                     text,
                     position,
@@ -272,14 +272,14 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
                 TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
-            it(`[cat = 1, car = 2][ [cat], [c|] ]`, () => {
+            it(`[cat = 1, car = 2][ [cat], [c|] ]`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [cat], [c|] ]`,
                 );
 
                 const expected: ReadonlyArray<string> = ["car"];
 
-                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultInspectionSettings,
                     text,
                     position,
@@ -288,14 +288,14 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
                 TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
-            it(`[cat = 1, car = 2][ [cat], [car], [c|] ]`, () => {
+            it(`[cat = 1, car = 2][ [cat], [car], [c|] ]`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [cat], [car], [c|] ]`,
                 );
 
                 const expected: ReadonlyArray<string> = [];
 
-                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultInspectionSettings,
                     text,
                     position,
@@ -306,13 +306,13 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
         });
 
         describe(`ParseErr`, () => {
-            it(`[cat = 1, car = 2][ [|`, () => {
+            it(`[cat = 1, car = 2][ [|`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`[cat = 1, car = 2][ [|`);
 
                 const expected: ReadonlyArray<string> = ["cat", "car"];
 
-                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultInspectionSettings,
                     text,
                     position,
@@ -321,13 +321,13 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
                 TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
-            it(`[cat = 1, car = 2][ [ |`, () => {
+            it(`[cat = 1, car = 2][ [ |`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`[cat = 1, car = 2][ [ |`);
 
                 const expected: ReadonlyArray<string> = ["cat", "car"];
 
-                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultInspectionSettings,
                     text,
                     position,
@@ -336,13 +336,13 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
                 TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
-            it(`[cat = 1, car = 2][ [ c|`, () => {
+            it(`[cat = 1, car = 2][ [ c|`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`[cat = 1, car = 2][ [ c|`);
 
                 const expected: ReadonlyArray<string> = ["cat", "car"];
 
-                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultInspectionSettings,
                     text,
                     position,
@@ -351,13 +351,13 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
                 TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
-            it(`[cat = 1, car = 2][ [ cat|`, () => {
+            it(`[cat = 1, car = 2][ [ cat|`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`[cat = 1, car = 2][ [ cat|`);
 
                 const expected: ReadonlyArray<string> = ["cat"];
 
-                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultInspectionSettings,
                     text,
                     position,
@@ -366,13 +366,13 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
                 TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
-            it(`[cat = 1, car = 2][ [ cat |`, () => {
+            it(`[cat = 1, car = 2][ [ cat |`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`[cat = 1, car = 2][ [ cat |`);
 
                 const expected: ReadonlyArray<string> = [];
 
-                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultInspectionSettings,
                     text,
                     position,
@@ -381,13 +381,13 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
                 TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
-            it(`[cat = 1, car = 2][ [ cat ]|`, () => {
+            it(`[cat = 1, car = 2][ [ cat ]|`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`[cat = 1, car = 2][ [ cat ]|`);
 
                 const expected: ReadonlyArray<string> = [];
 
-                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultInspectionSettings,
                     text,
                     position,
@@ -396,13 +396,13 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
                 TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
-            it(`[cat = 1, car = 2][ [ cat ] |`, () => {
+            it(`[cat = 1, car = 2][ [ cat ] |`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`[cat = 1, car = 2][ [ cat ] |`);
 
                 const expected: ReadonlyArray<string> = [];
 
-                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultInspectionSettings,
                     text,
                     position,
@@ -411,13 +411,13 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
                 TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
-            it(`[cat = 1, car = 2][ [ cat ]|`, () => {
+            it(`[cat = 1, car = 2][ [ cat ]|`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`[cat = 1, car = 2][ [ cat ]|`);
 
                 const expected: ReadonlyArray<string> = [];
 
-                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultInspectionSettings,
                     text,
                     position,
@@ -426,13 +426,13 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
                 TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
-            it(`[cat = 1, car = 2][ [ cat ]|`, () => {
+            it(`[cat = 1, car = 2][ [ cat ]|`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`[cat = 1, car = 2][ [ cat ]|`);
 
                 const expected: ReadonlyArray<string> = [];
 
-                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultInspectionSettings,
                     text,
                     position,
@@ -441,13 +441,13 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
                 TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
-            it(`[cat = 1, car = 2][ [ cat ], |`, () => {
+            it(`[cat = 1, car = 2][ [ cat ], |`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`[cat = 1, car = 2][ [ cat ], |`);
 
                 const expected: ReadonlyArray<string> = [];
 
-                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultInspectionSettings,
                     text,
                     position,
@@ -456,14 +456,14 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
                 TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
-            it(`[cat = 1, car = 2][ [ cat ], [|`, () => {
+            it(`[cat = 1, car = 2][ [ cat ], [|`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [ cat ], [|`,
                 );
 
                 const expected: ReadonlyArray<string> = ["car"];
 
-                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultInspectionSettings,
                     text,
                     position,
@@ -472,14 +472,14 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
                 TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
-            it(`[cat = 1, car = 2][ [ cat ], [|<>`, () => {
+            it(`[cat = 1, car = 2][ [ cat ], [|<>`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [ cat ], [|<>`,
                 );
 
                 const expected: ReadonlyArray<string> = ["car"];
 
-                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultInspectionSettings,
                     text,
                     position,
@@ -488,14 +488,14 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
                 TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
-            it(`[cat = 1, car = 2][ [ cat ], [| <>`, () => {
+            it(`[cat = 1, car = 2][ [ cat ], [| <>`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [ cat ], [| <>`,
                 );
 
                 const expected: ReadonlyArray<string> = ["car"];
 
-                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultInspectionSettings,
                     text,
                     position,
@@ -504,14 +504,14 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
                 TestUtils.assertAutocompleteItemLabels(expected, actual);
             });
 
-            it(`[cat = 1, car = 2][ [ cat ], [<>|`, () => {
+            it(`[cat = 1, car = 2][ [ cat ], [<>|`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `[cat = 1, car = 2][ [ cat ], [<>|`,
                 );
 
                 const expected: ReadonlyArray<string> = [];
 
-                const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+                const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                     TestConstants.DefaultInspectionSettings,
                     text,
                     position,
@@ -523,14 +523,14 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
     });
 
     describe(`Indirection`, () => {
-        it(`let fn = () => [cat = 1, car = 2] in fn()[|`, () => {
+        it(`let fn = () => [cat = 1, car = 2] in fn()[|`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `let fn = () => [cat = 1, car = 2] in fn()[|`,
             );
 
             const expected: ReadonlyArray<string> = ["cat", "car"];
 
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                 TestConstants.DefaultInspectionSettings,
                 text,
                 position,
@@ -539,14 +539,14 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`let foo = () => [cat = 1, car = 2], bar = foo in bar()[|`, () => {
+        it(`let foo = () => [cat = 1, car = 2], bar = foo in bar()[|`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `let foo = () => [cat = 1, car = 2], bar = foo in bar()[|`,
             );
 
             const expected: ReadonlyArray<string> = ["cat", "car"];
 
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                 TestConstants.DefaultInspectionSettings,
                 text,
                 position,
@@ -555,14 +555,14 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`let foo = () => [cat = 1, car = 2], bar = () => foo in bar()()[|`, () => {
+        it(`let foo = () => [cat = 1, car = 2], bar = () => foo in bar()()[|`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `let foo = () => [cat = 1, car = 2], bar = () => foo in bar()()[|`,
             );
 
             const expected: ReadonlyArray<string> = ["cat", "car"];
 
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                 TestConstants.DefaultInspectionSettings,
                 text,
                 position,
@@ -571,14 +571,14 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`let foo = () => if true then [cat = 1] else [car = 2] in foo()[|`, () => {
+        it(`let foo = () => if true then [cat = 1] else [car = 2] in foo()[|`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `let foo = () => if true then [cat = 1] else [car = 2] in foo()[|`,
             );
 
             const expected: ReadonlyArray<string> = ["cat", "car"];
 
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                 TestConstants.DefaultInspectionSettings,
                 text,
                 position,
@@ -589,14 +589,14 @@ describe(`Inspection - Autocomplete - FieldSelection`, () => {
     });
 
     describe(`GeneralizedIdentifier`, () => {
-        it(`[#"regularIdentifier" = 1, #"generalized identifier" = 2][|`, () => {
+        it(`[#"regularIdentifier" = 1, #"generalized identifier" = 2][|`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `[#"regularIdentifier" = 1, #"generalized identifier" = 2][|`,
             );
 
             const expected: ReadonlyArray<string> = [`regularIdentifier`, `#"generalized identifier"`];
 
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetFieldAccessAutocomplete(
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetFieldAccessAutocomplete(
                 TestConstants.DefaultInspectionSettings,
                 text,
                 position,

--- a/src/test/inspection/autocomplete/autocompleteKeyword.ts
+++ b/src/test/inspection/autocomplete/autocompleteKeyword.ts
@@ -9,8 +9,11 @@ import type { Position } from "vscode-languageserver-types";
 import { TestConstants, TestUtils } from "../..";
 import { Inspection } from "../../../powerquery-language-services";
 
-function assertGetKeywordAutocomplete(text: string, position: Position): ReadonlyArray<Inspection.AutocompleteItem> {
-    const actual: Inspection.Autocomplete = TestUtils.assertGetAutocomplete(
+async function assertGetKeywordAutocomplete(
+    text: string,
+    position: Position,
+): Promise<ReadonlyArray<Inspection.AutocompleteItem>> {
+    const actual: Inspection.Autocomplete = await TestUtils.assertGetAutocomplete(
         TestConstants.DefaultInspectionSettings,
         text,
         position,
@@ -22,7 +25,7 @@ function assertGetKeywordAutocomplete(text: string, position: Position): Readonl
 }
 
 describe(`Inspection - Autocomplete - Keyword`, () => {
-    it("|", () => {
+    it("|", async () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`|`);
 
         const expected: ReadonlyArray<Keyword.KeywordKind> = [
@@ -30,82 +33,132 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
             Keyword.KeywordKind.Section,
         ];
 
-        const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+        const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(text, position);
         TestUtils.assertAutocompleteItemLabels(expected, actual);
     });
 
     describe("partial keyword", () => {
-        it("a|", () => {
+        it("a|", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`a|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it("x a|", () => {
+        it("x a|", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`x a|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.And, Keyword.KeywordKind.As];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it("e|", () => {
+        it("e|", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`e|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Each, Keyword.KeywordKind.Error];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it("if x then x e|", () => {
+        it("if x then x e|", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if x then x e|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Else];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it("i|", () => {
+        it("i|", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`i|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.If];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it("l|", () => {
+        it("l|", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`l|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Let];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it("m|", () => {
+        it("m|", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`m|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it("x m|", () => {
+        it("x m|", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`x m|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Meta];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it("n|", () => {
+        it("n|", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`n|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Not];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it("true o|", () => {
+        it("true o|", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`true o|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Or];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it("try true o|", () => {
+        it("try true o|", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`try true o|`);
 
             const expected: ReadonlyArray<Keyword.KeywordKind> = [
@@ -113,95 +166,159 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
                 Keyword.KeywordKind.Otherwise,
             ];
 
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it("try true o |", () => {
+        it("try true o |", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`try true o |`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it("try true ot|", () => {
+        it("try true ot|", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`try true ot|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Otherwise];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it("try true oth|", () => {
+        it("try true oth|", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`try true oth|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Otherwise];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it("s|", () => {
+        it("s|", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`s|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Section];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it("[] |", () => {
+        it("[] |", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[] |`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Section];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it("[] |s", () => {
+        it("[] |s", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[] |s`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it("[] s|", () => {
+        it("[] s|", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[] s|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Section];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it("[] s |", () => {
+        it("[] s |", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[] s |`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it("section; s|", () => {
+        it("section; s|", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`section; s|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Shared];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it("section; shared x|", () => {
+        it("section; shared x|", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`section; shared x|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it("section; [] s|", () => {
+        it("section; [] s|", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`section; [] s|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Shared];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it("if true t|", () => {
+        it("if true t|", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if true t|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Then];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it("t|", () => {
+        it("t|", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`t|`);
 
             const expected: ReadonlyArray<Keyword.KeywordKind> = [
@@ -210,27 +327,41 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
                 Keyword.KeywordKind.Type,
             ];
 
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 
     describe(`${Ast.NodeKind.ErrorHandlingExpression}`, () => {
-        it(`try |`, () => {
+        it(`try |`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`try |`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`try true|`, () => {
+        it(`try true|`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`try true|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.True];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`try true |`, () => {
+        it(`try true |`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`try true |`);
 
             const expected: ReadonlyArray<Keyword.KeywordKind> = [
@@ -242,471 +373,785 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
                 Keyword.KeywordKind.Otherwise,
             ];
 
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 
     describe(`${Ast.NodeKind.ErrorRaisingExpression}`, () => {
-        it(`if |error`, () => {
+        it(`if |error`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if |error`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`if error|`, () => {
+        it(`if error|`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if error|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`error |`, () => {
+        it(`error |`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`error |`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 
     describe(`${Ast.NodeKind.FunctionExpression}`, () => {
-        it(`let x = (_ |) => a in x`, () => {
+        it(`let x = (_ |) => a in x`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let x = (_ |) => a in x`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.As];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`let x = (_ a|) => a in`, () => {
+        it(`let x = (_ a|) => a in`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let x = (_ a|) => a in`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.As];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 
     describe(`${Ast.NodeKind.IfExpression}`, () => {
-        it(`if|`, () => {
+        it(`if|`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(` if |`, () => {
+        it(` if |`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if |`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`if 1|`, () => {
+        it(`if 1|`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if 1|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`if |if`, () => {
+        it(`if |if`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if |if`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`if i|f`, () => {
+        it(`if i|f`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if i|f`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.If];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`if if | `, () => {
+        it(`if if | `, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if if |`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`if 1 |`, () => {
+        it(`if 1 |`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if 1 |`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Then];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`if 1 t|`, () => {
+        it(`if 1 t|`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if 1 t|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Then];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`if 1 then |`, () => {
+        it(`if 1 then |`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if 1 then |`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`if 1 then 1|`, () => {
+        it(`if 1 then 1|`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if 1 then 1|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`if 1 then 1 e|`, () => {
+        it(`if 1 then 1 e|`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if 1 then 1 e|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Else];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`if 1 then 1 else|`, () => {
+        it(`if 1 then 1 else|`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if 1 then 1 else|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`if 1 th|en 1 else`, () => {
+        it(`if 1 th|en 1 else`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if 1 th|en 1 else`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Then];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`if 1 then 1 else |`, () => {
+        it(`if 1 then 1 else |`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if 1 then 1 else |`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 
     describe(`${Ast.NodeKind.InvokeExpression}`, () => {
-        it(`foo(|`, () => {
+        it(`foo(|`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`foo(|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`foo(a|`, () => {
+        it(`foo(a|`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`foo(a|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`foo(a|,`, () => {
+        it(`foo(a|,`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`foo(a|,`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`foo(a,|`, () => {
+        it(`foo(a,|`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`foo(a,|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 
     describe(`${Ast.NodeKind.ListExpression}`, () => {
-        it(`{|`, () => {
+        it(`{|`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`{|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`{1|`, () => {
+        it(`{1|`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`{1|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`{1|,`, () => {
+        it(`{1|,`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`{1|,`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`{1,|`, () => {
+        it(`{1,|`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`{1,|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`{1,|2`, () => {
+        it(`{1,|2`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`{1,|2`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`{1,|2,`, () => {
+        it(`{1,|2,`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`{1,|2,`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`{1..|`, () => {
+        it(`{1..|`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`{1..|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 
     describe(`${Ast.NodeKind.OtherwiseExpression}`, () => {
-        it(`try true otherwise| false`, () => {
+        it(`try true otherwise| false`, async () => {
             const [text, position]: [string, Position] =
                 TestUtils.assertGetTextWithPosition(`try true otherwise| false`);
 
             const expected: ReadonlyArray<Keyword.KeywordKind> = [];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`try true otherwise |false`, () => {
+        it(`try true otherwise |false`, async () => {
             const [text, position]: [string, Position] =
                 TestUtils.assertGetTextWithPosition(`try true otherwise |false`);
 
             const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`try true oth|`, () => {
+        it(`try true oth|`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`try true oth|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Otherwise];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`try true otherwise |`, () => {
+        it(`try true otherwise |`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`try true otherwise |`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 
     describe(`${Ast.NodeKind.ParenthesizedExpression}`, () => {
-        it(`+(|`, () => {
+        it(`+(|`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+(|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 
     describe(`${Ast.NodeKind.RecordExpression}`, () => {
-        it(`+[|`, () => {
+        it(`+[|`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`+[a=|`, () => {
+        it(`+[a=|`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[a=|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`+[a=1|`, () => {
+        it(`+[a=1|`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[a=1|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`+[a|=1`, () => {
+        it(`+[a|=1`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[a|=1`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`+[a=1|]`, () => {
+        it(`+[a=1|]`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[a=1|]`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`+[a=|1]`, () => {
+        it(`+[a=|1]`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[a=| 1]`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`+[a=1|,`, () => {
+        it(`+[a=1|,`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[a=1|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`+[a=1,|`, () => {
+        it(`+[a=1,|`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[a=1,|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`+[a=1|,b`, () => {
+        it(`+[a=1|,b`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[a=1|,b`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`+[a=1|,b=`, () => {
+        it(`+[a=1|,b=`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[a=1|,b=`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`+[a=|1,b=`, () => {
+        it(`+[a=|1,b=`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[a=|1,b=`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`+[a=1,b=2|`, () => {
+        it(`+[a=1,b=2|`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[a=1,b=2|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`+[a=1,b=2 |`, () => {
+        it(`+[a=1,b=2 |`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+[a=1,b=2 |`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 
     describe(`AutocompleteExpression`, () => {
-        it(`error |`, () => {
+        it(`error |`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`error |`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`let x = |`, () => {
+        it(`let x = |`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let x = |`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`() => |`, () => {
+        it(`() => |`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`() => |`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`if |`, () => {
+        it(`if |`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if |`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`if true then |`, () => {
+        it(`if true then |`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`if true then |`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`if true then true else |`, () => {
+        it(`if true then true else |`, async () => {
             const [text, position]: [string, Position] =
                 TestUtils.assertGetTextWithPosition(`if true then true else |`);
 
             const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`foo(|`, () => {
+        it(`foo(|`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`foo(|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`let x = 1 in |`, () => {
+        it(`let x = 1 in |`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let x = 1 in |`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`+{|`, () => {
+        it(`+{|`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+{|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`try true otherwise |`, () => {
+        it(`try true otherwise |`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`try true otherwise |`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`+(|`, () => {
+        it(`+(|`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`+(|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 
     describe(`${Ast.NodeKind.SectionMember}`, () => {
-        it(`section; [] |`, () => {
+        it(`section; [] |`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`section; [] |`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Shared];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`section; [] x |`, () => {
+        it(`section; [] x |`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`section; [] x |`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`section; x = |`, () => {
+        it(`section; x = |`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`section; x = |`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`section; x = 1 |`, () => {
+        it(`section; x = 1 |`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`section; x = 1 |`);
 
             const expected: ReadonlyArray<Keyword.KeywordKind> = [
@@ -717,44 +1162,68 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
                 Keyword.KeywordKind.Or,
             ];
 
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`section; x = 1 i|`, () => {
+        it(`section; x = 1 i|`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`section; x = 1 i|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Is];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`section foo; a = () => true; b = "string"; c = 1; d = |;`, () => {
+        it(`section foo; a = () => true; b = "string"; c = 1; d = |;`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `section foo; a = () => true; b = "string"; c = 1; d = |;`,
             );
 
             const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });
 
     describe(`${Ast.NodeKind.LetExpression}`, () => {
-        it(`let a = |`, () => {
+        it(`let a = |`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = |`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`let a = 1|`, () => {
+        it(`let a = 1|`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = 1|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`let a = 1 |`, () => {
+        it(`let a = 1 |`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = 1 |`);
 
             const expected: ReadonlyArray<Keyword.KeywordKind> = [
@@ -766,11 +1235,15 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
                 Keyword.KeywordKind.In,
             ];
 
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`let a = 1 | foobar`, () => {
+        it(`let a = 1 | foobar`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = 1 | foobar`);
 
             const expected: ReadonlyArray<Keyword.KeywordKind> = [
@@ -782,46 +1255,75 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
                 Keyword.KeywordKind.In,
             ];
 
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`let a = 1 i|`, () => {
+        it(`let a = 1 i|`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = 1 i|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Is, Keyword.KeywordKind.In];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`let a = 1 o|`, () => {
+        it(`let a = 1 o|`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = 1 o|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Or];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`let a = 1 m|`, () => {
+        it(`let a = 1 m|`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = 1 m|`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [Keyword.KeywordKind.Meta];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`let a = 1, |`, () => {
+        it(`let a = 1, |`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = 1, |`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`let a = let b = |`, () => {
+        it(`let a = let b = |`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = let b = |`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`let a = let b = 1 |`, () => {
+        it(`let a = let b = 1 |`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = let b = 1 |`);
 
             const expected: ReadonlyArray<Keyword.KeywordKind> = [
@@ -833,14 +1335,23 @@ describe(`Inspection - Autocomplete - Keyword`, () => {
                 Keyword.KeywordKind.In,
             ];
 
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
 
-        it(`let a = let b = 1, |`, () => {
+        it(`let a = let b = 1, |`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = let b = 1, |`);
             const expected: ReadonlyArray<Keyword.KeywordKind> = [];
-            const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetKeywordAutocomplete(text, position);
+
+            const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetKeywordAutocomplete(
+                text,
+                position,
+            );
+
             TestUtils.assertAutocompleteItemLabels(expected, actual);
         });
     });

--- a/src/test/inspection/autocomplete/autocompleteLanguageConstant.ts
+++ b/src/test/inspection/autocomplete/autocompleteLanguageConstant.ts
@@ -11,12 +11,12 @@ import { AbridgedAutocompleteItem, createAbridgedAutocompleteItem } from "./comm
 import { Inspection, InspectionSettings } from "../../../powerquery-language-services";
 import { TestConstants, TestUtils } from "../..";
 
-function assertGetLanguageConstantAutocomplete(
+async function assertGetLanguageConstantAutocomplete(
     settings: InspectionSettings,
     text: string,
     position: Position,
-): AbridgedAutocompleteItem | undefined {
-    const actual: Inspection.Autocomplete = TestUtils.assertGetAutocomplete(settings, text, position);
+): Promise<AbridgedAutocompleteItem | undefined> {
+    const actual: Inspection.Autocomplete = await TestUtils.assertGetAutocomplete(settings, text, position);
     Assert.isOk(actual.triedLanguageConstant);
 
     return actual.triedLanguageConstant.value
@@ -25,7 +25,7 @@ function assertGetLanguageConstantAutocomplete(
 }
 
 describe(`Inspection - Autocomplete - Language constants`, () => {
-    it(`a as |`, () => {
+    it(`a as |`, async () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`a as |`);
 
         const expected: AbridgedAutocompleteItem | undefined = {
@@ -33,7 +33,7 @@ describe(`Inspection - Autocomplete - Language constants`, () => {
             label: Constant.LanguageConstant.Nullable,
         };
 
-        const actual: AbridgedAutocompleteItem | undefined = assertGetLanguageConstantAutocomplete(
+        const actual: AbridgedAutocompleteItem | undefined = await assertGetLanguageConstantAutocomplete(
             TestConstants.DefaultInspectionSettings,
             text,
             position,
@@ -42,7 +42,7 @@ describe(`Inspection - Autocomplete - Language constants`, () => {
         expect(actual).to.deep.equal(expected);
     });
 
-    it(`a as n|`, () => {
+    it(`a as n|`, async () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`a as n|`);
 
         const expected: AbridgedAutocompleteItem | undefined = {
@@ -50,7 +50,7 @@ describe(`Inspection - Autocomplete - Language constants`, () => {
             label: Constant.LanguageConstant.Nullable,
         };
 
-        const actual: AbridgedAutocompleteItem | undefined = assertGetLanguageConstantAutocomplete(
+        const actual: AbridgedAutocompleteItem | undefined = await assertGetLanguageConstantAutocomplete(
             TestConstants.DefaultInspectionSettings,
             text,
             position,
@@ -59,7 +59,7 @@ describe(`Inspection - Autocomplete - Language constants`, () => {
         expect(actual).to.deep.equal(expected);
     });
 
-    it(`(a as |`, () => {
+    it(`(a as |`, async () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(a as |`);
 
         const expected: AbridgedAutocompleteItem | undefined = {
@@ -67,7 +67,7 @@ describe(`Inspection - Autocomplete - Language constants`, () => {
             label: Constant.LanguageConstant.Nullable,
         };
 
-        const actual: AbridgedAutocompleteItem | undefined = assertGetLanguageConstantAutocomplete(
+        const actual: AbridgedAutocompleteItem | undefined = await assertGetLanguageConstantAutocomplete(
             TestConstants.DefaultInspectionSettings,
             text,
             position,
@@ -76,7 +76,7 @@ describe(`Inspection - Autocomplete - Language constants`, () => {
         expect(actual).to.deep.equal(expected);
     });
 
-    it(`(a as n|`, () => {
+    it(`(a as n|`, async () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(a as n|`);
 
         const expected: AbridgedAutocompleteItem | undefined = {
@@ -84,7 +84,7 @@ describe(`Inspection - Autocomplete - Language constants`, () => {
             label: Constant.LanguageConstant.Nullable,
         };
 
-        const actual: AbridgedAutocompleteItem | undefined = assertGetLanguageConstantAutocomplete(
+        const actual: AbridgedAutocompleteItem | undefined = await assertGetLanguageConstantAutocomplete(
             TestConstants.DefaultInspectionSettings,
             text,
             position,
@@ -93,7 +93,7 @@ describe(`Inspection - Autocomplete - Language constants`, () => {
         expect(actual).to.deep.equal(expected);
     });
 
-    it(`(x, |`, () => {
+    it(`(x, |`, async () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(x, |`);
 
         const expected: AbridgedAutocompleteItem | undefined = {
@@ -101,7 +101,7 @@ describe(`Inspection - Autocomplete - Language constants`, () => {
             label: Constant.LanguageConstant.Optional,
         };
 
-        const actual: AbridgedAutocompleteItem | undefined = assertGetLanguageConstantAutocomplete(
+        const actual: AbridgedAutocompleteItem | undefined = await assertGetLanguageConstantAutocomplete(
             TestConstants.DefaultInspectionSettings,
             text,
             position,
@@ -110,7 +110,7 @@ describe(`Inspection - Autocomplete - Language constants`, () => {
         expect(actual).to.deep.equal(expected);
     });
 
-    it(`(x, op|`, () => {
+    it(`(x, op|`, async () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(x, op|`);
 
         const expected: AbridgedAutocompleteItem | undefined = {
@@ -118,7 +118,7 @@ describe(`Inspection - Autocomplete - Language constants`, () => {
             label: Constant.LanguageConstant.Optional,
         };
 
-        const actual: AbridgedAutocompleteItem | undefined = assertGetLanguageConstantAutocomplete(
+        const actual: AbridgedAutocompleteItem | undefined = await assertGetLanguageConstantAutocomplete(
             TestConstants.DefaultInspectionSettings,
             text,
             position,

--- a/src/test/inspection/autocomplete/autocompletePrimitiveType.ts
+++ b/src/test/inspection/autocomplete/autocompletePrimitiveType.ts
@@ -9,23 +9,23 @@ import type { Position } from "vscode-languageserver-types";
 import { Inspection, InspectionSettings } from "../../../powerquery-language-services";
 import { TestConstants, TestUtils } from "../..";
 
-function assertGetPrimitiveTypeAutocompleteOk(
+async function assertGetPrimitiveTypeAutocompleteOk(
     settings: InspectionSettings,
     text: string,
     position: Position,
-): ReadonlyArray<Inspection.AutocompleteItem> {
-    const actual: Inspection.Autocomplete = TestUtils.assertGetAutocomplete(settings, text, position);
+): Promise<ReadonlyArray<Inspection.AutocompleteItem>> {
+    const actual: Inspection.Autocomplete = await TestUtils.assertGetAutocomplete(settings, text, position);
     Assert.isOk(actual.triedPrimitiveType);
 
     return actual.triedPrimitiveType.value;
 }
 
 describe(`Inspection - Autocomplete - PrimitiveType`, () => {
-    it("type|", () => {
+    it("type|", async () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`type|`);
         const expected: ReadonlyArray<Constant.PrimitiveTypeConstant> = [];
 
-        const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
+        const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultInspectionSettings,
             text,
             position,
@@ -34,11 +34,11 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
         TestUtils.assertAutocompleteItemLabels(expected, actual);
     });
 
-    it("type |", () => {
+    it("type |", async () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`type |`);
         const expected: ReadonlyArray<Constant.PrimitiveTypeConstant> = Constant.PrimitiveTypeConstants;
 
-        const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
+        const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultInspectionSettings,
             text,
             position,
@@ -47,11 +47,11 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
         TestUtils.assertAutocompleteItemLabels(expected, actual);
     });
 
-    it("let x = type|", () => {
+    it("let x = type|", async () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let x = type|`);
         const expected: ReadonlyArray<Constant.PrimitiveTypeConstant> = [];
 
-        const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
+        const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultInspectionSettings,
             text,
             position,
@@ -60,11 +60,11 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
         TestUtils.assertAutocompleteItemLabels(expected, actual);
     });
 
-    it("let x = type |", () => {
+    it("let x = type |", async () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let x = type |`);
         const expected: ReadonlyArray<Constant.PrimitiveTypeConstant> = Constant.PrimitiveTypeConstants;
 
-        const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
+        const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultInspectionSettings,
             text,
             position,
@@ -73,11 +73,11 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
         TestUtils.assertAutocompleteItemLabels(expected, actual);
     });
 
-    it("type | number", () => {
+    it("type | number", async () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`type | number`);
         const expected: ReadonlyArray<Constant.PrimitiveTypeConstant> = Constant.PrimitiveTypeConstants;
 
-        const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
+        const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultInspectionSettings,
             text,
             position,
@@ -86,7 +86,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
         TestUtils.assertAutocompleteItemLabels(expected, actual);
     });
 
-    it("type n|", () => {
+    it("type n|", async () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`type n|`);
 
         const expected: ReadonlyArray<Constant.PrimitiveTypeConstant> = [
@@ -95,7 +95,7 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
             Constant.PrimitiveTypeConstant.Number,
         ];
 
-        const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
+        const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultInspectionSettings,
             text,
             position,
@@ -104,11 +104,11 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
         TestUtils.assertAutocompleteItemLabels(expected, actual);
     });
 
-    it("(x|) => 1", () => {
+    it("(x|) => 1", async () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(x|) => 1`);
         const expected: ReadonlyArray<Constant.PrimitiveTypeConstant> = [];
 
-        const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
+        const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultInspectionSettings,
             text,
             position,
@@ -117,11 +117,11 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
         TestUtils.assertAutocompleteItemLabels(expected, actual);
     });
 
-    it("(x as| number) => 1", () => {
+    it("(x as| number) => 1", async () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(x as| number) => 1`);
         const expected: ReadonlyArray<Constant.PrimitiveTypeConstant> = [];
 
-        const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
+        const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultInspectionSettings,
             text,
             position,
@@ -130,11 +130,11 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
         TestUtils.assertAutocompleteItemLabels(expected, actual);
     });
 
-    it("(x as | number) => 1", () => {
+    it("(x as | number) => 1", async () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(x as | number) => 1`);
         const expected: ReadonlyArray<Constant.PrimitiveTypeConstant> = Constant.PrimitiveTypeConstants;
 
-        const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
+        const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultInspectionSettings,
             text,
             position,
@@ -143,13 +143,13 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
         TestUtils.assertAutocompleteItemLabels(expected, actual);
     });
 
-    it("(x as| nullable number) => 1", () => {
+    it("(x as| nullable number) => 1", async () => {
         const [text, position]: [string, Position] =
             TestUtils.assertGetTextWithPosition(`(x as| nullable number) => 1`);
 
         const expected: ReadonlyArray<Constant.PrimitiveTypeConstant> = [];
 
-        const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
+        const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultInspectionSettings,
             text,
             position,
@@ -158,13 +158,13 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
         TestUtils.assertAutocompleteItemLabels(expected, actual);
     });
 
-    it("(x as | nullable number) => 1", () => {
+    it("(x as | nullable number) => 1", async () => {
         const [text, position]: [string, Position] =
             TestUtils.assertGetTextWithPosition(`(x as | nullable number) => 1`);
 
         const expected: ReadonlyArray<Constant.PrimitiveTypeConstant> = Constant.PrimitiveTypeConstants;
 
-        const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
+        const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultInspectionSettings,
             text,
             position,
@@ -173,13 +173,13 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
         TestUtils.assertAutocompleteItemLabels(expected, actual);
     });
 
-    it("(x as nullable| number) => 1", () => {
+    it("(x as nullable| number) => 1", async () => {
         const [text, position]: [string, Position] =
             TestUtils.assertGetTextWithPosition(`(x as nullable| number) => 1`);
 
         const expected: ReadonlyArray<Constant.PrimitiveTypeConstant> = [];
 
-        const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
+        const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultInspectionSettings,
             text,
             position,
@@ -188,13 +188,13 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
         TestUtils.assertAutocompleteItemLabels(expected, actual);
     });
 
-    it("(x as nullable num|ber) => 1", () => {
+    it("(x as nullable num|ber) => 1", async () => {
         const [text, position]: [string, Position] =
             TestUtils.assertGetTextWithPosition(`(x as nullable num|ber) => 1`);
 
         const expected: ReadonlyArray<Constant.PrimitiveTypeConstant> = Constant.PrimitiveTypeConstants;
 
-        const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
+        const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultInspectionSettings,
             text,
             position,
@@ -203,11 +203,11 @@ describe(`Inspection - Autocomplete - PrimitiveType`, () => {
         TestUtils.assertAutocompleteItemLabels(expected, actual);
     });
 
-    it("let a = 1 is |", () => {
+    it("let a = 1 is |", async () => {
         const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = 1 is |`);
         const expected: ReadonlyArray<Constant.PrimitiveTypeConstant> = Constant.PrimitiveTypeConstants;
 
-        const actual: ReadonlyArray<Inspection.AutocompleteItem> = assertGetPrimitiveTypeAutocompleteOk(
+        const actual: ReadonlyArray<Inspection.AutocompleteItem> = await assertGetPrimitiveTypeAutocompleteOk(
             TestConstants.DefaultInspectionSettings,
             text,
             position,

--- a/src/test/inspection/currentInvokeExpression.ts
+++ b/src/test/inspection/currentInvokeExpression.ts
@@ -17,7 +17,7 @@ function assertParseOkInvokeExpressionOk(
     settings: InspectionSettings,
     text: string,
     position: Position,
-): Inspection.CurrentInvokeExpression | undefined {
+): Promise<Inspection.CurrentInvokeExpression | undefined> {
     const parseOk: PQP.Task.ParseTaskOk = TestUtils.assertGetLexParseOk(settings, text);
 
     return assertInvokeExpressionOk(settings, parseOk.nodeIdMapCollection, position);
@@ -27,23 +27,23 @@ function assertParseErrInvokeExpressionOk(
     settings: InspectionSettings,
     text: string,
     position: Position,
-): Inspection.CurrentInvokeExpression | undefined {
+): Promise<Inspection.CurrentInvokeExpression | undefined> {
     const parseError: PQP.Task.ParseTaskParseError = TestUtils.assertGetLexParseError(settings, text);
 
     return assertInvokeExpressionOk(settings, parseError.nodeIdMapCollection, position);
 }
 
-function assertInvokeExpressionOk(
+async function assertInvokeExpressionOk(
     settings: InspectionSettings,
     nodeIdMapCollection: NodeIdMap.Collection,
     position: Position,
-): Inspection.CurrentInvokeExpression | undefined {
+): Promise<Inspection.CurrentInvokeExpression | undefined> {
     const activeNode: Inspection.ActiveNode = Inspection.ActiveNodeUtils.assertActiveNode(
         nodeIdMapCollection,
         position,
     );
 
-    const triedInspect: Inspection.TriedCurrentInvokeExpression = Inspection.tryCurrentInvokeExpression(
+    const triedInspect: Inspection.TriedCurrentInvokeExpression = await Inspection.tryCurrentInvokeExpression(
         settings,
         nodeIdMapCollection,
         activeNode,
@@ -261,12 +261,12 @@ function expectNestedInvocation(inspected: Inspection.CurrentInvokeExpression | 
 
 describe(`subset Inspection - InvokeExpression`, () => {
     describe(`parse Ok`, () => {
-        it("expects no parameters, given no parameters", () => {
+        it("expects no parameters, given no parameters", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `${TestConstants.TestLibraryName.CreateFooAndBarRecord}(|)`,
             );
 
-            const inspected: Inspection.CurrentInvokeExpression | undefined = assertParseOkInvokeExpressionOk(
+            const inspected: Inspection.CurrentInvokeExpression | undefined = await assertParseOkInvokeExpressionOk(
                 TestConstants.SimpleInspectionSettings,
                 text,
                 position,
@@ -275,12 +275,12 @@ describe(`subset Inspection - InvokeExpression`, () => {
             expectNoParameter_givenNoParameter(inspected);
         });
 
-        it("expects no parameters, given extraneous parameter", () => {
+        it("expects no parameters, given extraneous parameter", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `${TestConstants.TestLibraryName.CreateFooAndBarRecord}(1|)`,
             );
 
-            const inspected: Inspection.CurrentInvokeExpression | undefined = assertParseOkInvokeExpressionOk(
+            const inspected: Inspection.CurrentInvokeExpression | undefined = await assertParseOkInvokeExpressionOk(
                 TestConstants.SimpleInspectionSettings,
                 text,
                 position,
@@ -289,12 +289,12 @@ describe(`subset Inspection - InvokeExpression`, () => {
             expectNoParameters_givenExtraneousParameter(inspected);
         });
 
-        it("expect number parameter, missing parameter", () => {
+        it("expect number parameter, missing parameter", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `${TestConstants.TestLibraryName.SquareIfNumber}(|)`,
             );
 
-            const inspected: Inspection.CurrentInvokeExpression | undefined = assertParseOkInvokeExpressionOk(
+            const inspected: Inspection.CurrentInvokeExpression | undefined = await assertParseOkInvokeExpressionOk(
                 TestConstants.SimpleInspectionSettings,
                 text,
                 position,
@@ -303,12 +303,12 @@ describe(`subset Inspection - InvokeExpression`, () => {
             expectNumberParameter_missingParameter(inspected);
         });
 
-        it("expects required and optional, given required", () => {
+        it("expects required and optional, given required", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `${TestConstants.TestLibraryName.CombineNumberAndOptionalText}(1|)`,
             );
 
-            const inspected: Inspection.CurrentInvokeExpression | undefined = assertParseOkInvokeExpressionOk(
+            const inspected: Inspection.CurrentInvokeExpression | undefined = await assertParseOkInvokeExpressionOk(
                 TestConstants.SimpleInspectionSettings,
                 text,
                 position,
@@ -317,12 +317,12 @@ describe(`subset Inspection - InvokeExpression`, () => {
             expectRequiredAndOptional_givenRequired(inspected);
         });
 
-        it("expects required and optional, given required and optional", () => {
+        it("expects required and optional, given required and optional", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `${TestConstants.TestLibraryName.CombineNumberAndOptionalText}(1, "secondArg"|)`,
             );
 
-            const inspected: Inspection.CurrentInvokeExpression | undefined = assertParseOkInvokeExpressionOk(
+            const inspected: Inspection.CurrentInvokeExpression | undefined = await assertParseOkInvokeExpressionOk(
                 TestConstants.SimpleInspectionSettings,
                 text,
                 position,
@@ -331,12 +331,12 @@ describe(`subset Inspection - InvokeExpression`, () => {
             expectRequiredAndOptional_givenRequiredAndOptional(inspected);
         });
 
-        it("expects text, given text", () => {
+        it("expects text, given text", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `${TestConstants.TestLibraryName.DuplicateText}("foo"|)`,
             );
 
-            const inspected: Inspection.CurrentInvokeExpression | undefined = assertParseOkInvokeExpressionOk(
+            const inspected: Inspection.CurrentInvokeExpression | undefined = await assertParseOkInvokeExpressionOk(
                 TestConstants.SimpleInspectionSettings,
                 text,
                 position,
@@ -345,12 +345,12 @@ describe(`subset Inspection - InvokeExpression`, () => {
             expectText_givenText(inspected);
         });
 
-        it("expects text, given nothing", () => {
+        it("expects text, given nothing", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `${TestConstants.TestLibraryName.DuplicateText}(|)`,
             );
 
-            const inspected: Inspection.CurrentInvokeExpression | undefined = assertParseOkInvokeExpressionOk(
+            const inspected: Inspection.CurrentInvokeExpression | undefined = await assertParseOkInvokeExpressionOk(
                 TestConstants.SimpleInspectionSettings,
                 text,
                 position,
@@ -359,12 +359,12 @@ describe(`subset Inspection - InvokeExpression`, () => {
             expectText_givenNothing(inspected);
         });
 
-        it("expects text, given number", () => {
+        it("expects text, given number", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `${TestConstants.TestLibraryName.DuplicateText}(1|)`,
             );
 
-            const inspected: Inspection.CurrentInvokeExpression | undefined = assertParseOkInvokeExpressionOk(
+            const inspected: Inspection.CurrentInvokeExpression | undefined = await assertParseOkInvokeExpressionOk(
                 TestConstants.SimpleInspectionSettings,
                 text,
                 position,
@@ -373,12 +373,12 @@ describe(`subset Inspection - InvokeExpression`, () => {
             expectText_givenNumber(inspected);
         });
 
-        it("nested invocations, expects no parameters, missing parameter", () => {
+        it("nested invocations, expects no parameters, missing parameter", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `Foobar(${TestConstants.TestLibraryName.CreateFooAndBarRecord}(|), Baz)`,
             );
 
-            const inspected: Inspection.CurrentInvokeExpression | undefined = assertParseOkInvokeExpressionOk(
+            const inspected: Inspection.CurrentInvokeExpression | undefined = await assertParseOkInvokeExpressionOk(
                 TestConstants.SimpleInspectionSettings,
                 text,
                 position,
@@ -389,12 +389,12 @@ describe(`subset Inspection - InvokeExpression`, () => {
     });
 
     describe(`parse error`, () => {
-        it("expects no parameters, given no parameters", () => {
+        it("expects no parameters, given no parameters", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `${TestConstants.TestLibraryName.CreateFooAndBarRecord}(|`,
             );
 
-            const inspected: Inspection.CurrentInvokeExpression | undefined = assertParseErrInvokeExpressionOk(
+            const inspected: Inspection.CurrentInvokeExpression | undefined = await assertParseErrInvokeExpressionOk(
                 TestConstants.SimpleInspectionSettings,
                 text,
                 position,
@@ -403,12 +403,12 @@ describe(`subset Inspection - InvokeExpression`, () => {
             expectNoParameter_givenNoParameter(inspected);
         });
 
-        it("expects no parameters, given extraneous parameter", () => {
+        it("expects no parameters, given extraneous parameter", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `${TestConstants.TestLibraryName.CreateFooAndBarRecord}(1|`,
             );
 
-            const inspected: Inspection.CurrentInvokeExpression | undefined = assertParseErrInvokeExpressionOk(
+            const inspected: Inspection.CurrentInvokeExpression | undefined = await assertParseErrInvokeExpressionOk(
                 TestConstants.SimpleInspectionSettings,
                 text,
                 position,
@@ -417,12 +417,12 @@ describe(`subset Inspection - InvokeExpression`, () => {
             expectNoParameters_givenExtraneousParameter(inspected);
         });
 
-        it("expect number parameter, missing parameter", () => {
+        it("expect number parameter, missing parameter", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `${TestConstants.TestLibraryName.SquareIfNumber}(|`,
             );
 
-            const inspected: Inspection.CurrentInvokeExpression | undefined = assertParseErrInvokeExpressionOk(
+            const inspected: Inspection.CurrentInvokeExpression | undefined = await assertParseErrInvokeExpressionOk(
                 TestConstants.SimpleInspectionSettings,
                 text,
                 position,
@@ -431,12 +431,12 @@ describe(`subset Inspection - InvokeExpression`, () => {
             expectNumberParameter_missingParameter(inspected);
         });
 
-        it("expects required and optional, given required", () => {
+        it("expects required and optional, given required", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `${TestConstants.TestLibraryName.CombineNumberAndOptionalText}(1|`,
             );
 
-            const inspected: Inspection.CurrentInvokeExpression | undefined = assertParseErrInvokeExpressionOk(
+            const inspected: Inspection.CurrentInvokeExpression | undefined = await assertParseErrInvokeExpressionOk(
                 TestConstants.SimpleInspectionSettings,
                 text,
                 position,
@@ -445,12 +445,12 @@ describe(`subset Inspection - InvokeExpression`, () => {
             expectRequiredAndOptional_givenRequired(inspected);
         });
 
-        it("expects required and optional, given required and optional", () => {
+        it("expects required and optional, given required and optional", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `${TestConstants.TestLibraryName.CombineNumberAndOptionalText}(1, "secondArg"|`,
             );
 
-            const inspected: Inspection.CurrentInvokeExpression | undefined = assertParseErrInvokeExpressionOk(
+            const inspected: Inspection.CurrentInvokeExpression | undefined = await assertParseErrInvokeExpressionOk(
                 TestConstants.SimpleInspectionSettings,
                 text,
                 position,
@@ -459,12 +459,12 @@ describe(`subset Inspection - InvokeExpression`, () => {
             expectRequiredAndOptional_givenRequiredAndOptional(inspected);
         });
 
-        it("expects text, given text", () => {
+        it("expects text, given text", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `${TestConstants.TestLibraryName.DuplicateText}("foo"|`,
             );
 
-            const inspected: Inspection.CurrentInvokeExpression | undefined = assertParseErrInvokeExpressionOk(
+            const inspected: Inspection.CurrentInvokeExpression | undefined = await assertParseErrInvokeExpressionOk(
                 TestConstants.SimpleInspectionSettings,
                 text,
                 position,
@@ -473,12 +473,12 @@ describe(`subset Inspection - InvokeExpression`, () => {
             expectText_givenText(inspected);
         });
 
-        it("expects text, given nothing", () => {
+        it("expects text, given nothing", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `${TestConstants.TestLibraryName.DuplicateText}(|`,
             );
 
-            const inspected: Inspection.CurrentInvokeExpression | undefined = assertParseErrInvokeExpressionOk(
+            const inspected: Inspection.CurrentInvokeExpression | undefined = await assertParseErrInvokeExpressionOk(
                 TestConstants.SimpleInspectionSettings,
                 text,
                 position,
@@ -487,12 +487,12 @@ describe(`subset Inspection - InvokeExpression`, () => {
             expectText_givenNothing(inspected);
         });
 
-        it("expects text, given number", () => {
+        it("expects text, given number", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `${TestConstants.TestLibraryName.DuplicateText}(1|`,
             );
 
-            const inspected: Inspection.CurrentInvokeExpression | undefined = assertParseErrInvokeExpressionOk(
+            const inspected: Inspection.CurrentInvokeExpression | undefined = await assertParseErrInvokeExpressionOk(
                 TestConstants.SimpleInspectionSettings,
                 text,
                 position,
@@ -501,12 +501,12 @@ describe(`subset Inspection - InvokeExpression`, () => {
             expectText_givenNumber(inspected);
         });
 
-        it("nested invocations, expects no parameters, missing parameter", () => {
+        it("nested invocations, expects no parameters, missing parameter", async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `Foobar(${TestConstants.TestLibraryName.CreateFooAndBarRecord}(|), Baz`,
             );
 
-            const inspected: Inspection.CurrentInvokeExpression | undefined = assertParseErrInvokeExpressionOk(
+            const inspected: Inspection.CurrentInvokeExpression | undefined = await assertParseErrInvokeExpressionOk(
                 TestConstants.SimpleInspectionSettings,
                 text,
                 position,

--- a/src/test/inspection/currentInvokeExpression.ts
+++ b/src/test/inspection/currentInvokeExpression.ts
@@ -13,22 +13,22 @@ import { Inspection, InspectionSettings } from "../../powerquery-language-servic
 import { TestConstants, TestUtils } from "..";
 import { CurrentInvokeExpressionArguments } from "../../powerquery-language-services/inspection";
 
-function assertParseOkInvokeExpressionOk(
+async function assertParseOkInvokeExpressionOk(
     settings: InspectionSettings,
     text: string,
     position: Position,
 ): Promise<Inspection.CurrentInvokeExpression | undefined> {
-    const parseOk: PQP.Task.ParseTaskOk = TestUtils.assertGetLexParseOk(settings, text);
+    const parseOk: PQP.Task.ParseTaskOk = await TestUtils.assertGetLexParseOk(settings, text);
 
     return assertInvokeExpressionOk(settings, parseOk.nodeIdMapCollection, position);
 }
 
-function assertParseErrInvokeExpressionOk(
+async function assertParseErrInvokeExpressionOk(
     settings: InspectionSettings,
     text: string,
     position: Position,
 ): Promise<Inspection.CurrentInvokeExpression | undefined> {
-    const parseError: PQP.Task.ParseTaskParseError = TestUtils.assertGetLexParseError(settings, text);
+    const parseError: PQP.Task.ParseTaskParseError = await TestUtils.assertGetLexParseError(settings, text);
 
     return assertInvokeExpressionOk(settings, parseError.nodeIdMapCollection, position);
 }

--- a/src/test/inspection/scope.ts
+++ b/src/test/inspection/scope.ts
@@ -165,22 +165,22 @@ function assertNodeScopeOk(
     return triedNodeScope.value;
 }
 
-export function assertGetParseOkScopeOk(
+export async function assertGetParseOkScopeOk(
     settings: PQP.LexSettings & PQP.ParseSettings,
     text: string,
     position: Position,
-): Inspection.NodeScope {
-    const parseOk: PQP.Task.ParseTaskOk = TestUtils.assertGetLexParseOk(settings, text);
+): Promise<Inspection.NodeScope> {
+    const parseOk: PQP.Task.ParseTaskOk = await TestUtils.assertGetLexParseOk(settings, text);
 
     return assertNodeScopeOk(settings, parseOk.nodeIdMapCollection, position);
 }
 
-export function assertGetParseErrScopeOk(
+export async function assertGetParseErrScopeOk(
     settings: PQP.LexSettings & PQP.ParseSettings,
     text: string,
     position: Position,
-): Inspection.NodeScope {
-    const parseError: PQP.Task.ParseTaskParseError = TestUtils.assertGetLexParseError(settings, text);
+): Promise<Inspection.NodeScope> {
+    const parseError: PQP.Task.ParseTaskParseError = await TestUtils.assertGetLexParseError(settings, text);
 
     return assertNodeScopeOk(settings, parseError.nodeIdMapCollection, position);
 }
@@ -188,29 +188,29 @@ export function assertGetParseErrScopeOk(
 describe(`subset Inspection - Scope - Identifier`, () => {
     describe(`Scope`, () => {
         describe(`${Ast.NodeKind.EachExpression} (Ast)`, () => {
-            it(`|each 1`, () => {
+            it(`|each 1`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`|each 1`);
                 const expected: ReadonlyArray<TAbridgedNodeScopeItem> = [];
 
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
-                    assertGetParseOkScopeOk(DefaultSettings, text, position),
+                    await assertGetParseOkScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`each| 1`, () => {
+            it(`each| 1`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`each| 1`);
                 const expected: AbridgedNodeScope = [];
 
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
-                    assertGetParseOkScopeOk(DefaultSettings, text, position),
+                    await assertGetParseOkScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`each |1`, () => {
+            it(`each |1`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`each |1`);
 
                 const expected: AbridgedNodeScope = [
@@ -223,13 +223,13 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 ];
 
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
-                    assertGetParseOkScopeOk(DefaultSettings, text, position),
+                    await assertGetParseOkScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`each 1|`, () => {
+            it(`each 1|`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`each 1|`);
 
                 const expected: AbridgedNodeScope = [
@@ -242,13 +242,13 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 ];
 
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
-                    assertGetParseOkScopeOk(DefaultSettings, text, position),
+                    await assertGetParseOkScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`each each 1|`, () => {
+            it(`each each 1|`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`each each 1|`);
 
                 const expected: AbridgedNodeScope = [
@@ -261,7 +261,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 ];
 
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
-                    assertGetParseOkScopeOk(DefaultSettings, text, position),
+                    await assertGetParseOkScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
@@ -269,18 +269,18 @@ describe(`subset Inspection - Scope - Identifier`, () => {
         });
 
         describe(`${Ast.NodeKind.EachExpression} (ParserContext)`, () => {
-            it(`each|`, () => {
+            it(`each|`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`each|`);
                 const expected: AbridgedNodeScope = [];
 
                 const actual: AbridgedNodeScope = createAbridgedNodeScopeItems(
-                    assertGetParseErrScopeOk(DefaultSettings, text, position),
+                    await assertGetParseErrScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`each |`, () => {
+            it(`each |`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`each |`);
 
                 const expected: AbridgedNodeScope = [
@@ -293,7 +293,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 ];
 
                 const actual: AbridgedNodeScope = createAbridgedNodeScopeItems(
-                    assertGetParseErrScopeOk(DefaultSettings, text, position),
+                    await assertGetParseErrScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
@@ -301,40 +301,40 @@ describe(`subset Inspection - Scope - Identifier`, () => {
         });
 
         describe(`${Ast.NodeKind.FunctionExpression} (Ast)`, () => {
-            it(`|(x) => z`, () => {
+            it(`|(x) => z`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`|(x) => z`);
                 const expected: AbridgedNodeScope = [];
 
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
-                    assertGetParseOkScopeOk(DefaultSettings, text, position),
+                    await assertGetParseOkScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`(x|, y) => z`, () => {
+            it(`(x|, y) => z`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(x|, y) => z`);
                 const expected: AbridgedNodeScope = [];
 
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
-                    assertGetParseOkScopeOk(DefaultSettings, text, position),
+                    await assertGetParseOkScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`(x, y)| => z`, () => {
+            it(`(x, y)| => z`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(x, y)| => z`);
                 const expected: AbridgedNodeScope = [];
 
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
-                    assertGetParseOkScopeOk(DefaultSettings, text, position),
+                    await assertGetParseOkScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`(x, y) => z|`, () => {
+            it(`(x, y) => z|`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(x, y) => z|`);
 
                 const expected: AbridgedNodeScope = [
@@ -357,7 +357,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 ];
 
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
-                    assertGetParseOkScopeOk(DefaultSettings, text, position),
+                    await assertGetParseOkScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
@@ -365,40 +365,40 @@ describe(`subset Inspection - Scope - Identifier`, () => {
         });
 
         describe(`${Ast.NodeKind.FunctionExpression} (ParserContext)`, () => {
-            it(`|(x) =>`, () => {
+            it(`|(x) =>`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`|(x) =>`);
                 const expected: AbridgedNodeScope = [];
 
                 const actual: AbridgedNodeScope = createAbridgedNodeScopeItems(
-                    assertGetParseErrScopeOk(DefaultSettings, text, position),
+                    await assertGetParseErrScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`(x|, y) =>`, () => {
+            it(`(x|, y) =>`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(x|, y) =>`);
                 const expected: AbridgedNodeScope = [];
 
                 const actual: AbridgedNodeScope = createAbridgedNodeScopeItems(
-                    assertGetParseErrScopeOk(DefaultSettings, text, position),
+                    await assertGetParseErrScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`(x, y)| =>`, () => {
+            it(`(x, y)| =>`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(x, y)| =>`);
                 const expected: AbridgedNodeScope = [];
 
                 const actual: AbridgedNodeScope = createAbridgedNodeScopeItems(
-                    assertGetParseErrScopeOk(DefaultSettings, text, position),
+                    await assertGetParseErrScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`(x, y) =>|`, () => {
+            it(`(x, y) =>|`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(x, y) =>|`);
 
                 const expected: AbridgedNodeScope = [
@@ -421,7 +421,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 ];
 
                 const actual: AbridgedNodeScope = createAbridgedNodeScopeItems(
-                    assertGetParseErrScopeOk(DefaultSettings, text, position),
+                    await assertGetParseErrScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
@@ -429,7 +429,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
         });
 
         describe(`${Ast.NodeKind.IdentifierExpression} (Ast)`, () => {
-            it(`let x = 1, y = x in 1|`, () => {
+            it(`let x = 1, y = x in 1|`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`let x = 1, y = x in 1|`);
 
@@ -451,7 +451,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 ];
 
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
-                    assertGetParseOkScopeOk(DefaultSettings, text, position),
+                    await assertGetParseOkScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
@@ -459,29 +459,29 @@ describe(`subset Inspection - Scope - Identifier`, () => {
         });
 
         describe(`${Ast.NodeKind.RecordExpression} (Ast)`, () => {
-            it(`|[a=1]`, () => {
+            it(`|[a=1]`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`|[a=1]`);
                 const expected: AbridgedNodeScope = [];
 
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
-                    assertGetParseOkScopeOk(DefaultSettings, text, position),
+                    await assertGetParseOkScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`[|a=1]`, () => {
+            it(`[|a=1]`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[|a=1]`);
                 const expected: AbridgedNodeScope = [];
 
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
-                    assertGetParseOkScopeOk(DefaultSettings, text, position),
+                    await assertGetParseOkScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`[a=1|]`, () => {
+            it(`[a=1|]`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[a=1|]`);
 
                 const expected: AbridgedNodeScope = [
@@ -495,13 +495,13 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 ];
 
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
-                    assertGetParseOkScopeOk(DefaultSettings, text, position),
+                    await assertGetParseOkScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`[a=1, b=2|]`, () => {
+            it(`[a=1, b=2|]`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[a=1, b=2|]`);
 
                 const expected: AbridgedNodeScope = [
@@ -522,13 +522,13 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 ];
 
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
-                    assertGetParseOkScopeOk(DefaultSettings, text, position),
+                    await assertGetParseOkScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`[a=1, b=2|, c=3]`, () => {
+            it(`[a=1, b=2|, c=3]`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[a=1, b=2|, c=3]`);
 
                 const expected: AbridgedNodeScope = [
@@ -556,24 +556,24 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 ];
 
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
-                    assertGetParseOkScopeOk(DefaultSettings, text, position),
+                    await assertGetParseOkScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`[a=1]|`, () => {
+            it(`[a=1]|`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[a=1]|`);
                 const expected: AbridgedNodeScope = [];
 
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
-                    assertGetParseOkScopeOk(DefaultSettings, text, position),
+                    await assertGetParseOkScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`[a=[|b=1]]`, () => {
+            it(`[a=[|b=1]]`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[a=[|b=1]]`);
 
                 const expected: AbridgedNodeScope = [
@@ -587,7 +587,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 ];
 
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
-                    assertGetParseOkScopeOk(DefaultSettings, text, position),
+                    await assertGetParseOkScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
@@ -595,29 +595,29 @@ describe(`subset Inspection - Scope - Identifier`, () => {
         });
 
         describe(`${Ast.NodeKind.RecordExpression} (ParserContext)`, () => {
-            it(`|[a=1`, () => {
+            it(`|[a=1`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`|[a=1`);
                 const expected: AbridgedNodeScope = [];
 
                 const actual: AbridgedNodeScope = createAbridgedNodeScopeItems(
-                    assertGetParseErrScopeOk(DefaultSettings, text, position),
+                    await assertGetParseErrScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`[|a=1`, () => {
+            it(`[|a=1`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[|a=1`);
                 const expected: AbridgedNodeScope = [];
 
                 const actual: AbridgedNodeScope = createAbridgedNodeScopeItems(
-                    assertGetParseErrScopeOk(DefaultSettings, text, position),
+                    await assertGetParseErrScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`[a=|1`, () => {
+            it(`[a=|1`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[a=|1`);
 
                 const expected: AbridgedNodeScope = [
@@ -631,13 +631,13 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 ];
 
                 const actual: AbridgedNodeScope = createAbridgedNodeScopeItems(
-                    assertGetParseErrScopeOk(DefaultSettings, text, position),
+                    await assertGetParseErrScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`[a=1|`, () => {
+            it(`[a=1|`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[a=1|`);
 
                 const expected: AbridgedNodeScope = [
@@ -651,13 +651,13 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 ];
 
                 const actual: AbridgedNodeScope = createAbridgedNodeScopeItems(
-                    assertGetParseErrScopeOk(DefaultSettings, text, position),
+                    await assertGetParseErrScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`[a=1, b=|`, () => {
+            it(`[a=1, b=|`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[a=1, b=|`);
 
                 const expected: AbridgedNodeScope = [
@@ -678,13 +678,13 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 ];
 
                 const actual: AbridgedNodeScope = createAbridgedNodeScopeItems(
-                    assertGetParseErrScopeOk(DefaultSettings, text, position),
+                    await assertGetParseErrScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`[a=1, b=2|, c=3`, () => {
+            it(`[a=1, b=2|, c=3`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[a=1, b=2|, c=3`);
 
                 const expected: AbridgedNodeScope = [
@@ -712,13 +712,13 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 ];
 
                 const actual: AbridgedNodeScope = createAbridgedNodeScopeItems(
-                    assertGetParseErrScopeOk(DefaultSettings, text, position),
+                    await assertGetParseErrScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`[a=[|b=1`, () => {
+            it(`[a=[|b=1`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[a=[|b=1`);
 
                 const expected: AbridgedNodeScope = [
@@ -732,13 +732,13 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 ];
 
                 const actual: AbridgedNodeScope = createAbridgedNodeScopeItems(
-                    assertGetParseErrScopeOk(DefaultSettings, text, position),
+                    await assertGetParseErrScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`[a=[b=|`, () => {
+            it(`[a=[b=|`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`[a=[b=|`);
 
                 const expected: AbridgedNodeScope = [
@@ -759,7 +759,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 ];
 
                 const actual: AbridgedNodeScope = createAbridgedNodeScopeItems(
-                    assertGetParseErrScopeOk(DefaultSettings, text, position),
+                    await assertGetParseErrScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
@@ -767,20 +767,20 @@ describe(`subset Inspection - Scope - Identifier`, () => {
         });
 
         describe(`${Ast.NodeKind.Section} (Ast)`, () => {
-            it(`s|ection foo; x = 1; y = 2;`, () => {
+            it(`s|ection foo; x = 1; y = 2;`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`s|ection foo; x = 1; y = 2;`);
 
                 const expected: AbridgedNodeScope = [];
 
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
-                    assertGetParseOkScopeOk(DefaultSettings, text, position),
+                    await assertGetParseOkScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`section foo; x = 1|; y = 2;`, () => {
+            it(`section foo; x = 1|; y = 2;`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`section foo; x = 1|; y = 2;`);
 
@@ -802,13 +802,13 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 ];
 
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
-                    assertGetParseOkScopeOk(DefaultSettings, text, position),
+                    await assertGetParseOkScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`section foo; x = 1; y = 2|;`, () => {
+            it(`section foo; x = 1; y = 2|;`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`section foo; x = 1; y = 2|;`);
 
@@ -830,26 +830,26 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 ];
 
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
-                    assertGetParseOkScopeOk(DefaultSettings, text, position),
+                    await assertGetParseOkScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`section foo; x = 1; y = 2;|`, () => {
+            it(`section foo; x = 1; y = 2;|`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`section foo; x = 1; y = 2;|`);
 
                 const expected: AbridgedNodeScope = [];
 
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
-                    assertGetParseOkScopeOk(DefaultSettings, text, position),
+                    await assertGetParseOkScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`section foo; x = 1; y = 2; z = let a = 1 in |b;`, () => {
+            it(`section foo; x = 1; y = 2; z = let a = 1 in |b;`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `section foo; x = 1; y = 2; z = let a = 1 in |b;`,
                 );
@@ -886,7 +886,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 ];
 
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
-                    assertGetParseOkScopeOk(DefaultSettings, text, position),
+                    await assertGetParseOkScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
@@ -894,20 +894,20 @@ describe(`subset Inspection - Scope - Identifier`, () => {
         });
 
         describe(`${Ast.NodeKind.SectionMember} (ParserContext)`, () => {
-            it(`s|ection foo; x = 1; y = 2`, () => {
+            it(`s|ection foo; x = 1; y = 2`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`s|ection foo; x = 1; y = 2`);
 
                 const expected: AbridgedNodeScope = [];
 
                 const actual: AbridgedNodeScope = createAbridgedNodeScopeItems(
-                    assertGetParseErrScopeOk(DefaultSettings, text, position),
+                    await assertGetParseErrScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`section foo; x = 1|; y = 2`, () => {
+            it(`section foo; x = 1|; y = 2`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`section foo; x = 1|; y = 2`);
 
@@ -929,13 +929,13 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 ];
 
                 const actual: AbridgedNodeScope = createAbridgedNodeScopeItems(
-                    assertGetParseErrScopeOk(DefaultSettings, text, position),
+                    await assertGetParseErrScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`section foo; x = 1; y = 2|`, () => {
+            it(`section foo; x = 1; y = 2|`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`section foo; x = 1; y = 2|`);
 
@@ -957,13 +957,13 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 ];
 
                 const actual: AbridgedNodeScope = createAbridgedNodeScopeItems(
-                    assertGetParseErrScopeOk(DefaultSettings, text, position),
+                    await assertGetParseErrScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`section foo; x = 1; y = () => 10|`, () => {
+            it(`section foo; x = 1; y = () => 10|`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `section foo; x = 1; y = () => 10|`,
                 );
@@ -986,7 +986,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 ];
 
                 const actual: AbridgedNodeScope = createAbridgedNodeScopeItems(
-                    assertGetParseErrScopeOk(DefaultSettings, text, position),
+                    await assertGetParseErrScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
@@ -994,7 +994,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
         });
 
         describe(`${Ast.NodeKind.LetExpression} (Ast)`, () => {
-            it(`let a = 1 in |x`, () => {
+            it(`let a = 1 in |x`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = 1 in |x`);
 
                 const expected: AbridgedNodeScope = [
@@ -1008,13 +1008,13 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 ];
 
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
-                    assertGetParseOkScopeOk(DefaultSettings, text, position),
+                    await assertGetParseOkScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`let a = 1 in x|`, () => {
+            it(`let a = 1 in x|`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = 1 in x|`);
 
                 const expected: AbridgedNodeScope = [
@@ -1028,13 +1028,13 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 ];
 
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
-                    assertGetParseOkScopeOk(DefaultSettings, text, position),
+                    await assertGetParseOkScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`let a = |1 in x`, () => {
+            it(`let a = |1 in x`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = |1 in x`);
 
                 const expected: AbridgedNodeScope = [
@@ -1048,13 +1048,13 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 ];
 
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
-                    assertGetParseOkScopeOk(DefaultSettings, text, position),
+                    await assertGetParseOkScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`let a = 1, b = 2 in x|`, () => {
+            it(`let a = 1, b = 2 in x|`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`let a = 1, b = 2 in x|`);
 
@@ -1076,13 +1076,13 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 ];
 
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
-                    assertGetParseOkScopeOk(DefaultSettings, text, position),
+                    await assertGetParseOkScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`let a = 1|, b = 2 in x`, () => {
+            it(`let a = 1|, b = 2 in x`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`let a = 1|, b = 2 in x`);
 
@@ -1104,13 +1104,13 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 ];
 
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
-                    assertGetParseOkScopeOk(DefaultSettings, text, position),
+                    await assertGetParseOkScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`(p1, p2) => let a = 1, b = 2, c = 3| in c`, () => {
+            it(`(p1, p2) => let a = 1, b = 2, c = 3| in c`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `(p1, p2) => let a = 1, b = 2, c = 3| in c`,
                 );
@@ -1156,13 +1156,13 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 ];
 
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
-                    assertGetParseOkScopeOk(DefaultSettings, text, position),
+                    await assertGetParseOkScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`let eggs = let ham = 0 in 1, foo = 2, bar = 3 in 4|`, () => {
+            it(`let eggs = let ham = 0 in 1, foo = 2, bar = 3 in 4|`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `let eggs = let ham = 0 in 1, foo = 2, bar = 3 in 4|`,
                 );
@@ -1192,13 +1192,13 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 ];
 
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
-                    assertGetParseOkScopeOk(DefaultSettings, text, position),
+                    await assertGetParseOkScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`let eggs = let ham = 0 in |1, foo = 2, bar = 3 in 4`, () => {
+            it(`let eggs = let ham = 0 in |1, foo = 2, bar = 3 in 4`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                     `let eggs = let ham = 0 in |1, foo = 2, bar = 3 in 4`,
                 );
@@ -1235,7 +1235,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 ];
 
                 const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedNodeScopeItems(
-                    assertGetParseOkScopeOk(DefaultSettings, text, position),
+                    await assertGetParseOkScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
@@ -1243,7 +1243,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
         });
 
         describe(`${Ast.NodeKind.LetExpression} (ParserContext)`, () => {
-            it(`let a = 1 in |`, () => {
+            it(`let a = 1 in |`, async () => {
                 const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`let a = 1 in |`);
 
                 const expected: AbridgedNodeScope = [
@@ -1257,13 +1257,13 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 ];
 
                 const actual: AbridgedNodeScope = createAbridgedNodeScopeItems(
-                    assertGetParseErrScopeOk(DefaultSettings, text, position),
+                    await assertGetParseErrScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`let a = 1, b = 2 in |`, () => {
+            it(`let a = 1, b = 2 in |`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`let a = 1, b = 2 in |`);
 
@@ -1285,13 +1285,13 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 ];
 
                 const actual: AbridgedNodeScope = createAbridgedNodeScopeItems(
-                    assertGetParseErrScopeOk(DefaultSettings, text, position),
+                    await assertGetParseErrScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`let a = 1|, b = 2 in`, () => {
+            it(`let a = 1|, b = 2 in`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`let a = 1|, b = 2 in `);
 
@@ -1313,13 +1313,13 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 ];
 
                 const actual: AbridgedNodeScope = createAbridgedNodeScopeItems(
-                    assertGetParseErrScopeOk(DefaultSettings, text, position),
+                    await assertGetParseErrScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`let x = (let y = 1 in z|) in`, () => {
+            it(`let x = (let y = 1 in z|) in`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`let x = (let y = 1 in z|) in`);
 
@@ -1341,13 +1341,13 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 ];
 
                 const actual: AbridgedNodeScope = createAbridgedNodeScopeItems(
-                    assertGetParseErrScopeOk(DefaultSettings, text, position),
+                    await assertGetParseErrScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
             });
 
-            it(`let x = (let y = 1 in z) in |`, () => {
+            it(`let x = (let y = 1 in z) in |`, async () => {
                 const [text, position]: [string, Position] =
                     TestUtils.assertGetTextWithPosition(`let x = (let y = 1 in z) in |`);
 
@@ -1362,7 +1362,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 ];
 
                 const actual: AbridgedNodeScope = createAbridgedNodeScopeItems(
-                    assertGetParseErrScopeOk(DefaultSettings, text, position),
+                    await assertGetParseErrScopeOk(DefaultSettings, text, position),
                 );
 
                 expect(actual).to.deep.equal(expected);
@@ -1371,7 +1371,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
     });
 
     describe(`Parameter`, () => {
-        it(`(a, b as number, c as nullable function, optional d, optional e as table) => 1|`, () => {
+        it(`(a, b as number, c as nullable function, optional d, optional e as table) => 1|`, async () => {
             const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(
                 `(a, b as number, c as nullable function, optional d, optional e as table) => 1|`,
             );
@@ -1420,7 +1420,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
             ];
 
             const actual: ReadonlyArray<TAbridgedNodeScopeItem> = createAbridgedParameterScopeItems(
-                assertGetParseOkScopeOk(DefaultSettings, text, position),
+                await assertGetParseOkScopeOk(DefaultSettings, text, position),
             );
 
             expect(actual).to.deep.equal(expected);

--- a/src/test/inspection/type.ts
+++ b/src/test/inspection/type.ts
@@ -43,7 +43,7 @@ async function assertParseOkNodeTypeEqual(
     text: string,
     expected: Type.TPowerQueryType,
 ): Promise<void> {
-    const parseOk: PQP.Task.ParseTaskOk = TestUtils.assertGetLexParseOk(TestSettings, text);
+    const parseOk: PQP.Task.ParseTaskOk = await TestUtils.assertGetLexParseOk(TestSettings, text);
 
     const actual: Type.TPowerQueryType = await assertGetParseNodeOk(
         settings,
@@ -55,7 +55,7 @@ async function assertParseOkNodeTypeEqual(
 }
 
 async function assertParseErrNodeTypeEqual(text: string, expected: Type.TPowerQueryType): Promise<void> {
-    const parseError: PQP.Task.ParseTaskParseError = TestUtils.assertGetLexParseError(TestSettings, text);
+    const parseError: PQP.Task.ParseTaskParseError = await TestUtils.assertGetLexParseError(TestSettings, text);
 
     const actual: Type.TPowerQueryType = await assertGetParseNodeOk(
         TestSettings,
@@ -83,7 +83,7 @@ async function assertParseOkScopeTypeEqual(
     expected: Inspection.ScopeTypeByKey,
 ): Promise<void> {
     const [textWithoutPipe, position]: [string, Position] = TestUtils.assertGetTextWithPosition(textWithPipe);
-    const parseOk: PQP.Task.ParseTaskOk = TestUtils.assertGetLexParseOk(TestSettings, textWithoutPipe);
+    const parseOk: PQP.Task.ParseTaskOk = await TestUtils.assertGetLexParseOk(TestSettings, textWithoutPipe);
 
     const actual: Inspection.ScopeTypeByKey = await assertGetParseOkScopeTypeOk(
         settings,

--- a/src/test/inspection/type.ts
+++ b/src/test/inspection/type.ts
@@ -117,33 +117,33 @@ async function assertGetParseOkScopeTypeOk(
 describe(`Inspection - Type`, () => {
     describe(`static analysis`, () => {
         describe("BinOpExpression", () => {
-            it(`1 + 1`, () => {
+            it(`1 + 1`, async () => {
                 const expression: string = "1 + 1";
                 const expected: Type.Number = Type.NumberInstance;
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`true and false`, () => {
+            it(`true and false`, async () => {
                 const expression: string = `true and false`;
                 const expected: Type.Logical = Type.LogicalInstance;
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`"hello" & "world"`, () => {
+            it(`"hello" & "world"`, async () => {
                 const expression: string = `"hello" & "world"`;
                 const expected: Type.Text = Type.TextInstance;
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`true + 1`, () => {
+            it(`true + 1`, async () => {
                 const expression: string = `true + 1`;
                 const expected: Type.None = Type.NoneInstance;
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
         });
 
         describe(`${Ast.NodeKind.AsNullablePrimitiveType}`, () => {
-            it(`(foo as number, bar as nullable number) => foo + bar|`, () => {
+            it(`(foo as number, bar as nullable number) => foo + bar|`, async () => {
                 const expression: string = `(foo as number, bar as nullable number) => foo + bar|`;
 
                 const expected: Inspection.ScopeTypeByKey = new Map([
@@ -151,33 +151,33 @@ describe(`Inspection - Type`, () => {
                     ["bar", Type.NullableNumberInstance],
                 ]);
 
-                assertParseOkScopeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkScopeTypeEqual(TestSettings, expression, expected);
             });
         });
 
         describe(`${Ast.NodeKind.AsExpression}`, () => {
-            it(`1 as number`, () => {
+            it(`1 as number`, async () => {
                 const expression: string = `1 as number`;
                 const expected: Type.Number = Type.NumberInstance;
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`1 as text`, () => {
+            it(`1 as text`, async () => {
                 const expression: string = `1 as text`;
                 const expected: Type.Text = Type.TextInstance;
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`1 as any`, () => {
+            it(`1 as any`, async () => {
                 const expression: string = `1 as any`;
                 const expected: Type.Any = Type.AnyInstance;
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
         });
 
         describe(`${Ast.NodeKind.EachExpression}`, () => {
             // Test for when EachExpression returns a static value
-            it(`each 1`, () => {
+            it(`each 1`, async () => {
                 const expression: string = `each 1`;
 
                 const expected: Type.DefinedFunction = TypeUtils.createDefinedFunction(
@@ -193,12 +193,12 @@ describe(`Inspection - Type`, () => {
                     TypeUtils.createNumberLiteral(false, "1"),
                 );
 
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
         });
 
         describe(`${Ast.NodeKind.ErrorHandlingExpression}`, () => {
-            it(`try 1`, () => {
+            it(`try 1`, async () => {
                 const expression: string = `try 1`;
 
                 const expected: Type.TPowerQueryType = TypeUtils.createAnyUnion([
@@ -206,10 +206,10 @@ describe(`Inspection - Type`, () => {
                     TypeUtils.createPrimitiveType(false, Type.TypeKind.Record),
                 ]);
 
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`try 1 otherwise false`, () => {
+            it(`try 1 otherwise false`, async () => {
                 const expression: string = `try 1 otherwise false`;
 
                 const expected: Type.TPowerQueryType = TypeUtils.createAnyUnion([
@@ -217,20 +217,20 @@ describe(`Inspection - Type`, () => {
                     TypeUtils.createPrimitiveType(false, Type.TypeKind.Logical),
                 ]);
 
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
         });
 
         describe(`${Ast.NodeKind.ErrorRaisingExpression}`, () => {
-            it(`error 1`, () => {
+            it(`error 1`, async () => {
                 const expression: string = `error 1`;
                 const expected: Type.Any = Type.AnyInstance;
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
         });
 
         describe(`${Ast.NodeKind.FieldProjection}`, () => {
-            it(`[a = 1][[a]]`, () => {
+            it(`[a = 1][[a]]`, async () => {
                 const expression: string = `[a = 1][[a]]`;
 
                 const expected: Type.DefinedRecord = TypeUtils.createDefinedRecord(
@@ -239,22 +239,22 @@ describe(`Inspection - Type`, () => {
                     false,
                 );
 
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`[a = 1][[b]]`, () => {
+            it(`[a = 1][[b]]`, async () => {
                 const expression: string = `[a = 1][[b]]`;
                 const expected: Type.None = Type.NoneInstance;
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`[a = 1][[b]]?`, () => {
+            it(`[a = 1][[b]]?`, async () => {
                 const expression: string = `[a = 1][[b]]?`;
                 const expected: Type.Null = Type.NullInstance;
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`(1 as record)[[a]]`, () => {
+            it(`(1 as record)[[a]]`, async () => {
                 const expression: string = `let x = (1 as record) in x[[a]]`;
 
                 const expected: Type.DefinedRecord = TypeUtils.createDefinedRecord(
@@ -263,10 +263,10 @@ describe(`Inspection - Type`, () => {
                     false,
                 );
 
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`(1 as record)[[a]]?`, () => {
+            it(`(1 as record)[[a]]?`, async () => {
                 const expression: string = `let x = (1 as record) in x[[a]]?`;
 
                 const expected: Type.DefinedRecord = TypeUtils.createDefinedRecord(
@@ -275,17 +275,17 @@ describe(`Inspection - Type`, () => {
                     false,
                 );
 
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`(each [[foo]])([foo = "bar"])`, () => {
+            it(`(each [[foo]])([foo = "bar"])`, async () => {
                 const expression: string = `(each [[foo]])([foo = "bar"])`;
                 const expected: Type.TPowerQueryType = Type.UnknownInstance;
 
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`(each [[foo]])([foo = "bar", spam = "eggs"])`, () => {
+            it(`(each [[foo]])([foo = "bar", spam = "eggs"])`, async () => {
                 const expression: string = `(each [[foo]])([foo = "bar", spam = "eggs"])`;
 
                 const expectedFields: Map<string, Type.TPowerQueryType> = new Map([
@@ -303,7 +303,7 @@ describe(`Inspection - Type`, () => {
                     maybeEachScopeById: new Map([[5, eachScope]]),
                 };
 
-                assertParseOkNodeTypeEqual(
+                await assertParseOkNodeTypeEqual(
                     testSettingsWithEachScope,
                     expression,
                     TypeUtils.createDefinedRecord(false, expectedFields, false),
@@ -312,46 +312,46 @@ describe(`Inspection - Type`, () => {
         });
 
         describe(`${Ast.NodeKind.FieldSelector}`, () => {
-            it(`[a = 1][a]`, () => {
+            it(`[a = 1][a]`, async () => {
                 const expression: string = `[a = 1][a]`;
                 const expected: Type.NumberLiteral = TypeUtils.createNumberLiteral(false, "1");
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`[a = 1][b]`, () => {
+            it(`[a = 1][b]`, async () => {
                 const expression: string = `[a = 1][b]`;
                 const expected: Type.TPowerQueryType = Type.NoneInstance;
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`[a = 1][b]?`, () => {
+            it(`[a = 1][b]?`, async () => {
                 const expression: string = `[a = 1][b]?`;
                 const expected: Type.TPowerQueryType = Type.NullInstance;
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`let x = (1 as record) in x[a]`, () => {
+            it(`let x = (1 as record) in x[a]`, async () => {
                 const expression: string = `let x = (1 as record) in x[a]`;
                 const expected: Type.TPowerQueryType = Type.AnyInstance;
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`let x = (1 as record) in x[a]?`, () => {
+            it(`let x = (1 as record) in x[a]?`, async () => {
                 const expression: string = `let x = (1 as record) in x[a]?`;
                 const expected: Type.TPowerQueryType = Type.AnyInstance;
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
             // Test for when FieldSelector is used in an EachExpression but wasn't a scope
-            it(`(each [foo])([foo = "bar"])`, () => {
+            it(`(each [foo])([foo = "bar"])`, async () => {
                 const expression: string = `(each [foo])([foo = "bar"])`;
                 const expected: Type.TPowerQueryType = Type.UnknownInstance;
 
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
             // Test for when FieldSelector is used and was given an eachScope
-            it(`(each [foo])([foo = "bar"])`, () => {
+            it(`(each [foo])([foo = "bar"])`, async () => {
                 const expression: string = `(each [foo])([foo = "bar"])`;
                 const expected: Type.TPowerQueryType = TypeUtils.createTextLiteral(false, `"bar"`);
 
@@ -366,12 +366,12 @@ describe(`Inspection - Type`, () => {
                     maybeEachScopeById: new Map([[5, eachScope]]),
                 };
 
-                assertParseOkNodeTypeEqual(testSettingsWithEachScope, expression, expected);
+                await assertParseOkNodeTypeEqual(testSettingsWithEachScope, expression, expected);
             });
         });
 
         describe(`${Ast.NodeKind.FunctionExpression}`, () => {
-            it(`() => 1`, () => {
+            it(`() => 1`, async () => {
                 const expression: string = `() => 1`;
 
                 const expected: Type.DefinedFunction = TypeUtils.createDefinedFunction(
@@ -380,11 +380,11 @@ describe(`Inspection - Type`, () => {
                     TypeUtils.createNumberLiteral(false, "1"),
                 );
 
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
             // Test AnyUnion return
-            it(`() => if true then 1 else ""`, () => {
+            it(`() => if true then 1 else ""`, async () => {
                 const expression: string = `() => if true then 1 else ""`;
 
                 const expected: Type.DefinedFunction = TypeUtils.createDefinedFunction(
@@ -396,10 +396,10 @@ describe(`Inspection - Type`, () => {
                     ]),
                 );
 
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`(a, b as number, c as nullable number, optional d) => 1`, () => {
+            it(`(a, b as number, c as nullable number, optional d) => 1`, async () => {
                 const expression: string = `(a, b as number, c as nullable number, optional d) => 1`;
 
                 const expected: Type.TPowerQueryType = TypeUtils.createDefinedFunction(
@@ -433,24 +433,24 @@ describe(`Inspection - Type`, () => {
                     TypeUtils.createNumberLiteral(false, "1"),
                 );
 
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
         });
 
         describe(`${Ast.NodeKind.FunctionType}`, () => {
-            it(`type function`, () => {
+            it(`type function`, async () => {
                 const expression: string = `type function`;
                 const expected: Type.Function = Type.FunctionInstance;
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`type function () as text`, () => {
+            it(`type function () as text`, async () => {
                 const expression: string = `type function () as text`;
                 const expected: Type.FunctionType = TypeUtils.createFunctionType(false, [], Type.TextInstance);
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`type function (foo as number, bar as nullable text, optional baz as date) as text`, () => {
+            it(`type function (foo as number, bar as nullable text, optional baz as date) as text`, async () => {
                 const expression: string = `type function (foo as number, bar as nullable text, optional baz as date) as text`;
 
                 const expected: Type.FunctionType = TypeUtils.createFunctionType(
@@ -478,32 +478,32 @@ describe(`Inspection - Type`, () => {
                     Type.TextInstance,
                 );
 
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
         });
 
         describe(`${Ast.NodeKind.IdentifierExpression}`, () => {
-            it(`let x = true in x`, () => {
+            it(`let x = true in x`, async () => {
                 const expression: string = "let x = true in x";
                 const expected: Type.Logical = Type.LogicalInstance;
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`let x = 1 in x`, () => {
+            it(`let x = 1 in x`, async () => {
                 const expression: string = "let x = 1 in x";
                 const expected: Type.NumberLiteral = TypeUtils.createNumberLiteral(false, "1");
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
         });
 
         describe(`${Ast.NodeKind.IfExpression}`, () => {
-            it(`if true then true else false`, () => {
+            it(`if true then true else false`, async () => {
                 const expression: string = `if true then true else false`;
                 const expected: Type.Logical = Type.LogicalInstance;
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`if true then 1 else false`, () => {
+            it(`if true then 1 else false`, async () => {
                 const expression: string = `if true then 1 else false`;
 
                 const expected: Type.TPowerQueryType = TypeUtils.createAnyUnion([
@@ -511,10 +511,10 @@ describe(`Inspection - Type`, () => {
                     TypeUtils.createPrimitiveType(false, Type.TypeKind.Logical),
                 ]);
 
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`if if true then true else false then 1 else 0`, () => {
+            it(`if if true then true else false then 1 else 0`, async () => {
                 const expression: string = `if if true then true else false then 1 else ""`;
 
                 const expected: Type.TPowerQueryType = TypeUtils.createAnyUnion([
@@ -522,34 +522,34 @@ describe(`Inspection - Type`, () => {
                     TypeUtils.createTextLiteral(false, `""`),
                 ]);
 
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`if`, () => {
+            it(`if`, async () => {
                 const expression: string = `if`;
                 const expected: Type.TPowerQueryType = Type.UnknownInstance;
-                assertParseErrNodeTypeEqual(expression, expected);
+                await assertParseErrNodeTypeEqual(expression, expected);
             });
 
-            it(`if "a"`, () => {
+            it(`if "a"`, async () => {
                 const expression: string = `if "a"`;
                 const expected: Type.TPowerQueryType = Type.NoneInstance;
-                assertParseErrNodeTypeEqual(expression, expected);
+                await assertParseErrNodeTypeEqual(expression, expected);
             });
 
-            it(`if true or "a"`, () => {
+            it(`if true or "a"`, async () => {
                 const expression: string = `if true or "a"`;
                 const expected: Type.TPowerQueryType = Type.NoneInstance;
-                assertParseErrNodeTypeEqual(expression, expected);
+                await assertParseErrNodeTypeEqual(expression, expected);
             });
 
-            it(`if 1 as any then "a" as text else "b" as text`, () => {
+            it(`if 1 as any then "a" as text else "b" as text`, async () => {
                 const expression: string = `if 1 as any then "a"as text else "b" as text`;
                 const expected: Type.TPowerQueryType = TypeUtils.createPrimitiveType(false, Type.TypeKind.Text);
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`if 1 as any then "a" else "b"`, () => {
+            it(`if 1 as any then "a" else "b"`, async () => {
                 const expression: string = `if 1 as any then "a" else "b"`;
 
                 const expected: Type.TPowerQueryType = TypeUtils.createAnyUnion([
@@ -557,10 +557,10 @@ describe(`Inspection - Type`, () => {
                     TypeUtils.createTextLiteral(false, `"b"`),
                 ]);
 
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`if true then 1`, () => {
+            it(`if true then 1`, async () => {
                 const expression: string = `if true then 1`;
 
                 const expected: Type.TPowerQueryType = TypeUtils.createAnyUnion([
@@ -568,38 +568,38 @@ describe(`Inspection - Type`, () => {
                     TypeUtils.createPrimitiveType(false, Type.TypeKind.Unknown),
                 ]);
 
-                assertParseErrNodeTypeEqual(expression, expected);
+                await assertParseErrNodeTypeEqual(expression, expected);
             });
         });
 
         describe(`${Ast.NodeKind.IsExpression}`, () => {
-            it(`1 is text`, () => {
+            it(`1 is text`, async () => {
                 const expression: string = `1 is text`;
                 const expected: Type.Logical = Type.LogicalInstance;
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
         });
 
         describe(`${Ast.NodeKind.IsNullablePrimitiveType}`, () => {
-            it(`1 is nullable text`, () => {
+            it(`1 is nullable text`, async () => {
                 const expression: string = `1 is nullable text`;
                 const expected: Type.Logical = Type.LogicalInstance;
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
         });
 
         describe(`${Ast.NodeKind.ListExpression}`, () => {
-            it(`{1}`, () => {
+            it(`{1}`, async () => {
                 const expression: string = `{1}`;
 
                 const expected: Type.DefinedList = TypeUtils.createDefinedList(false, [
                     TypeUtils.createNumberLiteral(false, "1"),
                 ]);
 
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`{1, ""}`, () => {
+            it(`{1, ""}`, async () => {
                 const expression: string = `{1, ""}`;
 
                 const expected: Type.DefinedList = TypeUtils.createDefinedList(false, [
@@ -607,12 +607,12 @@ describe(`Inspection - Type`, () => {
                     TypeUtils.createTextLiteral(false, `""`),
                 ]);
 
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
         });
 
         describe(`${Ast.NodeKind.ListType}`, () => {
-            it(`type { number }`, () => {
+            it(`type { number }`, async () => {
                 const expression: string = `type { number }`;
 
                 const expected: Type.ListType = TypeUtils.createListType(
@@ -620,64 +620,64 @@ describe(`Inspection - Type`, () => {
                     TypeUtils.createPrimitiveType(false, Type.TypeKind.Number),
                 );
 
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
         });
 
         describe(`${Ast.NodeKind.LiteralExpression}`, () => {
-            it(`true`, () => {
+            it(`true`, async () => {
                 const expression: string = "true";
                 const expected: Type.Logical = Type.LogicalInstance;
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`false`, () => {
+            it(`false`, async () => {
                 const expression: string = "false";
                 const expected: Type.Logical = Type.LogicalInstance;
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`1`, () => {
+            it(`1`, async () => {
                 const expression: string = "1";
                 const expected: Type.NumberLiteral = TypeUtils.createNumberLiteral(false, "1");
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`null`, () => {
+            it(`null`, async () => {
                 const expression: string = "null";
                 const expected: Type.TPowerQueryType = TypeUtils.createPrimitiveType(true, Type.TypeKind.Null);
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`{}`, () => {
+            it(`{}`, async () => {
                 const expression: string = `{}`;
                 const expected: Type.DefinedList = TypeUtils.createDefinedList(false, []);
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`[]`, () => {
+            it(`[]`, async () => {
                 const expression: string = `[]`;
                 const expected: Type.DefinedRecord = TypeUtils.createDefinedRecord(false, new Map(), false);
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
         });
 
         describe(`${Ast.NodeKind.NullableType}`, () => {
-            it(`type nullable number`, () => {
+            it(`type nullable number`, async () => {
                 const expression: string = "type nullable number";
                 const expected: Type.TPowerQueryType = TypeUtils.createPrimitiveType(true, Type.TypeKind.Number);
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
         });
 
         describe(`${Ast.NodeKind.NullCoalescingExpression}`, () => {
-            it(`1 ?? 1`, () => {
+            it(`1 ?? 1`, async () => {
                 const expression: string = `1 ?? 1`;
                 const expected: Type.NumberLiteral = TypeUtils.createNumberLiteral(false, "1");
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`1 ?? 2`, () => {
+            it(`1 ?? 2`, async () => {
                 const expression: string = `1 ?? 2`;
 
                 const expected: Type.TPowerQueryType = TypeUtils.createAnyUnion([
@@ -685,10 +685,10 @@ describe(`Inspection - Type`, () => {
                     TypeUtils.createNumberLiteral(false, `2`),
                 ]);
 
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`1 ?? ""`, () => {
+            it(`1 ?? ""`, async () => {
                 const expression: string = `1 ?? ""`;
 
                 const expected: Type.TPowerQueryType = TypeUtils.createAnyUnion([
@@ -696,18 +696,18 @@ describe(`Inspection - Type`, () => {
                     TypeUtils.createTextLiteral(false, `""`),
                 ]);
 
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`1 ?? (1 + "")`, () => {
+            it(`1 ?? (1 + "")`, async () => {
                 const expression: string = `1 ?? (1 + "")`;
                 const expected: Type.None = Type.NoneInstance;
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
         });
 
         describe(`${Ast.NodeKind.RecordExpression}`, () => {
-            it(`[foo = 1] & [bar = 2]`, () => {
+            it(`[foo = 1] & [bar = 2]`, async () => {
                 const expression: string = `[foo = 1] & [bar = 2]`;
 
                 const expected: Type.DefinedRecord = TypeUtils.createDefinedRecord(
@@ -719,10 +719,10 @@ describe(`Inspection - Type`, () => {
                     false,
                 );
 
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`[] & [bar = 2]`, () => {
+            it(`[] & [bar = 2]`, async () => {
                 const expression: string = `[] & [bar = 2]`;
 
                 const expected: Type.DefinedRecord = TypeUtils.createDefinedRecord(
@@ -731,10 +731,10 @@ describe(`Inspection - Type`, () => {
                     false,
                 );
 
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`[foo = 1] & []`, () => {
+            it(`[foo = 1] & []`, async () => {
                 const expression: string = `[foo = 1] & []`;
 
                 const expected: Type.DefinedRecord = TypeUtils.createDefinedRecord(
@@ -743,10 +743,10 @@ describe(`Inspection - Type`, () => {
                     false,
                 );
 
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`[foo = 1] & [foo = ""]`, () => {
+            it(`[foo = 1] & [foo = ""]`, async () => {
                 const expression: string = `[foo = 1] & [foo = ""]`;
 
                 const expected: Type.DefinedRecord = TypeUtils.createDefinedRecord(
@@ -755,10 +755,10 @@ describe(`Inspection - Type`, () => {
                     false,
                 );
 
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`[] as record & [foo = 1]`, () => {
+            it(`[] as record & [foo = 1]`, async () => {
                 const expression: string = `[] as record & [foo = 1]`;
 
                 const expected: Type.DefinedRecord = TypeUtils.createDefinedRecord(
@@ -767,10 +767,10 @@ describe(`Inspection - Type`, () => {
                     true,
                 );
 
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`[foo = 1] & [] as record`, () => {
+            it(`[foo = 1] & [] as record`, async () => {
                 const expression: string = `[foo = 1] & [] as record`;
 
                 const expected: Type.DefinedRecord = TypeUtils.createDefinedRecord(
@@ -779,18 +779,18 @@ describe(`Inspection - Type`, () => {
                     true,
                 );
 
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`[] as record & [] as record`, () => {
+            it(`[] as record & [] as record`, async () => {
                 const expression: string = `[] as record & [] as record`;
                 const expected: Type.TPowerQueryType = TypeUtils.createPrimitiveType(false, Type.TypeKind.Record);
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
         });
 
         describe(`${Ast.NodeKind.RecordType}`, () => {
-            it(`type [foo]`, () => {
+            it(`type [foo]`, async () => {
                 const expression: string = `type [foo]`;
 
                 const expected: Type.RecordType = TypeUtils.createRecordType(
@@ -799,10 +799,10 @@ describe(`Inspection - Type`, () => {
                     false,
                 );
 
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`type [foo, ...]`, () => {
+            it(`type [foo, ...]`, async () => {
                 const expression: string = `type [foo, ...]`;
 
                 const expected: Type.RecordType = TypeUtils.createRecordType(
@@ -811,10 +811,10 @@ describe(`Inspection - Type`, () => {
                     true,
                 );
 
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`type [foo = number, bar = nullable text]`, () => {
+            it(`type [foo = number, bar = nullable text]`, async () => {
                 const expression: string = `type [foo = number, bar = nullable text]`;
 
                 const expected: Type.RecordType = TypeUtils.createRecordType(
@@ -826,45 +826,45 @@ describe(`Inspection - Type`, () => {
                     false,
                 );
 
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
         });
 
         describe(`${Ast.NodeKind.RecursivePrimaryExpression}`, () => {
             describe(`any is allowed`, () => {
-                it(`${Ast.NodeKind.InvokeExpression}`, () => {
+                it(`${Ast.NodeKind.InvokeExpression}`, async () => {
                     const expression: string = `let x = (_ as any) in x()`;
                     const expected: Type.Any = Type.AnyInstance;
-                    assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                    await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
                 });
 
-                it(`${Ast.NodeKind.ItemAccessExpression}`, () => {
+                it(`${Ast.NodeKind.ItemAccessExpression}`, async () => {
                     const expression: string = `let x = (_ as any) in x{0}`;
                     const expected: Type.Any = Type.AnyInstance;
-                    assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                    await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
                 });
 
                 describe(`${Ast.NodeKind.FieldSelector}`, () => {
-                    it("[a = 1][a]", () => {
+                    it("[a = 1][a]", async () => {
                         const expression: string = `[a = 1][a]`;
                         const expected: Type.NumberLiteral = TypeUtils.createNumberLiteral(false, "1");
-                        assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                        await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
                     });
 
-                    it("[a = 1][b]", () => {
+                    it("[a = 1][b]", async () => {
                         const expression: string = `[a = 1][b]`;
                         const expected: Type.None = Type.NoneInstance;
-                        assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                        await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
                     });
 
-                    it("a[b]?", () => {
+                    it("a[b]?", async () => {
                         const expression: string = `[a = 1][b]?`;
                         const expected: Type.Null = Type.NullInstance;
-                        assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                        await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
                     });
                 });
 
-                it(`${Ast.NodeKind.FieldProjection}`, () => {
+                it(`${Ast.NodeKind.FieldProjection}`, async () => {
                     const expression: string = `let x = (_ as any) in x[[foo]]`;
 
                     const expected: Type.TPowerQueryType = TypeUtils.createAnyUnion([
@@ -872,25 +872,25 @@ describe(`Inspection - Type`, () => {
                         TypeUtils.createDefinedTable(false, new PQP.OrderedMap([["foo", Type.AnyInstance]]), false),
                     ]);
 
-                    assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                    await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
                 });
 
-                it(`${Ast.NodeKind.FieldSelector}`, () => {
+                it(`${Ast.NodeKind.FieldSelector}`, async () => {
                     const expression: string = `[a = 1][a]`;
                     const expected: Type.NumberLiteral = TypeUtils.createNumberLiteral(false, "1");
-                    assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                    await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
                 });
             });
 
-            it(`let x = () as function => () as number => 1 in x()()`, () => {
+            it(`let x = () as function => () as number => 1 in x()()`, async () => {
                 const expression: string = `let x = () as function => () as number => 1 in x()()`;
                 const expected: Type.NumberLiteral = TypeUtils.createNumberLiteral(false, "1");
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
         });
 
         describe(`Recursive identifiers`, () => {
-            it(`let foo = 1 in [foo = foo]`, () => {
+            it(`let foo = 1 in [foo = foo]`, async () => {
                 const expression: string = `let foo = 1 in [foo = foo]`;
 
                 const expected: Type.DefinedRecord = TypeUtils.createDefinedRecord(
@@ -899,10 +899,10 @@ describe(`Inspection - Type`, () => {
                     false,
                 );
 
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`let foo = 1 in [foo = foo, bar = foo]`, () => {
+            it(`let foo = 1 in [foo = foo, bar = foo]`, async () => {
                 const expression: string = `let foo = 1 in [foo = foo, bar = foo]`;
 
                 const expected: Type.DefinedRecord = TypeUtils.createDefinedRecord(
@@ -914,10 +914,10 @@ describe(`Inspection - Type`, () => {
                     false,
                 );
 
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`let someIdentifier = 1, result = let someIdentifier = 2 in [ outer = someIdentifier, inner = @someIdentifier ] in result`, () => {
+            it(`let someIdentifier = 1, result = let someIdentifier = 2 in [ outer = someIdentifier, inner = @someIdentifier ] in result`, async () => {
                 const expression: string = `
     let
         someIdentifier = 1,
@@ -941,12 +941,12 @@ in
                     false,
                 );
 
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
         });
 
         describe(`${Ast.NodeKind.TableType}`, () => {
-            it(`type table [foo]`, () => {
+            it(`type table [foo]`, async () => {
                 const expression: string = `type table [foo]`;
 
                 const expected: Type.TableType = TypeUtils.createTableType(
@@ -955,10 +955,10 @@ in
                     false,
                 );
 
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`type table [foo]`, () => {
+            it(`type table [foo]`, async () => {
                 const expression: string = `type table [foo]`;
 
                 const expected: Type.TableType = TypeUtils.createTableType(
@@ -967,10 +967,10 @@ in
                     false,
                 );
 
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`type table [foo = number, bar = nullable text]`, () => {
+            it(`type table [foo = number, bar = nullable text]`, async () => {
                 const expression: string = `type table [foo = number, bar = nullable text]`;
 
                 const expected: Type.TableType = TypeUtils.createTableType(
@@ -982,97 +982,97 @@ in
                     false,
                 );
 
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
         });
 
         describe(`${Ast.NodeKind.UnaryExpression}`, () => {
-            it(`+1`, () => {
+            it(`+1`, async () => {
                 const expression: string = `+1`;
                 const expected: Type.NumberLiteral = TypeUtils.createNumberLiteral(false, "+1");
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`-1`, () => {
+            it(`-1`, async () => {
                 const expression: string = `-1`;
                 const expected: Type.NumberLiteral = TypeUtils.createNumberLiteral(false, "-1");
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`--1`, () => {
+            it(`--1`, async () => {
                 const expression: string = `--1`;
                 const expected: Type.NumberLiteral = TypeUtils.createNumberLiteral(false, "--1");
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`not true`, () => {
+            it(`not true`, async () => {
                 const expression: string = `not true`;
                 const expected: Type.Logical = Type.LogicalInstance;
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`not false`, () => {
+            it(`not false`, async () => {
                 const expression: string = `not false`;
                 const expected: Type.Logical = Type.LogicalInstance;
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`not 1`, () => {
+            it(`not 1`, async () => {
                 const expression: string = `not 1`;
                 const expected: Type.None = Type.NoneInstance;
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`+true`, () => {
+            it(`+true`, async () => {
                 const expression: string = `+true`;
                 const expected: Type.TPowerQueryType = TypeUtils.createPrimitiveType(false, Type.TypeKind.None);
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
         });
     });
 
     describe(`external type`, () => {
         describe(`value`, () => {
-            it(`resolves to external type`, () => {
+            it(`resolves to external type`, async () => {
                 const expression: string = `foo`;
                 const expected: Type.Function = Type.FunctionInstance;
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`indirect identifier resolves to external type`, () => {
+            it(`indirect identifier resolves to external type`, async () => {
                 const expression: string = `let bar = foo in bar`;
                 const expected: Type.Function = Type.FunctionInstance;
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`fails to resolve to external type`, () => {
+            it(`fails to resolve to external type`, async () => {
                 const expression: string = `bar`;
                 const expected: Type.Unknown = Type.UnknownInstance;
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
         });
 
         describe(`invocation`, () => {
-            it(`resolves with identifier`, () => {
+            it(`resolves with identifier`, async () => {
                 const expression: string = `foo()`;
                 const expected: Type.Text = Type.TextInstance;
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`resolves with deferenced identifier`, () => {
+            it(`resolves with deferenced identifier`, async () => {
                 const expression: string = `let bar = foo in bar()`;
                 const expected: Type.Text = Type.TextInstance;
-                assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
             });
 
-            it(`resolves based on argument`, () => {
+            it(`resolves based on argument`, async () => {
                 const expression1: string = `foo()`;
                 const expected1: Type.Text = Type.TextInstance;
-                assertParseOkNodeTypeEqual(TestSettings, expression1, expected1);
+                await assertParseOkNodeTypeEqual(TestSettings, expression1, expected1);
 
                 const expression2: string = `foo("bar")`;
                 const expected2: Type.Number = Type.NumberInstance;
-                assertParseOkNodeTypeEqual(TestSettings, expression2, expected2);
+                await assertParseOkNodeTypeEqual(TestSettings, expression2, expected2);
             });
         });
     });

--- a/src/test/inspection/type.ts
+++ b/src/test/inspection/type.ts
@@ -38,10 +38,14 @@ const TestSettings: InspectionSettings = {
     maybeExternalTypeResolver: ExternalTypeResolver,
 };
 
-function assertParseOkNodeTypeEqual(settings: InspectionSettings, text: string, expected: Type.TPowerQueryType): void {
+async function assertParseOkNodeTypeEqual(
+    settings: InspectionSettings,
+    text: string,
+    expected: Type.TPowerQueryType,
+): Promise<void> {
     const parseOk: PQP.Task.ParseTaskOk = TestUtils.assertGetLexParseOk(TestSettings, text);
 
-    const actual: Type.TPowerQueryType = assertGetParseNodeOk(
+    const actual: Type.TPowerQueryType = await assertGetParseNodeOk(
         settings,
         parseOk.nodeIdMapCollection,
         XorNodeUtils.boxAst(parseOk.ast),
@@ -50,10 +54,10 @@ function assertParseOkNodeTypeEqual(settings: InspectionSettings, text: string, 
     expect(actual).deep.equal(expected);
 }
 
-function assertParseErrNodeTypeEqual(text: string, expected: Type.TPowerQueryType): void {
+async function assertParseErrNodeTypeEqual(text: string, expected: Type.TPowerQueryType): Promise<void> {
     const parseError: PQP.Task.ParseTaskParseError = TestUtils.assertGetLexParseError(TestSettings, text);
 
-    const actual: Type.TPowerQueryType = assertGetParseNodeOk(
+    const actual: Type.TPowerQueryType = await assertGetParseNodeOk(
         TestSettings,
         parseError.nodeIdMapCollection,
         XorNodeUtils.boxContext(Assert.asDefined(parseError.parseState.contextState.maybeRoot)),
@@ -62,26 +66,26 @@ function assertParseErrNodeTypeEqual(text: string, expected: Type.TPowerQueryTyp
     expect(actual).deep.equal(expected);
 }
 
-function assertGetParseNodeOk(
+async function assertGetParseNodeOk(
     settings: InspectionSettings,
     nodeIdMapCollection: NodeIdMap.Collection,
     xorNode: TXorNode,
-): Type.TPowerQueryType {
-    const triedType: Inspection.TriedType = Inspection.tryType(settings, nodeIdMapCollection, xorNode.node.id);
+): Promise<Type.TPowerQueryType> {
+    const triedType: Inspection.TriedType = await Inspection.tryType(settings, nodeIdMapCollection, xorNode.node.id);
     Assert.isOk(triedType);
 
     return triedType.value;
 }
 
-function assertParseOkScopeTypeEqual(
+async function assertParseOkScopeTypeEqual(
     settings: InspectionSettings,
     textWithPipe: string,
     expected: Inspection.ScopeTypeByKey,
-): void {
+): Promise<void> {
     const [textWithoutPipe, position]: [string, Position] = TestUtils.assertGetTextWithPosition(textWithPipe);
     const parseOk: PQP.Task.ParseTaskOk = TestUtils.assertGetLexParseOk(TestSettings, textWithoutPipe);
 
-    const actual: Inspection.ScopeTypeByKey = assertGetParseOkScopeTypeOk(
+    const actual: Inspection.ScopeTypeByKey = await assertGetParseOkScopeTypeOk(
         settings,
         parseOk.nodeIdMapCollection,
         position,
@@ -90,16 +94,16 @@ function assertParseOkScopeTypeEqual(
     expect(actual).deep.equal(expected);
 }
 
-function assertGetParseOkScopeTypeOk(
+async function assertGetParseOkScopeTypeOk(
     settings: InspectionSettings,
     nodeIdMapCollection: NodeIdMap.Collection,
     position: Position,
-): Inspection.ScopeTypeByKey {
+): Promise<Inspection.ScopeTypeByKey> {
     const activeNodeLeaf: TXorNode = Inspection.ActiveNodeUtils.assertGetLeaf(
         Inspection.ActiveNodeUtils.assertActiveNode(nodeIdMapCollection, position),
     );
 
-    const triedScopeType: Inspection.TriedScopeType = Inspection.tryScopeType(
+    const triedScopeType: Inspection.TriedScopeType = await Inspection.tryScopeType(
         settings,
         nodeIdMapCollection,
         activeNodeLeaf.node.id,

--- a/src/test/inspectionUtils.ts
+++ b/src/test/inspectionUtils.ts
@@ -29,12 +29,12 @@ function expectSymbolsForNode(node: Ast.TNode, expectedSymbols: ReadonlyArray<Ab
 }
 
 describe("Document symbol base functions", () => {
-    it(`section foo; shared a = 1; b = "abc"; c = true;`, () => {
+    it(`section foo; shared a = 1; b = "abc"; c = true;`, async () => {
         const testDocument: MockDocument = TestUtils.createTextMockDocument(
             `section foo; shared a = 1; b = "abc"; c = true;`,
         );
 
-        const lexAndParseOk: WorkspaceCache.ParseCacheItem = WorkspaceCacheUtils.getOrCreateParse(
+        const lexAndParseOk: WorkspaceCache.ParseCacheItem = await WorkspaceCacheUtils.getOrCreateParse(
             testDocument,
             PQP.DefaultSettings,
         );
@@ -48,11 +48,11 @@ describe("Document symbol base functions", () => {
         ]);
     });
 
-    it(`section foo; a = {1,2};`, () => {
+    it(`section foo; a = {1,2};`, async () => {
         const text: string = `section foo; a = {1,2};`;
         const textDocument: MockDocument = TestUtils.createTextMockDocument(text);
 
-        const lexAndParseOk: WorkspaceCache.ParseCacheItem = WorkspaceCacheUtils.getOrCreateParse(
+        const lexAndParseOk: WorkspaceCache.ParseCacheItem = await WorkspaceCacheUtils.getOrCreateParse(
             textDocument,
             PQP.DefaultSettings,
         );
@@ -62,11 +62,11 @@ describe("Document symbol base functions", () => {
         expectSymbolsForNode(lexAndParseOk.ast, [{ name: "a", kind: SymbolKind.Array }]);
     });
 
-    it(`let a = 1, b = 2, c = 3 in c`, () => {
+    it(`let a = 1, b = 2, c = 3 in c`, async () => {
         const text: string = `let a = 1, b = 2, c = 3 in c`;
         const textDocument: MockDocument = TestUtils.createTextMockDocument(text);
 
-        const lexAndParseOk: WorkspaceCache.ParseCacheItem = WorkspaceCacheUtils.getOrCreateParse(
+        const lexAndParseOk: WorkspaceCache.ParseCacheItem = await WorkspaceCacheUtils.getOrCreateParse(
             textDocument,
             PQP.DefaultSettings,
         );
@@ -80,11 +80,11 @@ describe("Document symbol base functions", () => {
         ]);
     });
 
-    it("HelloWorldWithDocs file section", () => {
+    it("HelloWorldWithDocs file section", async () => {
         const text: string = TestUtils.readFile("HelloWorldWithDocs.pq");
         const textDocument: MockDocument = TestUtils.createTextMockDocument(text);
 
-        const lexAndParseOk: WorkspaceCache.ParseCacheItem = WorkspaceCacheUtils.getOrCreateParse(
+        const lexAndParseOk: WorkspaceCache.ParseCacheItem = await WorkspaceCacheUtils.getOrCreateParse(
             textDocument,
             PQP.DefaultSettings,
         );
@@ -100,11 +100,11 @@ describe("Document symbol base functions", () => {
         ]);
     });
 
-    it("DirectQueryForSQL file section", () => {
+    it("DirectQueryForSQL file section", async () => {
         const text: string = TestUtils.readFile("DirectQueryForSQL.pq");
         const textDocument: MockDocument = TestUtils.createTextMockDocument(text);
 
-        const lexAndParseOk: WorkspaceCache.ParseCacheItem = WorkspaceCacheUtils.getOrCreateParse(
+        const lexAndParseOk: WorkspaceCache.ParseCacheItem = await WorkspaceCacheUtils.getOrCreateParse(
             textDocument,
             PQP.DefaultSettings,
         );

--- a/src/test/inspectionUtils.ts
+++ b/src/test/inspectionUtils.ts
@@ -7,9 +7,11 @@ import { assert, expect } from "chai";
 import { Ast, AstUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 
 import * as TestUtils from "./testUtils";
-import { InspectionUtils, SymbolKind, WorkspaceCache, WorkspaceCacheUtils } from "../powerquery-language-services";
+import { InspectionUtils, SymbolKind, WorkspaceCacheUtils } from "../powerquery-language-services";
 import { AbridgedDocumentSymbol } from "./testUtils";
+import { isDefined } from "@microsoft/powerquery-parser/lib/powerquery-parser/common/assert";
 import { MockDocument } from "./mockDocument";
+import { TaskUtils } from "@microsoft/powerquery-parser";
 
 // Used to test symbols at a specific level of inspection
 function expectSymbolsForNode(node: Ast.TNode, expectedSymbols: ReadonlyArray<AbridgedDocumentSymbol>): void {
@@ -34,12 +36,13 @@ describe("Document symbol base functions", () => {
             `section foo; shared a = 1; b = "abc"; c = true;`,
         );
 
-        const lexAndParseOk: WorkspaceCache.ParseCacheItem = await WorkspaceCacheUtils.getOrCreateParse(
+        const lexAndParseOk: PQP.Task.TriedParseTask | undefined = await WorkspaceCacheUtils.getOrCreateParsePromise(
             testDocument,
             PQP.DefaultSettings,
         );
 
-        TestUtils.assertParserCacheItemOk(lexAndParseOk);
+        isDefined(lexAndParseOk);
+        TaskUtils.assertIsOk(lexAndParseOk);
 
         expectSymbolsForNode(lexAndParseOk.ast, [
             { name: "a", kind: SymbolKind.Number },
@@ -52,12 +55,13 @@ describe("Document symbol base functions", () => {
         const text: string = `section foo; a = {1,2};`;
         const textDocument: MockDocument = TestUtils.createTextMockDocument(text);
 
-        const lexAndParseOk: WorkspaceCache.ParseCacheItem = await WorkspaceCacheUtils.getOrCreateParse(
+        const lexAndParseOk: PQP.Task.TriedParseTask | undefined = await WorkspaceCacheUtils.getOrCreateParsePromise(
             textDocument,
             PQP.DefaultSettings,
         );
 
-        TestUtils.assertParserCacheItemOk(lexAndParseOk);
+        isDefined(lexAndParseOk);
+        TaskUtils.assertIsOk(lexAndParseOk);
 
         expectSymbolsForNode(lexAndParseOk.ast, [{ name: "a", kind: SymbolKind.Array }]);
     });
@@ -66,12 +70,13 @@ describe("Document symbol base functions", () => {
         const text: string = `let a = 1, b = 2, c = 3 in c`;
         const textDocument: MockDocument = TestUtils.createTextMockDocument(text);
 
-        const lexAndParseOk: WorkspaceCache.ParseCacheItem = await WorkspaceCacheUtils.getOrCreateParse(
+        const lexAndParseOk: PQP.Task.TriedParseTask | undefined = await WorkspaceCacheUtils.getOrCreateParsePromise(
             textDocument,
             PQP.DefaultSettings,
         );
 
-        TestUtils.assertParserCacheItemOk(lexAndParseOk);
+        isDefined(lexAndParseOk);
+        TaskUtils.assertIsOk(lexAndParseOk);
 
         expectSymbolsForNode(lexAndParseOk.ast, [
             { name: "a", kind: SymbolKind.Number },
@@ -84,12 +89,13 @@ describe("Document symbol base functions", () => {
         const text: string = TestUtils.readFile("HelloWorldWithDocs.pq");
         const textDocument: MockDocument = TestUtils.createTextMockDocument(text);
 
-        const lexAndParseOk: WorkspaceCache.ParseCacheItem = await WorkspaceCacheUtils.getOrCreateParse(
+        const lexAndParseOk: PQP.Task.TriedParseTask | undefined = await WorkspaceCacheUtils.getOrCreateParsePromise(
             textDocument,
             PQP.DefaultSettings,
         );
 
-        TestUtils.assertParserCacheItemOk(lexAndParseOk);
+        isDefined(lexAndParseOk);
+        TaskUtils.assertIsOk(lexAndParseOk);
 
         expectSymbolsForNode(lexAndParseOk.ast, [
             { name: "HelloWorldWithDocs.Contents", kind: SymbolKind.Variable },
@@ -104,12 +110,13 @@ describe("Document symbol base functions", () => {
         const text: string = TestUtils.readFile("DirectQueryForSQL.pq");
         const textDocument: MockDocument = TestUtils.createTextMockDocument(text);
 
-        const lexAndParseOk: WorkspaceCache.ParseCacheItem = await WorkspaceCacheUtils.getOrCreateParse(
+        const lexAndParseOk: PQP.Task.TriedParseTask | undefined = await WorkspaceCacheUtils.getOrCreateParsePromise(
             textDocument,
             PQP.DefaultSettings,
         );
 
-        TestUtils.assertParserCacheItemOk(lexAndParseOk);
+        isDefined(lexAndParseOk);
+        TaskUtils.assertIsOk(lexAndParseOk);
 
         expectSymbolsForNode(lexAndParseOk.ast, [
             { name: "DirectSQL.Database", kind: SymbolKind.Function },

--- a/src/test/providers/simpleLibrarySymbolProvider.ts
+++ b/src/test/providers/simpleLibrarySymbolProvider.ts
@@ -13,7 +13,6 @@ import {
     Inspection,
     NullSymbolProvider,
     SignatureHelp,
-    WorkspaceCache,
 } from "../../powerquery-language-services";
 import { TestConstants, TestUtils } from "..";
 import { ILibrary } from "../../powerquery-language-services/library/library";
@@ -22,7 +21,7 @@ const IsolatedAnalysisSettings: AnalysisSettings = {
     ...TestConstants.SimpleLibraryAnalysisSettings,
     maybeCreateLocalDocumentSymbolProviderFn: (
         _library: ILibrary,
-        _maybeTriedInspection: WorkspaceCache.CacheItem | undefined,
+        _maybePromiseInspection: Promise<Inspection.Inspection | undefined>,
     ) => NullSymbolProvider.singleton(),
 };
 

--- a/src/test/providers/slowSymbolProvider.ts
+++ b/src/test/providers/slowSymbolProvider.ts
@@ -28,13 +28,13 @@ export class SlowSymbolProvider extends LibrarySymbolProvider {
         return super.getAutocompleteItems(context);
     }
 
-    public async getHover(context: HoverProviderContext): Promise<Hover | null> {
+    public override async getHover(context: HoverProviderContext): Promise<Hover | null> {
         await this.delay();
 
         return super.getHover(context);
     }
 
-    public async getSignatureHelp(context: SignatureProviderContext): Promise<SignatureHelp | null> {
+    public override async getSignatureHelp(context: SignatureProviderContext): Promise<SignatureHelp | null> {
         await this.delay();
 
         return super.getSignatureHelp(context);

--- a/src/test/testConstants.ts
+++ b/src/test/testConstants.ts
@@ -14,7 +14,6 @@ import {
     LibraryUtils,
     LocalDocumentSymbolProvider,
     ValidationSettings,
-    WorkspaceCache,
 } from "../powerquery-language-services";
 import { LibrarySymbolProvider } from "../powerquery-language-services/providers/librarySymbolProvider";
 
@@ -246,9 +245,9 @@ export const SimpleLibraryAnalysisSettings: AnalysisSettings = {
     maybeCreateLibrarySymbolProviderFn: (library: Library.ILibrary) => new LibrarySymbolProvider(library),
     maybeCreateLocalDocumentSymbolProviderFn: (
         library: Library.ILibrary,
-        maybeTriedInspection: WorkspaceCache.CacheItem | undefined,
+        maybePromiseInspection: Promise<Inspection.Inspection | undefined>,
         createInspectionSettingsFn: () => InspectionSettings,
-    ) => new LocalDocumentSymbolProvider(library, maybeTriedInspection, createInspectionSettingsFn),
+    ) => new LocalDocumentSymbolProvider(library, maybePromiseInspection, createInspectionSettingsFn),
 };
 
 export const enum TestLibraryName {

--- a/src/test/testUtils/assert.ts
+++ b/src/test/testUtils/assert.ts
@@ -27,12 +27,14 @@ export function assertAsMarkupContent(value: Hover["contents"]): MarkupContent {
     return value;
 }
 
-export function assertGetAutocomplete(
+export async function assertGetAutocomplete(
     settings: InspectionSettings,
     text: string,
     position: Position,
 ): Promise<Inspection.Autocomplete> {
-    const triedLexParseTask: PQP.Task.TriedLexParseTask = PQP.TaskUtils.tryLexParse(settings, text);
+    // TODO: figure out why this exception is needed
+    // eslint-disable-next-line @typescript-eslint/await-thenable
+    const triedLexParseTask: PQP.Task.TriedLexParseTask = await PQP.TaskUtils.tryLexParse(settings, text);
     TaskUtils.assertIsParseStage(triedLexParseTask);
 
     if (PQP.TaskUtils.isParseStageOk(triedLexParseTask)) {
@@ -92,15 +94,22 @@ export async function assertGetInspectionCacheItem(
     return cacheItem;
 }
 
-export function assertGetLexParseOk(settings: PQP.Settings, text: string): PQP.Task.ParseTaskOk {
-    const triedLexParseTask: PQP.Task.TriedLexParseTask = PQP.TaskUtils.tryLexParse(settings, text);
+export async function assertGetLexParseOk(settings: PQP.Settings, text: string): Promise<PQP.Task.ParseTaskOk> {
+    // TODO: figure out why this exception is needed
+    // eslint-disable-next-line @typescript-eslint/await-thenable
+    const triedLexParseTask: PQP.Task.TriedLexParseTask = await PQP.TaskUtils.tryLexParse(settings, text);
     TaskUtils.assertIsParseStageOk(triedLexParseTask);
 
     return triedLexParseTask;
 }
 
-export function assertGetLexParseError(settings: PQP.Settings, text: string): PQP.Task.ParseTaskParseError {
-    const triedLexParseTask: PQP.Task.TriedLexParseTask = PQP.TaskUtils.tryLexParse(settings, text);
+export async function assertGetLexParseError(
+    settings: PQP.Settings,
+    text: string,
+): Promise<PQP.Task.ParseTaskParseError> {
+    // TODO: figure out why this exception is needed
+    // eslint-disable-next-line @typescript-eslint/await-thenable
+    const triedLexParseTask: PQP.Task.TriedLexParseTask = await PQP.TaskUtils.tryLexParse(settings, text);
     TaskUtils.assertIsParseStageParseError(triedLexParseTask);
 
     return triedLexParseTask;

--- a/src/test/testUtils/assert.ts
+++ b/src/test/testUtils/assert.ts
@@ -31,7 +31,7 @@ export function assertGetAutocomplete(
     settings: InspectionSettings,
     text: string,
     position: Position,
-): Inspection.Autocomplete {
+): Promise<Inspection.Autocomplete> {
     const triedLexParseTask: PQP.Task.TriedLexParseTask = PQP.TaskUtils.tryLexParse(settings, text);
     TaskUtils.assertIsParseStage(triedLexParseTask);
 
@@ -76,8 +76,11 @@ export function assertGetAutocompleteItem(
     );
 }
 
-export function assertGetInspectionCacheItem(document: MockDocument, position: Position): Inspection.Inspection {
-    const cacheItem: WorkspaceCache.InspectionCacheItem = WorkspaceCacheUtils.getOrCreateInspection(
+export async function assertGetInspectionCacheItem(
+    document: MockDocument,
+    position: Position,
+): Promise<Inspection.Inspection> {
+    const cacheItem: WorkspaceCache.InspectionCacheItem = await WorkspaceCacheUtils.getOrCreateInspection(
         document,
         TestConstants.SimpleInspectionSettings,
         position,

--- a/src/test/testUtils/assert.ts
+++ b/src/test/testUtils/assert.ts
@@ -118,8 +118,8 @@ export function assertGetTextWithPosition(text: string): [string, Position] {
     return [text.replace("|", ""), position];
 }
 
-export function assertGetValidationResult(document: TextDocument): ValidationResult {
-    return validate(document, TestConstants.SimpleValidationSettings);
+export async function assertGetValidationResult(document: TextDocument): Promise<ValidationResult> {
+    return await validate(document, TestConstants.SimpleValidationSettings);
 }
 
 export function assertHover(expected: string, actual: Hover): void {

--- a/src/test/testUtils/assert.ts
+++ b/src/test/testUtils/assert.ts
@@ -9,16 +9,7 @@ import { expect } from "chai";
 import * as TestConstants from "../testConstants";
 import * as TestUtils from "./testUtils";
 import { ActiveNodeUtils, TypeCacheUtils } from "../../powerquery-language-services/inspection";
-import {
-    Inspection,
-    InspectionSettings,
-    TextDocument,
-    validate,
-    WorkspaceCache,
-    WorkspaceCacheUtils,
-} from "../../powerquery-language-services";
-import { CacheItem } from "../../powerquery-language-services/workspaceCache/workspaceCache";
-import { MockDocument } from "../mockDocument";
+import { Inspection, InspectionSettings, TextDocument, validate } from "../../powerquery-language-services";
 import { ValidationResult } from "../../powerquery-language-services/validate/validationResult";
 
 export function assertAsMarkupContent(value: Hover["contents"]): MarkupContent {
@@ -78,21 +69,21 @@ export function assertGetAutocompleteItem(
     );
 }
 
-export async function assertGetInspectionCacheItem(
-    document: MockDocument,
-    position: Position,
-): Promise<Inspection.Inspection> {
-    const cacheItem: WorkspaceCache.InspectionCacheItem = await WorkspaceCacheUtils.getOrCreateInspection(
-        document,
-        TestConstants.SimpleInspectionSettings,
-        position,
-    );
+// export async function assertGetInspectionCacheItem(
+//     document: MockDocument,
+//     position: Position,
+// ): Promise<InspectionTask> {
+//     const cacheItem: any = await WorkspaceCacheUtils.getOrCreateInspectionPromise(
+//         document,
+//         TestConstants.SimpleInspectionSettings,
+//         position,
+//     );
 
-    assertIsDefined(cacheItem);
-    assertInspectionCacheItemOk(cacheItem);
+//     assertIsDefined(cacheItem);
+//     assertInspectionCacheItemOk(cacheItem);
 
-    return cacheItem;
-}
+//     return cacheItem;
+// }
 
 export async function assertGetLexParseOk(settings: PQP.Settings, text: string): Promise<PQP.Task.ParseTaskOk> {
     // TODO: figure out why this exception is needed
@@ -157,44 +148,44 @@ export function assertAutocompleteItemLabels(
     expect(actualLabels).to.include.members(expected);
 }
 
-export function assertCacheItemOk(cacheItem: WorkspaceCache.CacheItem): asserts cacheItem is CacheItem {
-    if (cacheItem !== undefined && !WorkspaceCacheUtils.isInspectionTask(cacheItem)) {
-        TaskUtils.assertIsOk(cacheItem);
-    }
-}
+// export function assertCacheItemOk(
+//     cacheItem: PQP.Task.TriedLexTask | PQP.Task.TriedParseTask | InspectionTask | undefined,
+// ): asserts cacheItem is PQP.Task.LexTaskOk | PQP.Task.ParseTaskOk | InspectionTask {
+//     if (cacheItem !== undefined && !WorkspaceCacheUtils.isInspectionTask(cacheItem)) {
+//         TaskUtils.assertIsOk(cacheItem);
+//     }
+// }
 
-export function assertInspectionCacheItemOk(
-    cacheItem: WorkspaceCache.InspectionCacheItem,
-): asserts cacheItem is WorkspaceCache.InspectionTask {
-    WorkspaceCacheUtils.assertIsInspectionTask(cacheItem);
-}
+// export function assertInspectionCacheItemOk(
+//     cacheItem: WorkspaceCache.InspectionTask,
+// ): asserts cacheItem is WorkspaceCache.InspectionTask {
+//     WorkspaceCacheUtils.assertIsInspectionTask(cacheItem);
+// }
 
-export function assertLexerCacheItemOk(cacheItem: WorkspaceCache.CacheItem): asserts cacheItem is PQP.Task.LexTaskOk {
-    assertNotInspectionCacheItem(cacheItem);
-    TaskUtils.assertIsLexStageOk(cacheItem);
-}
+// export function assertNotInspectionCacheItem(
+//     cacheItem: PQP.Task.TriedLexTask | PQP.Task.TriedParseTask | InspectionTask | undefined,
+// ): asserts cacheItem is Exclude<
+//     PQP.Task.TriedLexTask | PQP.Task.TriedParseTask | InspectionTask | undefined,
+//     undefined | WorkspaceCache.InspectionTask
+// > {
+//     if (cacheItem === undefined || cacheItem.stage === "Inspection") {
+//         throw new Error(`expected cacheItem to not be a Inspection cache item`);
+//     }
+// }
 
-export function assertNotInspectionCacheItem(
-    cacheItem: WorkspaceCache.CacheItem,
-): asserts cacheItem is Exclude<WorkspaceCache.CacheItem, undefined | WorkspaceCache.InspectionTask> {
-    if (cacheItem === undefined || cacheItem.stage === "Inspection") {
-        throw new Error(`expected cacheItem to not be a Inspection cache item`);
-    }
-}
+// export function assertParserCacheItemOk(
+//     cacheItem: WorkspaceCache.CacheItem,
+// ): asserts cacheItem is PQP.Task.ParseTaskOk {
+//     assertNotInspectionCacheItem(cacheItem);
+//     TaskUtils.assertIsParseStageOk(cacheItem);
+// }
 
-export function assertParserCacheItemOk(
-    cacheItem: WorkspaceCache.CacheItem,
-): asserts cacheItem is PQP.Task.ParseTaskOk {
-    assertNotInspectionCacheItem(cacheItem);
-    TaskUtils.assertIsParseStageOk(cacheItem);
-}
-
-export function assertParserCacheItemError(
-    cacheItem: WorkspaceCache.CacheItem,
-): asserts cacheItem is PQP.Task.ParseTaskOk {
-    assertNotInspectionCacheItem(cacheItem);
-    TaskUtils.assertIsParseStageParseError(cacheItem);
-}
+// export function assertParserCacheItemError(
+//     cacheItem: WorkspaceCache.CacheItem,
+// ): asserts cacheItem is PQP.Task.ParseTaskOk {
+//     assertNotInspectionCacheItem(cacheItem);
+//     TaskUtils.assertIsParseStageParseError(cacheItem);
+// }
 
 export function assertSignatureHelp(expected: TestUtils.AbridgedSignatureHelp, actual: SignatureHelp): void {
     expect(TestUtils.createAbridgedSignatureHelp(actual)).deep.equals(expected);

--- a/src/test/testUtils/assert.ts
+++ b/src/test/testUtils/assert.ts
@@ -9,7 +9,13 @@ import { expect } from "chai";
 import * as TestConstants from "../testConstants";
 import * as TestUtils from "./testUtils";
 import { ActiveNodeUtils, TypeCacheUtils } from "../../powerquery-language-services/inspection";
-import { Inspection, InspectionSettings, TextDocument, validate } from "../../powerquery-language-services";
+import {
+    Inspection,
+    InspectionSettings,
+    TextDocument,
+    validate,
+    WorkspaceCacheUtils,
+} from "../../powerquery-language-services";
 import { ValidationResult } from "../../powerquery-language-services/validate/validationResult";
 
 export function assertAsMarkupContent(value: Hover["contents"]): MarkupContent {
@@ -84,6 +90,18 @@ export function assertGetAutocompleteItem(
 
 //     return cacheItem;
 // }
+
+export async function assertGetInspection(document: TextDocument, position: Position): Promise<Inspection.Inspection> {
+    const inspected: Inspection.Inspection | undefined = await WorkspaceCacheUtils.getOrCreateInspectionPromise(
+        document,
+        TestConstants.SimpleInspectionSettings,
+        position,
+    );
+
+    Assert.isDefined(inspected);
+
+    return inspected;
+}
 
 export async function assertGetLexParseOk(settings: PQP.Settings, text: string): Promise<PQP.Task.ParseTaskOk> {
     // TODO: figure out why this exception is needed

--- a/src/test/testUtils/testUtils.ts
+++ b/src/test/testUtils/testUtils.ts
@@ -9,7 +9,7 @@ import { DocumentSymbol, Hover, Position, SignatureHelp, SymbolKind } from "vsco
 import * as AnalysisUtils from "../../powerquery-language-services/analysis/analysisUtils";
 import * as TestConstants from "../testConstants";
 import { Analysis, Inspection } from "../../powerquery-language-services";
-import { AnalysisSettings } from "../../powerquery-language-services/analysis/analysisSettings";
+import { AnalysisSettings } from "../..";
 import { MockDocument } from "../mockDocument";
 
 export interface AbridgedDocumentSymbol {

--- a/src/test/validation/duplicateIdentifier.ts
+++ b/src/test/validation/duplicateIdentifier.ts
@@ -75,8 +75,8 @@ async function validateDuplicateIdentifierDiagnostics(
 
 describe(`Validation - duplicateIdentifier`, () => {
     describe("Syntax validation", () => {
-        it("no errors", () => {
-            expectNoValidationErrors(TestUtils.createTextMockDocument("let b = 1 in b"));
+        it("no errors", async () => {
+            await expectNoValidationErrors(TestUtils.createTextMockDocument("let b = 1 in b"));
         });
 
         it("let 1", async () => {
@@ -93,12 +93,12 @@ describe(`Validation - duplicateIdentifier`, () => {
             assertValidationError(validationResult.diagnostics[0], { line: 0, character: 4 });
         });
 
-        it("HelloWorldWithDocs.pq", () => {
-            expectNoValidationErrors(TestUtils.createFileMockDocument("HelloWorldWithDocs.pq"));
+        it("HelloWorldWithDocs.pq", async () => {
+            await expectNoValidationErrors(TestUtils.createFileMockDocument("HelloWorldWithDocs.pq"));
         });
 
-        it("DirectQueryForSQL.pq", () => {
-            expectNoValidationErrors(TestUtils.createFileMockDocument("DirectQueryForSQL.pq"));
+        it("DirectQueryForSQL.pq", async () => {
+            await expectNoValidationErrors(TestUtils.createFileMockDocument("DirectQueryForSQL.pq"));
         });
     });
 
@@ -116,13 +116,13 @@ describe(`Validation - duplicateIdentifier`, () => {
             const changes: ReadonlyArray<TextDocumentContentChangeEvent> = textDocument.update("1");
             documentUpdated(textDocument, changes, textDocument.version);
 
-            expectNoValidationErrors(textDocument);
+            await expectNoValidationErrors(textDocument);
         });
 
-        it("WIP errors after update", async () => {
+        it("errors after update", async () => {
             const text: string = "let a = 1 in a";
             const textDocument: MockDocument = TestUtils.createTextMockDocument(text);
-            expectNoValidationErrors(textDocument);
+            await expectNoValidationErrors(textDocument);
 
             const changes: ReadonlyArray<TextDocumentContentChangeEvent> = textDocument.update(";;;;;;");
             documentUpdated(textDocument, changes, textDocument.version);
@@ -136,11 +136,11 @@ describe(`Validation - duplicateIdentifier`, () => {
     });
 
     describe("Duplicate identifiers", () => {
-        it("let a = 1, a = 2 in a", () => {
+        it("let a = 1, a = 2 in a", async () => {
             const text: string = "let a = 1, a = 2 in a";
             const textDocument: MockDocument = TestUtils.createTextMockDocument(text);
 
-            validateDuplicateIdentifierDiagnostics(textDocument, [
+            await validateDuplicateIdentifierDiagnostics(textDocument, [
                 {
                     name: "a",
                     position: { line: 0, character: 11 },
@@ -154,11 +154,11 @@ describe(`Validation - duplicateIdentifier`, () => {
             ]);
         });
 
-        it("let rec = [ a = 1, b = 2, c = 3, a = 4] in rec", () => {
+        it("let rec = [ a = 1, b = 2, c = 3, a = 4] in rec", async () => {
             const text: string = "let rec = [ a = 1, b = 2, c = 3, a = 4] in rec";
             const textDocument: MockDocument = TestUtils.createTextMockDocument(text);
 
-            validateDuplicateIdentifierDiagnostics(textDocument, [
+            await validateDuplicateIdentifierDiagnostics(textDocument, [
                 {
                     name: "a",
                     position: { line: 0, character: 33 },
@@ -172,11 +172,11 @@ describe(`Validation - duplicateIdentifier`, () => {
             ]);
         });
 
-        it("[a = 1, b = 2, c = 3, a = 4]", () => {
+        it("[a = 1, b = 2, c = 3, a = 4]", async () => {
             const text: string = "[a = 1, b = 2, c = 3, a = 4]";
             const textDocument: MockDocument = TestUtils.createTextMockDocument(text);
 
-            validateDuplicateIdentifierDiagnostics(textDocument, [
+            await validateDuplicateIdentifierDiagnostics(textDocument, [
                 {
                     name: "a",
                     position: { line: 0, character: 22 },
@@ -190,11 +190,11 @@ describe(`Validation - duplicateIdentifier`, () => {
             ]);
         });
 
-        it(`[#"a" = 1, a = 2, b = 3]`, () => {
+        it(`[#"a" = 1, a = 2, b = 3]`, async () => {
             const text: string = `[#"a" = 1, a = 2, b = 3]`;
             const textDocument: MockDocument = TestUtils.createTextMockDocument(text);
 
-            validateDuplicateIdentifierDiagnostics(textDocument, [
+            await validateDuplicateIdentifierDiagnostics(textDocument, [
                 {
                     name: "a",
                     position: { line: 0, character: 11 },
@@ -208,11 +208,11 @@ describe(`Validation - duplicateIdentifier`, () => {
             ]);
         });
 
-        it('section foo; shared a = 1; a = "hello";', () => {
+        it('section foo; shared a = 1; a = "hello";', async () => {
             const text: string = 'section foo; shared a = 1; a = "hello";';
             const textDocument: MockDocument = TestUtils.createTextMockDocument(text);
 
-            validateDuplicateIdentifierDiagnostics(textDocument, [
+            await validateDuplicateIdentifierDiagnostics(textDocument, [
                 {
                     name: "a",
                     position: { line: 0, character: 27 },
@@ -226,11 +226,11 @@ describe(`Validation - duplicateIdentifier`, () => {
             ]);
         });
 
-        it("section foo; shared a = let a = 1 in a; b = let b = 1, b = 2 in b;", () => {
+        it("section foo; shared a = let a = 1 in a; b = let b = 1, b = 2 in b;", async () => {
             const text: string = "section foo; shared a = let a = 1 in a; b = let b = 1, b = 2, b = 3 in b;";
             const textDocument: MockDocument = TestUtils.createTextMockDocument(text);
 
-            validateDuplicateIdentifierDiagnostics(textDocument, [
+            await validateDuplicateIdentifierDiagnostics(textDocument, [
                 {
                     name: "b",
                     position: { character: 55, line: 0 },
@@ -258,11 +258,11 @@ describe(`Validation - duplicateIdentifier`, () => {
             ]);
         });
 
-        it("let a = 1 meta [ abc = 1, abc = 3 ] in a", () => {
+        it("let a = 1 meta [ abc = 1, abc = 3 ] in a", async () => {
             const text: string = "let a = 1 meta [ abc = 1, abc = 3 ] in a";
             const textDocument: MockDocument = TestUtils.createTextMockDocument(text);
 
-            validateDuplicateIdentifierDiagnostics(textDocument, [
+            await validateDuplicateIdentifierDiagnostics(textDocument, [
                 {
                     name: "abc",
                     position: { line: 0, character: 26 },
@@ -276,11 +276,11 @@ describe(`Validation - duplicateIdentifier`, () => {
             ]);
         });
 
-        it("let a = let abc = 1, abc = 2, b = 3 in b in a", () => {
+        it("let a = let abc = 1, abc = 2, b = 3 in b in a", async () => {
             const text: string = "let a = let abc = 1, abc = 2, b = 3 in b in a";
             const textDocument: MockDocument = TestUtils.createTextMockDocument(text);
 
-            validateDuplicateIdentifierDiagnostics(textDocument, [
+            await validateDuplicateIdentifierDiagnostics(textDocument, [
                 {
                     name: "abc",
                     position: { line: 0, character: 21 },
@@ -294,11 +294,11 @@ describe(`Validation - duplicateIdentifier`, () => {
             ]);
         });
 
-        it('section foo; a = let #"s p a c e" = 2, #"s p a c e" = 3, a = 2 in a;', () => {
+        it('section foo; a = let #"s p a c e" = 2, #"s p a c e" = 3, a = 2 in a;', async () => {
             const text: string = 'section foo; a = let #"s p a c e" = 2, #"s p a c e" = 3, a = 2 in a;';
             const textDocument: MockDocument = TestUtils.createTextMockDocument(text);
 
-            validateDuplicateIdentifierDiagnostics(textDocument, [
+            await validateDuplicateIdentifierDiagnostics(textDocument, [
                 {
                     name: '#"s p a c e"',
                     position: { line: 0, character: 39 },

--- a/src/test/validation/duplicateIdentifier.ts
+++ b/src/test/validation/duplicateIdentifier.ts
@@ -119,7 +119,7 @@ describe(`Validation - duplicateIdentifier`, () => {
             expectNoValidationErrors(textDocument);
         });
 
-        it("errors after update", async () => {
+        it("WIP errors after update", async () => {
             const text: string = "let a = 1 in a";
             const textDocument: MockDocument = TestUtils.createTextMockDocument(text);
             expectNoValidationErrors(textDocument);

--- a/src/test/validation/duplicateIdentifier.ts
+++ b/src/test/validation/duplicateIdentifier.ts
@@ -27,8 +27,8 @@ function assertValidationError(diagnostic: Diagnostic, startPosition: Position):
     expect(diagnostic.severity).to.equal(DiagnosticSeverity.Error);
 }
 
-function expectNoValidationErrors(textDocument: MockDocument): void {
-    const validationResult: ValidationResult = validate(textDocument, TestConstants.SimpleValidationSettings);
+async function expectNoValidationErrors(textDocument: MockDocument): Promise<void> {
+    const validationResult: ValidationResult = await validate(textDocument, TestConstants.SimpleValidationSettings);
     expect(validationResult.hasSyntaxError).to.equal(false, "hasSyntaxError flag should be false");
     expect(validationResult.diagnostics.length).to.equal(0, "no diagnostics expected");
 }
@@ -39,11 +39,11 @@ interface DuplicateIdentifierError {
     readonly relatedPositions: ReadonlyArray<Position>;
 }
 
-function validateDuplicateIdentifierDiagnostics(
+async function validateDuplicateIdentifierDiagnostics(
     textDocument: MockDocument,
     expected: ReadonlyArray<DuplicateIdentifierError>,
-): void {
-    const validationResult: ValidationResult = validate(textDocument, TestConstants.SimpleValidationSettings);
+): Promise<void> {
+    const validationResult: ValidationResult = await validate(textDocument, TestConstants.SimpleValidationSettings);
     const errorSource: string = TestConstants.SimpleValidationSettings.source;
     const diagnostics: ReadonlyArray<Diagnostic> = validationResult.diagnostics;
 
@@ -79,10 +79,10 @@ describe(`Validation - duplicateIdentifier`, () => {
             expectNoValidationErrors(TestUtils.createTextMockDocument("let b = 1 in b"));
         });
 
-        it("let 1", () => {
+        it("let 1", async () => {
             const errorSource: string = TestConstants.SimpleValidationSettings.source;
 
-            const validationResult: ValidationResult = validate(
+            const validationResult: ValidationResult = await validate(
                 TestUtils.createTextMockDocument(`let 1`),
                 TestConstants.SimpleValidationSettings,
             );
@@ -103,13 +103,12 @@ describe(`Validation - duplicateIdentifier`, () => {
     });
 
     describe("validation with workspace cache", () => {
-        it("no errors after update", () => {
+        it("no errors after update", async () => {
             const text: string = "let a = 1,";
             const textDocument: MockDocument = TestUtils.createTextMockDocument(text);
 
-            const diagnostics: ReadonlyArray<Diagnostic> = validate(
-                textDocument,
-                TestConstants.SimpleValidationSettings,
+            const diagnostics: ReadonlyArray<Diagnostic> = (
+                await validate(textDocument, TestConstants.SimpleValidationSettings)
             ).diagnostics;
 
             expect(diagnostics.length).to.be.greaterThan(0, "validation result is expected to have errors");
@@ -120,7 +119,7 @@ describe(`Validation - duplicateIdentifier`, () => {
             expectNoValidationErrors(textDocument);
         });
 
-        it("errors after update", () => {
+        it("errors after update", async () => {
             const text: string = "let a = 1 in a";
             const textDocument: MockDocument = TestUtils.createTextMockDocument(text);
             expectNoValidationErrors(textDocument);
@@ -128,9 +127,8 @@ describe(`Validation - duplicateIdentifier`, () => {
             const changes: ReadonlyArray<TextDocumentContentChangeEvent> = textDocument.update(";;;;;;");
             documentUpdated(textDocument, changes, textDocument.version);
 
-            const diagnostics: ReadonlyArray<Diagnostic> = validate(
-                textDocument,
-                TestConstants.SimpleValidationSettings,
+            const diagnostics: ReadonlyArray<Diagnostic> = (
+                await validate(textDocument, TestConstants.SimpleValidationSettings)
             ).diagnostics;
 
             expect(diagnostics.length).to.be.greaterThan(0, "validation result is expected to have errors");

--- a/src/test/validation/invokeExpression.ts
+++ b/src/test/validation/invokeExpression.ts
@@ -29,8 +29,10 @@ interface ArgumentMismatchExec {
 
 const NumArgumentsPattern: RegExp = /Expected between (\d+)-(\d+) arguments, but (\d+) were given./;
 
-function expectGetInvokeExpressionDiagnostics(textDocument: TextDocument): ReadonlyArray<AbridgedInvocationDiagnostic> {
-    const validationResult: ValidationResult = TestUtils.assertGetValidationResult(textDocument);
+async function expectGetInvokeExpressionDiagnostics(
+    textDocument: TextDocument,
+): Promise<ReadonlyArray<AbridgedInvocationDiagnostic>> {
+    const validationResult: ValidationResult = await TestUtils.assertGetValidationResult(textDocument);
     const diagnostics: Diagnostic[] = validationResult.diagnostics;
 
     return diagnostics
@@ -101,53 +103,53 @@ describe("Validation - InvokeExpression", () => {
             checkInvokeExpressions: false,
         };
 
-        it(`argument count suppressed`, () => {
+        it(`argument count suppressed`, async () => {
             const textDocument: TextDocument = TestUtils.createTextMockDocument(
                 `${TestConstants.TestLibraryName.SquareIfNumber}()`,
             );
 
-            const validationResult: ValidationResult = PQLS.validate(textDocument, validationSettings);
+            const validationResult: ValidationResult = await PQLS.validate(textDocument, validationSettings);
             expect(validationResult.diagnostics.length).to.equal(0);
         });
     });
 
     describe(`single invocation`, () => {
-        it(`expects [1, 1] arguments, 0 given`, () => {
+        it(`expects [1, 1] arguments, 0 given`, async () => {
             const textDocument: TextDocument = TestUtils.createTextMockDocument(
                 `${TestConstants.TestLibraryName.SquareIfNumber}()`,
             );
 
             const invocationDiagnostics: ReadonlyArray<AbridgedInvocationDiagnostic> =
-                expectGetInvokeExpressionDiagnostics(textDocument);
+                await expectGetInvokeExpressionDiagnostics(textDocument);
 
             expectArgumentCountMismatch(invocationDiagnostics, 1, 1, 0);
         });
 
-        it(`expects [1, 2] arguments, 0 given`, () => {
+        it(`expects [1, 2] arguments, 0 given`, async () => {
             const textDocument: TextDocument = TestUtils.createTextMockDocument(
                 `${TestConstants.TestLibraryName.CombineNumberAndOptionalText}()`,
             );
 
             const invocationDiagnostics: ReadonlyArray<AbridgedInvocationDiagnostic> =
-                expectGetInvokeExpressionDiagnostics(textDocument);
+                await expectGetInvokeExpressionDiagnostics(textDocument);
 
             expectArgumentCountMismatch(invocationDiagnostics, 1, 2, 0);
         });
 
-        it(`expects [1, 2] arguments, 2 given`, () => {
+        it(`expects [1, 2] arguments, 2 given`, async () => {
             const textDocument: TextDocument = TestUtils.createTextMockDocument(
                 `${TestConstants.TestLibraryName.CombineNumberAndOptionalText}(0, "")`,
             );
 
             const invocationDiagnostics: ReadonlyArray<AbridgedInvocationDiagnostic> =
-                expectGetInvokeExpressionDiagnostics(textDocument);
+                await expectGetInvokeExpressionDiagnostics(textDocument);
 
             expect(invocationDiagnostics.length).to.equal(0);
         });
     });
 
     describe(`multiple invocation`, () => {
-        it(`position for multiple errors`, () => {
+        it(`position for multiple errors`, async () => {
             const textDocument: TextDocument = TestUtils.createTextMockDocument(
                 `
 let 
@@ -158,7 +160,7 @@ in
             );
 
             const invocationDiagnostics: ReadonlyArray<AbridgedInvocationDiagnostic> =
-                expectGetInvokeExpressionDiagnostics(textDocument);
+                await expectGetInvokeExpressionDiagnostics(textDocument);
 
             expect(invocationDiagnostics.length).to.equal(2);
 

--- a/src/test/workspaceCacheTest.ts
+++ b/src/test/workspaceCacheTest.ts
@@ -47,11 +47,11 @@ describe("workspaceCache", () => {
         TestUtils.assertParserCacheItemError(cacheItem);
     });
 
-    it("getOrCreateInspection", () => {
+    it("getOrCreateInspection", async () => {
         const [document, postion]: [MockDocument, Position] =
             TestUtils.createMockDocumentAndPosition("let c = 1 in |c");
 
-        const cacheItem: WorkspaceCache.CacheItem | undefined = WorkspaceCacheUtils.getOrCreateInspection(
+        const cacheItem: WorkspaceCache.CacheItem | undefined = await WorkspaceCacheUtils.getOrCreateInspection(
             document,
             PQLS.InspectionUtils.createInspectionSettings(
                 PQP.DefaultSettings,
@@ -65,11 +65,11 @@ describe("workspaceCache", () => {
         TestUtils.assertInspectionCacheItemOk(cacheItem);
     });
 
-    it("getOrCreateInspection with parser error", () => {
+    it("getOrCreateInspection with parser error", async () => {
         const [document, postion]: [MockDocument, Position] =
             TestUtils.createMockDocumentAndPosition("let c = 1, in |");
 
-        const cacheItem: WorkspaceCache.CacheItem | undefined = WorkspaceCacheUtils.getOrCreateInspection(
+        const cacheItem: WorkspaceCache.CacheItem | undefined = await WorkspaceCacheUtils.getOrCreateInspection(
             document,
             PQLS.InspectionUtils.createInspectionSettings(
                 PQP.DefaultSettings,
@@ -83,10 +83,10 @@ describe("workspaceCache", () => {
         TestUtils.assertInspectionCacheItemOk(cacheItem);
     });
 
-    it("cache invalidation with version change", () => {
+    it("cache invalidation with version change", async () => {
         const [document, postion]: [MockDocument, Position] = TestUtils.createMockDocumentAndPosition("foo|");
 
-        let cacheItem: WorkspaceCache.CacheItem | undefined = WorkspaceCacheUtils.getOrCreateInspection(
+        let cacheItem: WorkspaceCache.CacheItem | undefined = await WorkspaceCacheUtils.getOrCreateInspection(
             document,
             PQLS.InspectionUtils.createInspectionSettings(
                 PQP.DefaultSettings,
@@ -102,7 +102,7 @@ describe("workspaceCache", () => {
 
         document.setText("bar");
 
-        cacheItem = WorkspaceCacheUtils.getOrCreateInspection(
+        cacheItem = await WorkspaceCacheUtils.getOrCreateInspection(
             document,
             PQLS.InspectionUtils.createInspectionSettings(
                 PQP.DefaultSettings,

--- a/src/test/workspaceCacheTest.ts
+++ b/src/test/workspaceCacheTest.ts
@@ -25,10 +25,10 @@ describe("workspaceCache", () => {
         expect(cacheItem.lexerSnapshot.lineTerminators.length).to.equal(3);
     });
 
-    it("getOrCreateParse", () => {
+    it("getOrCreateParse", async () => {
         const text: string = "let c = 1 in c";
 
-        const cacheItem: WorkspaceCache.ParseCacheItem = WorkspaceCacheUtils.getOrCreateParse(
+        const cacheItem: WorkspaceCache.ParseCacheItem = await WorkspaceCacheUtils.getOrCreateParse(
             TestUtils.createTextMockDocument(text),
             PQP.DefaultSettings,
         );
@@ -36,10 +36,10 @@ describe("workspaceCache", () => {
         TestUtils.assertParserCacheItemOk(cacheItem);
     });
 
-    it("getOrCreateParse with error", () => {
+    it("getOrCreateParse with error", async () => {
         const text: string = "let c = 1, in c";
 
-        const cacheItem: WorkspaceCache.ParseCacheItem = WorkspaceCacheUtils.getOrCreateParse(
+        const cacheItem: WorkspaceCache.ParseCacheItem = await WorkspaceCacheUtils.getOrCreateParse(
             TestUtils.createTextMockDocument(text),
             PQP.DefaultSettings,
         );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,20 +1,22 @@
 {
     "compilerOptions": {
-        "target": "es5",
-        "module": "commonjs",
-        "sourceMap": true,
-        "outDir": "lib",
-        "strict": true,
+        "declaration": true,
         "downlevelIteration": true,
+        "incremental": true,
+        "module": "commonjs",
         "noEmitOnError": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitOverride": true,
         "noImplicitReturns": true,
         "noUnusedLocals": true,
         "noUnusedParameters": true,
-        "declaration": true,
+        "outDir": "lib",
+        "resolveJsonModule": true,
         "rootDir": "src",
-        "incremental": true,
-        "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
-        "resolveJsonModule": true
+        "sourceMap": true,
+        "strict": true,
+        "target": "es6",
+        "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
     },
     "include": ["src/**/*.ts"],
     "exclude": ["node_modules"]


### PR DESCRIPTION
The WorkspaceCacheUtils has been reworked to be async including its consumers. I still need to change more of the downstream into async, such as each of the individual inspections instead of making the whole collection async. From here on it shouldn't be insanely huge diffs for a PR.