### PR TITLE
validateDuplicateIdentifier improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.3.22",
+    "version": "0.3.23",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/powerquery-language-services",
-            "version": "0.3.22",
+            "version": "0.3.23",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/powerquery-formatter": "0.0.53",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.3.22",
+    "version": "0.3.23",
     "author": "Microsoft",
     "license": "MIT",
     "scripts": {


### PR DESCRIPTION
- Reduces memory usage by iterating over an existing Set rather than mapping the Set into an Array (which I did for some stupid reason)
- Additional traces
- Removes the check for RecordType as it was fundamentally busted (created #180)