### PR TITLE
Bugfix type inspection for nullable function parameter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/powerquery-language-services",
-            "version": "0.3.2",
+            "version": "0.3.3",
             "license": "MIT",
             "dependencies": {
-                "@microsoft/powerquery-formatter": "0.0.45",
-                "@microsoft/powerquery-parser": "0.6.2",
+                "@microsoft/powerquery-formatter": "0.0.46",
+                "@microsoft/powerquery-parser": "0.6.4",
                 "vscode-languageserver-textdocument": "1.0.3",
                 "vscode-languageserver-types": "3.16.0"
             },
@@ -124,17 +124,17 @@
             "dev": true
         },
         "node_modules/@microsoft/powerquery-formatter": {
-            "version": "0.0.45",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.0.45.tgz",
-            "integrity": "sha512-TxSkbLLESPnRSNhQzegVvNRilQbYU/Ian8+NdauWzoa8V2WUZwYoJKKBWQ7ElKUNTUXhFPfveXJCLt1DvFA2lQ==",
+            "version": "0.0.46",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.0.46.tgz",
+            "integrity": "sha512-7bThf/iAeTEPc+YkObB3NaNSB8maM/gAeP31mBnLt1QdqBOStnypEfSPrFKKbuADzHUJ+4PT4lYV4FhLflysbQ==",
             "dependencies": {
-                "@microsoft/powerquery-parser": "0.6.2"
+                "@microsoft/powerquery-parser": "0.6.4"
             }
         },
         "node_modules/@microsoft/powerquery-parser": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.6.2.tgz",
-            "integrity": "sha512-iy1CGdPmkSlZyZktaH5p0+CQWTOGj4JHhrEWu6qVJOOSXFImG8amSgLbWszZ07KniWQpvqyg50PWlMVC4+b58Q==",
+            "version": "0.6.4",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.6.4.tgz",
+            "integrity": "sha512-3XL9a3fq9r3ZynVDLpidee1yISyMyGBq/eZ+dT+EFOYZLLvGeB3+qbc7BoyhCcryA8gvBTwMuyUhcBY/iqJ6FA==",
             "dependencies": {
                 "grapheme-splitter": "^1.0.4",
                 "performance-now": "^2.1.0"
@@ -2927,17 +2927,17 @@
             "dev": true
         },
         "@microsoft/powerquery-formatter": {
-            "version": "0.0.45",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.0.45.tgz",
-            "integrity": "sha512-TxSkbLLESPnRSNhQzegVvNRilQbYU/Ian8+NdauWzoa8V2WUZwYoJKKBWQ7ElKUNTUXhFPfveXJCLt1DvFA2lQ==",
+            "version": "0.0.46",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.0.46.tgz",
+            "integrity": "sha512-7bThf/iAeTEPc+YkObB3NaNSB8maM/gAeP31mBnLt1QdqBOStnypEfSPrFKKbuADzHUJ+4PT4lYV4FhLflysbQ==",
             "requires": {
-                "@microsoft/powerquery-parser": "0.6.2"
+                "@microsoft/powerquery-parser": "0.6.4"
             }
         },
         "@microsoft/powerquery-parser": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.6.2.tgz",
-            "integrity": "sha512-iy1CGdPmkSlZyZktaH5p0+CQWTOGj4JHhrEWu6qVJOOSXFImG8amSgLbWszZ07KniWQpvqyg50PWlMVC4+b58Q==",
+            "version": "0.6.4",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.6.4.tgz",
+            "integrity": "sha512-3XL9a3fq9r3ZynVDLpidee1yISyMyGBq/eZ+dT+EFOYZLLvGeB3+qbc7BoyhCcryA8gvBTwMuyUhcBY/iqJ6FA==",
             "requires": {
                 "grapheme-splitter": "^1.0.4",
                 "performance-now": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "author": "Microsoft",
     "license": "MIT",
     "scripts": {
@@ -46,8 +46,8 @@
         "typescript": "4.5.4"
     },
     "dependencies": {
-        "@microsoft/powerquery-formatter": "0.0.45",
-        "@microsoft/powerquery-parser": "0.6.2",
+        "@microsoft/powerquery-formatter": "0.0.46",
+        "@microsoft/powerquery-parser": "0.6.4",
         "vscode-languageserver-textdocument": "1.0.3",
         "vscode-languageserver-types": "3.16.0"
     },

--- a/src/powerquery-language-services/inspection/pseudoFunctionExpressionType.ts
+++ b/src/powerquery-language-services/inspection/pseudoFunctionExpressionType.ts
@@ -52,8 +52,10 @@ export function pseudoFunctionExpressionType(
 
         if (maybeExaminable !== undefined) {
             examinedParameters.push({
-                ...maybeExaminable,
                 id: parameter.node.id,
+                isNullable: maybeExaminable.isNullable,
+                isOptional: maybeExaminable.isOptional,
+                maybeType: maybeExaminable.maybeType,
                 name: maybeName,
             });
         }

--- a/src/powerquery-language-services/inspection/type/inspectType/common.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/common.ts
@@ -544,6 +544,6 @@ export function createParameterType(parameter: ParameterScopeItem): Type.TPrimit
     return {
         kind: TypeUtils.typeKindFromPrimitiveTypeConstantKind(parameter.maybeType),
         maybeExtendedKind: undefined,
-        isNullable: parameter.isNullable,
+        isNullable: parameter.isNullable || parameter.isOptional,
     };
 }

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeTBinOpExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeTBinOpExpression.ts
@@ -189,6 +189,8 @@ function unionTableFields([leftType, rightType]: [Type.DefinedTable, Type.Define
 // Values: the resulting type of the binary operation expression.
 // Eg. '1 > 3' -> Type.TypeKind.Number
 export const Lookup: ReadonlyMap<string, Type.TypeKind> = new Map([
+    ...createLookupsForNullEquality(),
+
     ...createLookupsForRelational(Type.TypeKind.Null),
     ...createLookupsForEquality(Type.TypeKind.Null),
 
@@ -320,6 +322,34 @@ function createLookupsForEquality(typeKind: Type.TypeKind): ReadonlyArray<[strin
         [lookupKey(typeKind, Constant.EqualityOperator.EqualTo, typeKind), Type.TypeKind.Logical],
         [lookupKey(typeKind, Constant.EqualityOperator.NotEqualTo, typeKind), Type.TypeKind.Logical],
     ];
+}
+
+function createLookupsForNullEquality(): ReadonlyArray<[string, Type.TypeKind]> {
+    const results: [string, Type.TypeKind][] = [];
+
+    for (const typeKind of Type.TypeKinds) {
+        results.push([
+            lookupKey(typeKind, Constant.EqualityOperator.EqualTo, Type.TypeKind.Null),
+            Type.TypeKind.Logical,
+        ]);
+
+        results.push([
+            lookupKey(typeKind, Constant.EqualityOperator.NotEqualTo, Type.TypeKind.Null),
+            Type.TypeKind.Logical,
+        ]);
+
+        results.push([
+            lookupKey(Type.TypeKind.Null, Constant.EqualityOperator.EqualTo, typeKind),
+            Type.TypeKind.Logical,
+        ]);
+
+        results.push([
+            lookupKey(Type.TypeKind.Null, Constant.EqualityOperator.NotEqualTo, typeKind),
+            Type.TypeKind.Logical,
+        ]);
+    }
+
+    return results;
 }
 
 // Note: does not include the and <'&'> Constant.

--- a/src/test/inspection/type.ts
+++ b/src/test/inspection/type.ts
@@ -371,6 +371,40 @@ describe(`Inspection - Type`, () => {
         });
 
         describe(`${Ast.NodeKind.FunctionExpression}`, () => {
+            it(`(optional x as text) => if x <> null then 1 else 2`, async () => {
+                const expression: string = `(optional x as text) => if x <> null then 1 else 2`;
+
+                const expected: Type.DefinedFunction = TypeUtils.createDefinedFunction(
+                    false,
+                    [
+                        {
+                            isNullable: false,
+                            isOptional: true,
+                            maybeType: Type.TypeKind.Text,
+                            nameLiteral: "x",
+                        },
+                    ],
+                    TypeUtils.createAnyUnion([
+                        {
+                            isNullable: false,
+                            kind: Type.TypeKind.Number,
+                            literal: "1",
+                            maybeExtendedKind: Type.ExtendedTypeKind.NumberLiteral,
+                            normalizedLiteral: 1,
+                        },
+                        {
+                            isNullable: false,
+                            kind: Type.TypeKind.Number,
+                            literal: "2",
+                            maybeExtendedKind: Type.ExtendedTypeKind.NumberLiteral,
+                            normalizedLiteral: 2,
+                        },
+                    ]),
+                );
+
+                await assertParseOkNodeTypeEqual(TestSettings, expression, expected);
+            });
+
             it(`() => 1`, async () => {
                 const expression: string = `() => 1`;
 


### PR DESCRIPTION
Two bugs are resolved:
* The type for function parameters were not being considered nullable if a parameter was optional
* BinOpExpressions which performed a null check was incorrectly returning None as the type