### PR TITLE
Add validation for FunctionExpression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.3.3",
+    "version": "0.3.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/powerquery-language-services",
-            "version": "0.3.3",
+            "version": "0.3.4",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/powerquery-formatter": "0.0.46",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.3.3",
+    "version": "0.3.4",
     "author": "Microsoft",
     "license": "MIT",
     "scripts": {

--- a/src/powerquery-language-services/validate/validateFunctionExpression.ts
+++ b/src/powerquery-language-services/validate/validateFunctionExpression.ts
@@ -34,6 +34,7 @@ export function validateFunctionExpression(
 
     for (const nodeId of maybeFnExpressionIds) {
         diagnostics.push(validateNoDuplicateParameter(validationSettings, nodeIdMapCollection, nodeId));
+        validationSettings.maybeCancellationToken?.throwIfCancelled();
     }
 
     return diagnostics.flat();

--- a/src/test/validation/functionExpression.ts
+++ b/src/test/validation/functionExpression.ts
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import "mocha";
+import { assert, expect } from "chai";
+
+import {
+    Diagnostic,
+    DiagnosticErrorCode,
+    DiagnosticSeverity,
+    Position,
+    validate,
+} from "../../powerquery-language-services";
+import { TestConstants, TestUtils } from "..";
+import { MockDocument } from "../mockDocument";
+import { ValidationResult } from "../../powerquery-language-services/validate/validationResult";
+
+function assertValidationError(diagnostic: Diagnostic, startPosition: Position): void {
+    assert.isDefined(diagnostic.code);
+    assert.isDefined(diagnostic.message);
+    assert.isDefined(diagnostic.range);
+    expect(diagnostic.range.start).to.deep.equal(startPosition);
+    expect(diagnostic.severity).to.equal(DiagnosticSeverity.Error);
+}
+
+async function expectNoValidationErrors(textDocument: MockDocument): Promise<void> {
+    const validationResult: ValidationResult = await validate(textDocument, TestConstants.SimpleValidationSettings);
+    expect(validationResult.hasSyntaxError).to.equal(false, "hasSyntaxError flag should be false");
+    expect(validationResult.diagnostics.length).to.equal(0, "no diagnostics expected");
+}
+
+describe(`Validation - functionExpression`, () => {
+    describe("Syntax validation", () => {
+        it("no errors", async () => {
+            await expectNoValidationErrors(
+                TestUtils.createTextMockDocument("(foo as number, bar as number) => foo + bar"),
+            );
+        });
+
+        it("(foo as number, foo as number) => foo * 2", async () => {
+            const errorSource: string = TestConstants.SimpleValidationSettings.source;
+
+            const validationResult: ValidationResult = await validate(
+                TestUtils.createTextMockDocument(`(foo as number, foo as number) => foo * 2`),
+                TestConstants.SimpleValidationSettings,
+            );
+
+            expect(validationResult.hasSyntaxError).to.equal(false, "hasSyntaxError flag should be false");
+
+            assertValidationError(validationResult.diagnostics[0], { line: 0, character: 1 });
+            assertValidationError(validationResult.diagnostics[1], { line: 0, character: 16 });
+            expect(validationResult.diagnostics.length).to.equal(2);
+            expect(validationResult.diagnostics[0].source).to.equal(errorSource);
+            expect(validationResult.diagnostics[1].source).to.equal(errorSource);
+            expect(validationResult.diagnostics[0].code).to.equal(DiagnosticErrorCode.DuplicateIdentifier);
+            expect(validationResult.diagnostics[1].code).to.equal(DiagnosticErrorCode.DuplicateIdentifier);
+        });
+    });
+});


### PR DESCRIPTION
Resolves #18. It looks messy as a prototype for validateFunctionExpression.ts was merged by mistake in an earlier PR.