### PR TITLE
Write deltaScope back to given scopeById cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.3.5",
+    "version": "0.3.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/powerquery-language-services",
-            "version": "0.3.5",
+            "version": "0.3.6",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/powerquery-formatter": "0.0.47",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.3.5",
+    "version": "0.3.6",
     "author": "Microsoft",
     "license": "MIT",
     "scripts": {

--- a/src/powerquery-language-services/inspection/scope/scopeInspection.ts
+++ b/src/powerquery-language-services/inspection/scope/scopeInspection.ts
@@ -10,7 +10,7 @@ import {
     TXorNode,
     XorNodeUtils,
 } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
-import { Assert, ResultUtils } from "@microsoft/powerquery-parser";
+import { Assert, MapUtils, ResultUtils } from "@microsoft/powerquery-parser";
 import { Ast, TypeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 
 import { Inspection, LanguageServiceTraceConstant, TraceUtils } from "../..";
@@ -49,9 +49,17 @@ export async function tryNodeScope(
             return new Map();
         }
 
-        const inspected: ScopeById = await inspectScope(settings, nodeIdMapCollection, ancestry, scopeById);
+        const inspectedDeltaScope: ScopeById = await inspectScope(settings, nodeIdMapCollection, ancestry, scopeById);
 
-        return Assert.asDefined(inspected.get(nodeId), `expected nodeId in scope result`, { nodeId });
+        MapUtils.assertGet(inspectedDeltaScope, nodeId, `expected nodeId in scope result`, {
+            nodeId,
+        });
+
+        for (const [key, value] of inspectedDeltaScope.entries()) {
+            scopeById.set(key, value);
+        }
+
+        return scopeById;
     });
 
     trace.exit();
@@ -233,14 +241,12 @@ async function inspectScope(
         return scopeById;
     }
 
-    // Store the delta between the given scope and what's found in a temporary map.
-    // This will prevent mutation in the given map if an error is thrown.
-    const scopeChanges: ScopeById = new Map();
-
     const state: ScopeInspectionState = {
         traceManager: settings.traceManager,
         givenScope: scopeById,
-        deltaScope: scopeChanges,
+        // Store the delta between the given scope and what's found in a temporary map.
+        // This will prevent mutation in the given map if an error is thrown.
+        deltaScope: new Map(),
         ancestry,
         nodeIdMapCollection,
         ancestryIndex: 0,

--- a/src/powerquery-language-services/inspection/scope/scopeInspection.ts
+++ b/src/powerquery-language-services/inspection/scope/scopeInspection.ts
@@ -51,7 +51,7 @@ export async function tryNodeScope(
 
         const inspectedDeltaScope: ScopeById = await inspectScope(settings, nodeIdMapCollection, ancestry, scopeById);
 
-        MapUtils.assertGet(inspectedDeltaScope, nodeId, `expected nodeId in scope result`, {
+        const result: NodeScope = MapUtils.assertGet(inspectedDeltaScope, nodeId, `expected nodeId in scope result`, {
             nodeId,
         });
 
@@ -59,7 +59,7 @@ export async function tryNodeScope(
             scopeById.set(key, value);
         }
 
-        return scopeById;
+        return result;
     });
 
     trace.exit();


### PR DESCRIPTION
There was a regression where we weren't actually storing the calculated results of a scope inspection between runs. Thanks to Al for brining this up!