### PR TITLE
Rename inspection task

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/powerquery-language-services",
-            "version": "0.3.0",
+            "version": "0.3.1",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/powerquery-formatter": "0.0.45",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "author": "Microsoft",
     "license": "MIT",
     "scripts": {

--- a/src/powerquery-language-services/analysis/analysisBase.ts
+++ b/src/powerquery-language-services/analysis/analysisBase.ts
@@ -273,7 +273,7 @@ export abstract class AnalysisBase implements Analysis {
     }
 
     private async getMaybeActiveNode(): Promise<Inspection.ActiveNode | undefined> {
-        const maybemaybeInspected: Inspection.Inspected | undefined = await this.promiseMaybeInspected;
+        const maybeInspected: Inspection.Inspected | undefined = await this.promiseMaybeInspected;
 
         if (maybeInspected === undefined) {
             return undefined;

--- a/src/powerquery-language-services/analysis/analysisBase.ts
+++ b/src/powerquery-language-services/analysis/analysisBase.ts
@@ -31,14 +31,14 @@ export abstract class AnalysisBase implements Analysis {
 
     constructor(
         protected analysisSettings: AnalysisSettings,
-        protected promiseMaybeInspection: Promise<Inspection.Inspection | undefined>,
+        protected promiseMaybeInspected: Promise<Inspection.Inspected | undefined>,
     ) {
         const library: Library.ILibrary = analysisSettings.library;
 
         this.languageAutocompleteItemProvider =
             analysisSettings.maybeCreateLanguageAutocompleteItemProviderFn !== undefined
                 ? analysisSettings.maybeCreateLanguageAutocompleteItemProviderFn()
-                : new LanguageAutocompleteItemProvider(promiseMaybeInspection);
+                : new LanguageAutocompleteItemProvider(promiseMaybeInspected);
 
         this.librarySymbolProvider =
             analysisSettings.maybeCreateLibrarySymbolProviderFn !== undefined
@@ -49,12 +49,12 @@ export abstract class AnalysisBase implements Analysis {
             analysisSettings.maybeCreateLocalDocumentSymbolProviderFn !== undefined
                 ? analysisSettings.maybeCreateLocalDocumentSymbolProviderFn(
                       library,
-                      promiseMaybeInspection,
+                      promiseMaybeInspected,
                       analysisSettings.createInspectionSettingsFn,
                   )
                 : new LocalDocumentSymbolProvider(
                       library,
-                      promiseMaybeInspection,
+                      promiseMaybeInspected,
                       analysisSettings.createInspectionSettingsFn,
                   );
     }
@@ -132,14 +132,14 @@ export abstract class AnalysisBase implements Analysis {
     }
 
     public async getSignatureHelp(): Promise<SignatureHelp> {
-        const maybeInspection: Inspection.Inspection | undefined = await this.promiseMaybeInspection;
+        const maybemaybeInspected: Inspection.Inspected | undefined = await this.promiseMaybeInspected;
 
-        if (maybeInspection === undefined) {
+        if (maybeInspected === undefined) {
             return EmptySignatureHelp;
         }
 
         const maybeContext: SignatureProviderContext | undefined =
-            await InspectionUtils.getMaybeContextForSignatureProvider(maybeInspection);
+            await InspectionUtils.getMaybeContextForSignatureProvider(maybeInspected);
 
         if (maybeContext === undefined) {
             return EmptySignatureHelp;
@@ -273,14 +273,14 @@ export abstract class AnalysisBase implements Analysis {
     }
 
     private async getMaybeActiveNode(): Promise<Inspection.ActiveNode | undefined> {
-        const maybeInspection: Inspection.Inspection | undefined = await this.promiseMaybeInspection;
+        const maybemaybeInspected: Inspection.Inspected | undefined = await this.promiseMaybeInspected;
 
-        if (maybeInspection === undefined) {
+        if (maybeInspected === undefined) {
             return undefined;
         }
 
-        return Inspection.ActiveNodeUtils.isPositionInBounds(maybeInspection.maybeActiveNode)
-            ? maybeInspection.maybeActiveNode
+        return Inspection.ActiveNodeUtils.isPositionInBounds(maybeInspected.maybeActiveNode)
+            ? maybeInspected.maybeActiveNode
             : undefined;
     }
 }

--- a/src/powerquery-language-services/analysis/analysisBase.ts
+++ b/src/powerquery-language-services/analysis/analysisBase.ts
@@ -132,7 +132,7 @@ export abstract class AnalysisBase implements Analysis {
     }
 
     public async getSignatureHelp(): Promise<SignatureHelp> {
-        const maybemaybeInspected: Inspection.Inspected | undefined = await this.promiseMaybeInspected;
+        const maybeInspected: Inspection.Inspected | undefined = await this.promiseMaybeInspected;
 
         if (maybeInspected === undefined) {
             return EmptySignatureHelp;

--- a/src/powerquery-language-services/analysis/analysisSettings.ts
+++ b/src/powerquery-language-services/analysis/analysisSettings.ts
@@ -14,7 +14,7 @@ export interface AnalysisSettings {
     readonly maybeCreateLibrarySymbolProviderFn?: (library: ILibrary) => ISymbolProvider;
     readonly maybeCreateLocalDocumentSymbolProviderFn?: (
         library: ILibrary,
-        promiseMaybeInspection: Promise<Inspection.Inspection | undefined>,
+        promiseMaybeInspected: Promise<Inspection.Inspected | undefined>,
         createInspectionSettingsFn: () => InspectionSettings,
     ) => ISymbolProvider;
     readonly symbolProviderTimeoutInMS?: number;

--- a/src/powerquery-language-services/analysis/documentAnalysis.ts
+++ b/src/powerquery-language-services/analysis/documentAnalysis.ts
@@ -12,7 +12,7 @@ export class DocumentAnalysis extends AnalysisBase {
     constructor(private readonly textDocument: TextDocument, analysisSettings: AnalysisSettings, position: Position) {
         super(
             analysisSettings,
-            WorkspaceCacheUtils.getOrCreateInspectionPromise(
+            WorkspaceCacheUtils.getOrCreateInspectedPromise(
                 textDocument,
                 analysisSettings.createInspectionSettingsFn(),
                 position,

--- a/src/powerquery-language-services/inspection/commonTypes.ts
+++ b/src/powerquery-language-services/inspection/commonTypes.ts
@@ -8,9 +8,9 @@ import { TMaybeActiveNode } from "./activeNode";
 import { TriedExpectedType } from "./expectedType";
 import { TypeCache } from "./typeCache";
 
-export type TriedInspection = PQP.Result<Inspection, PQP.CommonError.CommonError>;
+export type TriedInspection = PQP.Result<Inspected, PQP.CommonError.CommonError>;
 
-export interface Inspection {
+export interface Inspected {
     readonly maybeActiveNode: TMaybeActiveNode;
     readonly autocomplete: Inspection.Autocomplete;
     readonly triedCurrentInvokeExpression: Promise<Inspection.TriedCurrentInvokeExpression>;

--- a/src/powerquery-language-services/inspection/task.ts
+++ b/src/powerquery-language-services/inspection/task.ts
@@ -11,12 +11,12 @@ import { TriedNodeScope, tryNodeScope } from "./scope";
 import { TriedScopeType, tryScopeType } from "./type";
 import { TypeCache, TypeCacheUtils } from "./typeCache";
 import { autocomplete } from "./autocomplete";
-import { Inspection } from "./commonTypes";
+import { Inspected } from "./commonTypes";
 import { InspectionSettings } from "../inspectionSettings";
 import { TriedCurrentInvokeExpression } from "./invokeExpression";
 import { tryCurrentInvokeExpression } from "./invokeExpression/currentInvokeExpression";
 
-export async function inspection(
+export async function inspect(
     settings: InspectionSettings,
     parseState: PQP.Parser.ParseState,
     maybeParseError: PQP.Parser.ParseError.ParseError | undefined,
@@ -24,7 +24,7 @@ export async function inspection(
     // If a TypeCache is given, then potentially add to its values and include it as part of the return,
     // Else create a new TypeCache and include it in the return.
     typeCache: TypeCache = TypeCacheUtils.createEmptyCache(),
-): Promise<Inspection> {
+): Promise<Inspected> {
     const nodeIdMapCollection: NodeIdMap.Collection = parseState.contextState.nodeIdMapCollection;
 
     // We should only get an undefined for activeNode iff the document is empty

--- a/src/powerquery-language-services/inspectionUtils.ts
+++ b/src/powerquery-language-services/inspectionUtils.ts
@@ -27,7 +27,7 @@ export function createInspectionSettings(
 }
 
 export async function getMaybeContextForSignatureProvider(
-    inspected: Inspection.Inspection,
+    inspected: Inspection.Inspected,
 ): Promise<SignatureProviderContext | undefined> {
     const triedCurrentInvokeExpression: Inspection.TriedCurrentInvokeExpression =
         await inspected.triedCurrentInvokeExpression;
@@ -83,10 +83,10 @@ export function getMaybeSignatureHelp(context: SignatureProviderContext): Signat
 }
 
 export async function getMaybeType(
-    inspection: Inspection.Inspection,
+    inspected: Inspection.Inspected,
     identifier: string,
 ): Promise<Type.TPowerQueryType | undefined> {
-    const triedScopeType: Inspection.TriedScopeType = await inspection.triedScopeType;
+    const triedScopeType: Inspection.TriedScopeType = await inspected.triedScopeType;
 
     return ResultUtils.isOk(triedScopeType) ? triedScopeType.value.get(identifier) : undefined;
 }
@@ -218,7 +218,7 @@ export function getSymbolForIdentifierPairedExpression(
 
 export async function getAutocompleteItemsFromScope(
     context: AutocompleteItemProviderContext,
-    inspection: Inspection.Inspection,
+    inspection: Inspection.Inspected,
 ): Promise<ReadonlyArray<Inspection.AutocompleteItem>> {
     const triedNodeScope: Inspection.TriedNodeScope = await inspection.triedNodeScope;
     const triedScopeType: Inspection.TriedScopeType = await inspection.triedScopeType;

--- a/src/powerquery-language-services/providers/languageCompletionItemProvider.ts
+++ b/src/powerquery-language-services/providers/languageCompletionItemProvider.ts
@@ -25,12 +25,12 @@ export class LanguageAutocompleteItemProvider implements AutocompleteItemProvide
         KeywordKind.HashTime,
     ];
 
-    constructor(private readonly maybePromiseInspection: Promise<Inspection.Inspection | undefined>) {}
+    constructor(private readonly maybePromiseInspection: Promise<Inspection.Inspected | undefined>) {}
 
     public async getAutocompleteItems(
         _context: AutocompleteItemProviderContext,
     ): Promise<ReadonlyArray<AutocompleteItem>> {
-        const maybeInspection: Inspection.Inspection | undefined = await this.maybePromiseInspection;
+        const maybeInspection: Inspection.Inspected | undefined = await this.maybePromiseInspection;
 
         if (maybeInspection === undefined) {
             return [];

--- a/src/powerquery-language-services/providers/localDocumentSymbolProvider.ts
+++ b/src/powerquery-language-services/providers/localDocumentSymbolProvider.ts
@@ -27,7 +27,7 @@ export class LocalDocumentSymbolProvider implements ISymbolProvider {
 
     constructor(
         library: Library.ILibrary,
-        private readonly promiseMaybeInspection: Promise<Inspection.Inspection | undefined>,
+        private readonly promiseMaybeInspected: Promise<Inspection.Inspected | undefined>,
         private readonly createInspectionSettingsFn: () => InspectionSettings,
     ) {
         this.externalTypeResolver = library.externalTypeResolver;
@@ -37,26 +37,26 @@ export class LocalDocumentSymbolProvider implements ISymbolProvider {
     public async getAutocompleteItems(
         context: AutocompleteItemProviderContext,
     ): Promise<ReadonlyArray<Inspection.AutocompleteItem>> {
-        const maybeInspection: Inspection.Inspection | undefined = await this.promiseMaybeInspection;
+        const maybemaybeInspected: Inspection.Inspected | undefined = await this.promiseMaybeInspected;
 
-        if (maybeInspection === undefined) {
+        if (maybeInspected === undefined) {
             return [];
         }
 
         return [
-            ...this.getAutocompleteItemsFromFieldAccess(maybeInspection),
-            ...(await InspectionUtils.getAutocompleteItemsFromScope(context, maybeInspection)),
+            ...this.getAutocompleteItemsFromFieldAccess(maybeInspected),
+            ...(await InspectionUtils.getAutocompleteItemsFromScope(context, maybeInspected)),
         ];
     }
 
     public async getHover(context: HoverProviderContext): Promise<Hover | null> {
-        const maybeInspection: Inspection.Inspection | undefined = await this.promiseMaybeInspection;
+        const maybemaybeInspected: Inspection.Inspected | undefined = await this.promiseMaybeInspected;
 
-        if (maybeInspection === undefined) {
+        if (maybeInspected === undefined) {
             return null;
         }
 
-        const activeNode: Inspection.TMaybeActiveNode = maybeInspection.maybeActiveNode;
+        const activeNode: Inspection.TMaybeActiveNode = maybeInspected.maybeActiveNode;
 
         if (!Inspection.ActiveNodeUtils.isPositionInBounds(activeNode)) {
             return null;
@@ -65,7 +65,7 @@ export class LocalDocumentSymbolProvider implements ISymbolProvider {
         let maybeHover: Hover | undefined = await LocalDocumentSymbolProvider.getHoverForIdentifierPairedExpression(
             context,
             this.createInspectionSettingsFn(),
-            maybeInspection,
+            maybeInspected,
             activeNode,
         );
 
@@ -73,8 +73,8 @@ export class LocalDocumentSymbolProvider implements ISymbolProvider {
             return maybeHover;
         }
 
-        const triedNodeScope: Inspection.TriedNodeScope = await maybeInspection.triedNodeScope;
-        const triedScopeType: Inspection.TriedScopeType = await maybeInspection.triedScopeType;
+        const triedNodeScope: Inspection.TriedNodeScope = await maybeInspected.triedNodeScope;
+        const triedScopeType: Inspection.TriedScopeType = await maybeInspected.triedScopeType;
 
         if (!ResultUtils.isOk(triedNodeScope) || !ResultUtils.isOk(triedScopeType)) {
             return null;
@@ -114,10 +114,10 @@ export class LocalDocumentSymbolProvider implements ISymbolProvider {
     protected static async getHoverForIdentifierPairedExpression(
         context: HoverProviderContext,
         inspectionSettings: InspectionSettings,
-        inspection: Inspection.Inspection,
+        inspected: Inspection.Inspected,
         activeNode: Inspection.ActiveNode,
     ): Promise<Hover | undefined> {
-        const parseState: ParseState = inspection.parseState;
+        const parseState: ParseState = inspected.parseState;
         const ancestry: ReadonlyArray<TXorNode> = activeNode.ancestry;
         const maybeLeafKind: Ast.NodeKind | undefined = ancestry[0]?.node.kind;
 
@@ -159,7 +159,7 @@ export class LocalDocumentSymbolProvider implements ISymbolProvider {
             inspectionSettings,
             parseState.contextState.nodeIdMapCollection,
             maybeExpression.node.id,
-            inspection.typeCache,
+            inspected.typeCache,
         );
 
         // TODO handle error
@@ -230,20 +230,20 @@ export class LocalDocumentSymbolProvider implements ISymbolProvider {
     }
 
     private async getMaybeInspectionInvokeExpression(): Promise<Inspection.InvokeExpression | undefined> {
-        const maybeInspection: Inspection.Inspection | undefined = await this.promiseMaybeInspection;
+        const maybemaybeInspected: Inspection.Inspected | undefined = await this.promiseMaybeInspected;
 
-        if (maybeInspection === undefined) {
+        if (maybeInspected === undefined) {
             return undefined;
         }
 
         const triedCurrentInvokeExpression: Inspection.TriedCurrentInvokeExpression =
-            await maybeInspection.triedCurrentInvokeExpression;
+            await maybeInspected.triedCurrentInvokeExpression;
 
         return ResultUtils.isOk(triedCurrentInvokeExpression) ? triedCurrentInvokeExpression.value : undefined;
     }
 
     private getAutocompleteItemsFromFieldAccess(
-        inspection: Inspection.Inspection,
+        inspection: Inspection.Inspected,
     ): ReadonlyArray<Inspection.AutocompleteItem> {
         const triedFieldAccess: Inspection.TriedAutocompleteFieldAccess = inspection.autocomplete.triedFieldAccess;
 

--- a/src/powerquery-language-services/providers/localDocumentSymbolProvider.ts
+++ b/src/powerquery-language-services/providers/localDocumentSymbolProvider.ts
@@ -37,7 +37,7 @@ export class LocalDocumentSymbolProvider implements ISymbolProvider {
     public async getAutocompleteItems(
         context: AutocompleteItemProviderContext,
     ): Promise<ReadonlyArray<Inspection.AutocompleteItem>> {
-        const maybemaybeInspected: Inspection.Inspected | undefined = await this.promiseMaybeInspected;
+        const maybeInspected: Inspection.Inspected | undefined = await this.promiseMaybeInspected;
 
         if (maybeInspected === undefined) {
             return [];
@@ -50,7 +50,7 @@ export class LocalDocumentSymbolProvider implements ISymbolProvider {
     }
 
     public async getHover(context: HoverProviderContext): Promise<Hover | null> {
-        const maybemaybeInspected: Inspection.Inspected | undefined = await this.promiseMaybeInspected;
+        const maybeInspected: Inspection.Inspected | undefined = await this.promiseMaybeInspected;
 
         if (maybeInspected === undefined) {
             return null;
@@ -230,7 +230,7 @@ export class LocalDocumentSymbolProvider implements ISymbolProvider {
     }
 
     private async getMaybeInspectionInvokeExpression(): Promise<Inspection.InvokeExpression | undefined> {
-        const maybemaybeInspected: Inspection.Inspected | undefined = await this.promiseMaybeInspected;
+        const maybeInspected: Inspection.Inspected | undefined = await this.promiseMaybeInspected;
 
         if (maybeInspected === undefined) {
             return undefined;

--- a/src/powerquery-language-services/workspaceCache/workspaceCache.ts
+++ b/src/powerquery-language-services/workspaceCache/workspaceCache.ts
@@ -13,7 +13,7 @@ export interface CacheCollection {
     maybeLex: Promise<PQP.Task.TriedLexTask> | undefined;
     maybeParse: Promise<PQP.Task.TriedParseTask | undefined> | undefined;
     // Inspections are done on a given position so it requires a map for inspection promises.
-    readonly inspectionByPosition: Map<string, Promise<Inspection.Inspection> | undefined>;
+    readonly inspectionByPosition: Map<string, Promise<Inspection.Inspected> | undefined>;
     readonly typeCache: Inspection.TypeCache;
     readonly version: number;
 }

--- a/src/powerquery-language-services/workspaceCache/workspaceCacheUtils.ts
+++ b/src/powerquery-language-services/workspaceCache/workspaceCacheUtils.ts
@@ -88,11 +88,11 @@ export async function getOrCreateParsePromise(
     return cacheCollection.maybeParse;
 }
 
-export async function getOrCreateInspectionPromise(
+export async function getOrCreateInspectedPromise(
     textDocument: TextDocument,
     inspectionSettings: InspectionSettings,
     position: Position,
-): Promise<Inspection.Inspection | undefined> {
+): Promise<Inspection.Inspected | undefined> {
     const cacheCollection: CacheCollection = getOrCreateCacheCollection(textDocument);
     const positionMapKey: string = createInspectionByPositionKey(position);
 
@@ -127,7 +127,7 @@ export async function getOrCreateInspectionPromise(
         throw PQP.Assert.isNever(maybeTriedParse);
     }
 
-    return Inspection.inspection(
+    return Inspection.inspect(
         inspectionSettings,
         parseState,
         PQP.TaskUtils.isParseStageParseError(maybeTriedParse) ? maybeTriedParse.error : undefined,

--- a/src/test/analysis.ts
+++ b/src/test/analysis.ts
@@ -41,7 +41,7 @@ describe("Analysis", () => {
                 symbolProviderTimeoutInMS: 0, // immediate timeout
                 maybeCreateLocalDocumentSymbolProviderFn: (
                     library: ILibrary,
-                    _maybePromiseInspection: Promise<Inspection.Inspection | undefined>,
+                    _maybePromiseInspected: Promise<Inspection.Inspected | undefined>,
                     _createInspectionSettingsFn: () => InspectionSettings,
                 ) => new SlowSymbolProvider(library, 1000),
                 maybeCreateLibrarySymbolProviderFn: (library: ILibrary) => new SlowSymbolProvider(library, 1000),
@@ -127,7 +127,7 @@ async function runHoverTimeoutTest(provider: "local" | "library", expectedHoverT
             ? {
                   maybeCreateLocalDocumentSymbolProviderFn: (
                       library: ILibrary,
-                      _maybePromiseInspection: Promise<Inspection.Inspection> | undefined,
+                      _maybePromiseInspected: Promise<Inspection.Inspected> | undefined,
                       _createInspectionSettingsFn: () => InspectionSettings,
                   ): ISymbolProvider => new SlowSymbolProvider(library, 1000),
               }

--- a/src/test/inspection.ts
+++ b/src/test/inspection.ts
@@ -12,7 +12,7 @@ import { Inspection, InspectionUtils, Position, SignatureProviderContext } from 
 import { TestConstants, TestUtils } from ".";
 import { MockDocument } from "./mockDocument";
 
-async function expectScope(inspected: Inspection.Inspection, expected: ReadonlyArray<string>): Promise<void> {
+async function expectScope(inspected: Inspection.Inspected, expected: ReadonlyArray<string>): Promise<void> {
     const triedNodeScope: Inspection.TriedNodeScope = await inspected.triedNodeScope;
 
     if (ResultUtils.isError(triedNodeScope)) {
@@ -42,7 +42,7 @@ describe("InspectedInvokeExpression", () => {
                 `${TestConstants.TestLibraryName.SquareIfNumber}(1|,`,
             );
 
-            const inspected: Inspection.Inspection = await TestUtils.assertGetInspection(document, position);
+            const inspected: Inspection.Inspected = await TestUtils.assertGetInspection(document, position);
 
             const maybeContext: SignatureProviderContext | undefined =
                 await InspectionUtils.getMaybeContextForSignatureProvider(inspected);
@@ -59,7 +59,7 @@ describe("InspectedInvokeExpression", () => {
                 `${TestConstants.TestLibraryName.SquareIfNumber}(d,|`,
             );
 
-            const inspected: Inspection.Inspection = await TestUtils.assertGetInspection(document, position);
+            const inspected: Inspection.Inspected = await TestUtils.assertGetInspection(document, position);
 
             const maybeContext: SignatureProviderContext | undefined =
                 await InspectionUtils.getMaybeContextForSignatureProvider(inspected);
@@ -76,7 +76,7 @@ describe("InspectedInvokeExpression", () => {
                 `${TestConstants.TestLibraryName.SquareIfNumber}(d,1|`,
             );
 
-            const inspected: Inspection.Inspection = await TestUtils.assertGetInspection(document, position);
+            const inspected: Inspection.Inspected = await TestUtils.assertGetInspection(document, position);
 
             const maybeContext: SignatureProviderContext | undefined =
                 await InspectionUtils.getMaybeContextForSignatureProvider(inspected);
@@ -97,7 +97,7 @@ describe("InspectedInvokeExpression", () => {
                     character: 23,
                 };
 
-                const inspected: Inspection.Inspection = await TestUtils.assertGetInspection(document, position);
+                const inspected: Inspection.Inspected = await TestUtils.assertGetInspection(document, position);
 
                 await expectScope(inspected, [
                     "ConnectionString",

--- a/src/test/providers/simpleLibrarySymbolProvider.ts
+++ b/src/test/providers/simpleLibrarySymbolProvider.ts
@@ -21,7 +21,7 @@ const IsolatedAnalysisSettings: AnalysisSettings = {
     ...TestConstants.SimpleLibraryAnalysisSettings,
     maybeCreateLocalDocumentSymbolProviderFn: (
         _library: ILibrary,
-        _maybePromiseInspection: Promise<Inspection.Inspection | undefined>,
+        _maybePromiseInspected: Promise<Inspection.Inspected | undefined>,
     ) => NullSymbolProvider.singleton(),
 };
 

--- a/src/test/testConstants.ts
+++ b/src/test/testConstants.ts
@@ -245,7 +245,7 @@ export const SimpleLibraryAnalysisSettings: AnalysisSettings = {
     maybeCreateLibrarySymbolProviderFn: (library: Library.ILibrary) => new LibrarySymbolProvider(library),
     maybeCreateLocalDocumentSymbolProviderFn: (
         library: Library.ILibrary,
-        maybePromiseInspection: Promise<Inspection.Inspection | undefined>,
+        maybePromiseInspection: Promise<Inspection.Inspected | undefined>,
         createInspectionSettingsFn: () => InspectionSettings,
     ) => new LocalDocumentSymbolProvider(library, maybePromiseInspection, createInspectionSettingsFn),
 };

--- a/src/test/testUtils/assert.ts
+++ b/src/test/testUtils/assert.ts
@@ -75,32 +75,16 @@ export function assertGetAutocompleteItem(
     );
 }
 
-// export async function assertGetInspectionCacheItem(
-//     document: MockDocument,
-//     position: Position,
-// ): Promise<InspectionTask> {
-//     const cacheItem: any = await WorkspaceCacheUtils.getOrCreateInspectionPromise(
-//         document,
-//         TestConstants.SimpleInspectionSettings,
-//         position,
-//     );
-
-//     assertIsDefined(cacheItem);
-//     assertInspectionCacheItemOk(cacheItem);
-
-//     return cacheItem;
-// }
-
-export async function assertGetInspection(document: TextDocument, position: Position): Promise<Inspection.Inspection> {
-    const inspected: Inspection.Inspection | undefined = await WorkspaceCacheUtils.getOrCreateInspectionPromise(
+export async function assertGetInspection(document: TextDocument, position: Position): Promise<Inspection.Inspected> {
+    const maybeInspected: Inspection.Inspected | undefined = await WorkspaceCacheUtils.getOrCreateInspectedPromise(
         document,
         TestConstants.SimpleInspectionSettings,
         position,
     );
 
-    Assert.isDefined(inspected);
+    Assert.isDefined(maybeInspected);
 
-    return inspected;
+    return maybeInspected;
 }
 
 export async function assertGetLexParseOk(settings: PQP.Settings, text: string): Promise<PQP.Task.ParseTaskOk> {
@@ -165,45 +149,6 @@ export function assertAutocompleteItemLabels(
     const actualLabels: ReadonlyArray<string> = actual.map((item: Inspection.AutocompleteItem) => item.label);
     expect(actualLabels).to.include.members(expected);
 }
-
-// export function assertCacheItemOk(
-//     cacheItem: PQP.Task.TriedLexTask | PQP.Task.TriedParseTask | InspectionTask | undefined,
-// ): asserts cacheItem is PQP.Task.LexTaskOk | PQP.Task.ParseTaskOk | InspectionTask {
-//     if (cacheItem !== undefined && !WorkspaceCacheUtils.isInspectionTask(cacheItem)) {
-//         TaskUtils.assertIsOk(cacheItem);
-//     }
-// }
-
-// export function assertInspectionCacheItemOk(
-//     cacheItem: WorkspaceCache.InspectionTask,
-// ): asserts cacheItem is WorkspaceCache.InspectionTask {
-//     WorkspaceCacheUtils.assertIsInspectionTask(cacheItem);
-// }
-
-// export function assertNotInspectionCacheItem(
-//     cacheItem: PQP.Task.TriedLexTask | PQP.Task.TriedParseTask | InspectionTask | undefined,
-// ): asserts cacheItem is Exclude<
-//     PQP.Task.TriedLexTask | PQP.Task.TriedParseTask | InspectionTask | undefined,
-//     undefined | WorkspaceCache.InspectionTask
-// > {
-//     if (cacheItem === undefined || cacheItem.stage === "Inspection") {
-//         throw new Error(`expected cacheItem to not be a Inspection cache item`);
-//     }
-// }
-
-// export function assertParserCacheItemOk(
-//     cacheItem: WorkspaceCache.CacheItem,
-// ): asserts cacheItem is PQP.Task.ParseTaskOk {
-//     assertNotInspectionCacheItem(cacheItem);
-//     TaskUtils.assertIsParseStageOk(cacheItem);
-// }
-
-// export function assertParserCacheItemError(
-//     cacheItem: WorkspaceCache.CacheItem,
-// ): asserts cacheItem is PQP.Task.ParseTaskOk {
-//     assertNotInspectionCacheItem(cacheItem);
-//     TaskUtils.assertIsParseStageParseError(cacheItem);
-// }
 
 export function assertSignatureHelp(expected: TestUtils.AbridgedSignatureHelp, actual: SignatureHelp): void {
     expect(TestUtils.createAbridgedSignatureHelp(actual)).deep.equals(expected);

--- a/src/test/workspaceCacheTest.ts
+++ b/src/test/workspaceCacheTest.ts
@@ -53,7 +53,7 @@ describe("workspaceCache", () => {
         const [document, postion]: [MockDocument, Position] =
             TestUtils.createMockDocumentAndPosition("let c = 1 in |c");
 
-        const cacheItem: Inspection.Inspection | undefined = await WorkspaceCacheUtils.getOrCreateInspectionPromise(
+        const maybeInspected: Inspection.Inspected | undefined = await WorkspaceCacheUtils.getOrCreateInspectedPromise(
             document,
             PQLS.InspectionUtils.createInspectionSettings(
                 PQP.DefaultSettings,
@@ -63,14 +63,14 @@ describe("workspaceCache", () => {
             postion,
         );
 
-        TestUtils.assertIsDefined(cacheItem);
+        TestUtils.assertIsDefined(maybeInspected);
     });
 
     it("getOrCreateInspectionPromise with parser error", async () => {
         const [document, postion]: [MockDocument, Position] =
             TestUtils.createMockDocumentAndPosition("let c = 1, in |");
 
-        const cacheItem: Inspection.Inspection | undefined = await WorkspaceCacheUtils.getOrCreateInspectionPromise(
+        const maybeInspected: Inspection.Inspected | undefined = await WorkspaceCacheUtils.getOrCreateInspectedPromise(
             document,
             PQLS.InspectionUtils.createInspectionSettings(
                 PQP.DefaultSettings,
@@ -80,13 +80,13 @@ describe("workspaceCache", () => {
             postion,
         );
 
-        TestUtils.assertIsDefined(cacheItem);
+        TestUtils.assertIsDefined(maybeInspected);
     });
 
     it("cache invalidation with version change", async () => {
         const [document, postion]: [MockDocument, Position] = TestUtils.createMockDocumentAndPosition("foo|");
 
-        let cacheItem: Inspection.Inspection | undefined = await WorkspaceCacheUtils.getOrCreateInspectionPromise(
+        let maybeInspected: Inspection.Inspected | undefined = await WorkspaceCacheUtils.getOrCreateInspectedPromise(
             document,
             PQLS.InspectionUtils.createInspectionSettings(
                 PQP.DefaultSettings,
@@ -96,7 +96,7 @@ describe("workspaceCache", () => {
             postion,
         );
 
-        TestUtils.assertIsDefined(cacheItem);
+        TestUtils.assertIsDefined(maybeInspected);
 
         let cacheCollection: WorkspaceCache.CacheCollection = WorkspaceCacheUtils.getOrCreateCacheCollection(document);
 
@@ -104,7 +104,7 @@ describe("workspaceCache", () => {
 
         document.setText("bar");
 
-        cacheItem = await WorkspaceCacheUtils.getOrCreateInspectionPromise(
+        maybeInspected = await WorkspaceCacheUtils.getOrCreateInspectedPromise(
             document,
             PQLS.InspectionUtils.createInspectionSettings(
                 PQP.DefaultSettings,
@@ -114,7 +114,7 @@ describe("workspaceCache", () => {
             postion,
         );
 
-        TestUtils.assertIsDefined(cacheItem);
+        TestUtils.assertIsDefined(maybeInspected);
 
         cacheCollection = WorkspaceCacheUtils.getOrCreateCacheCollection(document);
 


### PR DESCRIPTION
Nit fixes: I don't like writing `Inspection,Inspection` so it's now `Inspection.Inspected`. For similar reasons the inspection task has being renamed to `inspect`. Additionally removed some commented code.