### PR TITLE
TypeStrategy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.3.23",
+    "version": "0.3.24",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/powerquery-language-services",
-            "version": "0.3.23",
+            "version": "0.3.24",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/powerquery-formatter": "0.0.53",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.3.23",
+    "version": "0.3.24",
     "author": "Microsoft",
     "license": "MIT",
     "scripts": {

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeList.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeList.ts
@@ -3,16 +3,18 @@
 
 import { NodeIdMapIterator, TXorNode } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 import { Trace, TraceConstant } from "@microsoft/powerquery-parser/lib/powerquery-parser/common/trace";
+import { Assert } from "@microsoft/powerquery-parser";
 import { Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 
 import { InspectionTraceConstant, TraceUtils } from "../../..";
 import { InspectTypeState, inspectXor } from "./common";
+import { TypeStrategy } from "../../../inspectionSettings";
 
 export async function inspectTypeList(
     state: InspectTypeState,
     xorNode: TXorNode,
     maybeCorrelationId: number | undefined,
-): Promise<Type.DefinedList> {
+): Promise<Type.List | Type.DefinedList> {
     const trace: Trace = state.traceManager.entry(
         InspectionTraceConstant.InspectType,
         inspectTypeList.name,
@@ -20,19 +22,34 @@ export async function inspectTypeList(
         TraceUtils.createXorNodeDetails(xorNode),
     );
 
-    state.maybeCancellationToken?.throwIfCancelled();
-    const items: ReadonlyArray<TXorNode> = NodeIdMapIterator.iterListItems(state.nodeIdMapCollection, xorNode);
+    let result: Type.List | Type.DefinedList;
 
-    const elements: ReadonlyArray<Type.TPowerQueryType> = await Promise.all(
-        items.map((item: TXorNode) => inspectXor(state, item, trace.id)),
-    );
+    switch (state.typeStrategy) {
+        case TypeStrategy.Extended: {
+            state.maybeCancellationToken?.throwIfCancelled();
+            const items: ReadonlyArray<TXorNode> = NodeIdMapIterator.iterListItems(state.nodeIdMapCollection, xorNode);
 
-    const result: Type.TPowerQueryType = {
-        kind: Type.TypeKind.List,
-        isNullable: false,
-        maybeExtendedKind: Type.ExtendedTypeKind.DefinedList,
-        elements,
-    };
+            const elements: ReadonlyArray<Type.TPowerQueryType> = await Promise.all(
+                items.map((item: TXorNode) => inspectXor(state, item, trace.id)),
+            );
+
+            result = {
+                kind: Type.TypeKind.List,
+                isNullable: false,
+                maybeExtendedKind: Type.ExtendedTypeKind.DefinedList,
+                elements,
+            };
+
+            break;
+        }
+
+        case TypeStrategy.Primitive:
+            result = Type.ListInstance;
+            break;
+
+        default:
+            Assert.isNever(state.typeStrategy);
+    }
 
     trace.exit({ [TraceConstant.Result]: TraceUtils.createTypeDetails(result) });
 

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeListType.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeListType.ts
@@ -4,15 +4,17 @@
 import { Ast, Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 import { NodeIdMapUtils, TXorNode, XorNodeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 import { Trace, TraceConstant } from "@microsoft/powerquery-parser/lib/powerquery-parser/common/trace";
+import { Assert } from "@microsoft/powerquery-parser";
 
 import { InspectionTraceConstant, TraceUtils } from "../../..";
 import { InspectTypeState, inspectXor } from "./common";
+import { TypeStrategy } from "../../../inspectionSettings";
 
 export async function inspectTypeListType(
     state: InspectTypeState,
     xorNode: TXorNode,
     maybeCorrelationId: number | undefined,
-): Promise<Type.ListType | Type.Unknown> {
+): Promise<Type.Type | Type.ListType | Type.Unknown> {
     const trace: Trace = state.traceManager.entry(
         InspectionTraceConstant.InspectType,
         inspectTypeListType.name,
@@ -23,25 +25,38 @@ export async function inspectTypeListType(
     state.maybeCancellationToken?.throwIfCancelled();
     XorNodeUtils.assertIsNodeKind<Ast.ListType>(xorNode, Ast.NodeKind.ListType);
 
-    const maybeListItem: TXorNode | undefined = NodeIdMapUtils.maybeNthChild(
-        state.nodeIdMapCollection,
-        xorNode.node.id,
-        1,
-    );
+    let result: Type.Type | Type.ListType | Type.Unknown;
 
-    let result: Type.TPowerQueryType;
+    switch (state.typeStrategy) {
+        case TypeStrategy.Extended: {
+            const maybeListItem: TXorNode | undefined = NodeIdMapUtils.maybeNthChild(
+                state.nodeIdMapCollection,
+                xorNode.node.id,
+                1,
+            );
 
-    if (maybeListItem === undefined) {
-        result = Type.UnknownInstance;
-    } else {
-        const itemType: Type.TPowerQueryType = await inspectXor(state, maybeListItem, trace.id);
+            if (maybeListItem === undefined) {
+                result = Type.UnknownInstance;
+            } else {
+                const itemType: Type.TPowerQueryType = await inspectXor(state, maybeListItem, trace.id);
 
-        result = {
-            kind: Type.TypeKind.Type,
-            maybeExtendedKind: Type.ExtendedTypeKind.ListType,
-            isNullable: false,
-            itemType,
-        };
+                result = {
+                    kind: Type.TypeKind.Type,
+                    maybeExtendedKind: Type.ExtendedTypeKind.ListType,
+                    isNullable: false,
+                    itemType,
+                };
+            }
+
+            break;
+        }
+
+        case TypeStrategy.Primitive:
+            result = Type.TypePrimitiveInstance;
+            break;
+
+        default:
+            Assert.isNever(state.typeStrategy);
     }
 
     trace.exit({ [TraceConstant.Result]: TraceUtils.createTypeDetails(result) });

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRangeExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRangeExpression.ts
@@ -1,12 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Ast, Type, TypeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { Ast, Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 import { Trace, TraceConstant } from "@microsoft/powerquery-parser/lib/powerquery-parser/common/trace";
 import { TXorNode, XorNodeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
 import { InspectionTraceConstant, TraceUtils } from "../../..";
 import { inspectTypeFromChildAttributeIndex, InspectTypeState } from "./common";
+import { Assert } from "@microsoft/powerquery-parser";
+import { TypeStrategy } from "../../../inspectionSettings";
 
 export async function inspectTypeRangeExpression(
     state: InspectTypeState,
@@ -23,37 +25,50 @@ export async function inspectTypeRangeExpression(
     state.maybeCancellationToken?.throwIfCancelled();
     XorNodeUtils.assertIsNodeKind<Ast.RangeExpression>(xorNode, Ast.NodeKind.RangeExpression);
 
-    const maybeLeftType: Type.TPowerQueryType | undefined = await inspectTypeFromChildAttributeIndex(
-        state,
-        xorNode,
-        0,
-        trace.id,
-    );
+    let result: Type.List | Type.None | Type.Unknown;
 
-    const maybeRightType: Type.TPowerQueryType | undefined = await inspectTypeFromChildAttributeIndex(
-        state,
-        xorNode,
-        2,
-        trace.id,
-    );
+    switch (state.typeStrategy) {
+        case TypeStrategy.Extended: {
+            const maybeLeftType: Type.TPowerQueryType | undefined = await inspectTypeFromChildAttributeIndex(
+                state,
+                xorNode,
+                0,
+                trace.id,
+            );
 
-    let result: Type.TPowerQueryType;
+            const maybeRightType: Type.TPowerQueryType | undefined = await inspectTypeFromChildAttributeIndex(
+                state,
+                xorNode,
+                2,
+                trace.id,
+            );
 
-    if (maybeLeftType === undefined || maybeRightType === undefined) {
-        result = Type.UnknownInstance;
-    } else if (maybeLeftType.kind === Type.TypeKind.Number && maybeRightType.kind === Type.TypeKind.Number) {
-        // TODO: handle isNullable better
-        if (maybeLeftType.isNullable === true || maybeRightType.isNullable === true) {
-            result = Type.NoneInstance;
-        } else {
-            result = TypeUtils.createPrimitiveType(maybeLeftType.isNullable, maybeLeftType.kind);
+            if (maybeLeftType === undefined || maybeRightType === undefined) {
+                result = Type.UnknownInstance;
+            } else if (maybeLeftType.kind === Type.TypeKind.Number && maybeRightType.kind === Type.TypeKind.Number) {
+                // TODO: handle isNullable better
+                if (maybeLeftType.isNullable === true || maybeRightType.isNullable === true) {
+                    result = Type.NoneInstance;
+                } else {
+                    result = Type.ListInstance;
+                }
+            } else if (maybeLeftType.kind === Type.TypeKind.None || maybeRightType.kind === Type.TypeKind.None) {
+                result = Type.NoneInstance;
+            } else if (maybeLeftType.kind === Type.TypeKind.Unknown || maybeRightType.kind === Type.TypeKind.Unknown) {
+                result = Type.UnknownInstance;
+            } else {
+                result = Type.NoneInstance;
+            }
+
+            break;
         }
-    } else if (maybeLeftType.kind === Type.TypeKind.None || maybeRightType.kind === Type.TypeKind.None) {
-        result = Type.NoneInstance;
-    } else if (maybeLeftType.kind === Type.TypeKind.Unknown || maybeRightType.kind === Type.TypeKind.Unknown) {
-        result = Type.UnknownInstance;
-    } else {
-        result = Type.NoneInstance;
+
+        case TypeStrategy.Primitive:
+            result = Type.ListInstance;
+            break;
+
+        default:
+            Assert.isNever(state.typeStrategy);
     }
 
     trace.exit({ [TraceConstant.Result]: TraceUtils.createTypeDetails(result) });

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRecordType.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeRecordType.ts
@@ -4,16 +4,18 @@
 import { Ast, Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 import { NodeIdMapUtils, TXorNode, XorNodeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 import { Trace, TraceConstant } from "@microsoft/powerquery-parser/lib/powerquery-parser/common/trace";
+import { Assert } from "@microsoft/powerquery-parser";
 
 import { InspectionTraceConstant, TraceUtils } from "../../..";
 import { examineFieldSpecificationList } from "./examineFieldSpecificationList";
 import { InspectTypeState } from "./common";
+import { TypeStrategy } from "../../../inspectionSettings";
 
 export async function inspectTypeRecordType(
     state: InspectTypeState,
     xorNode: TXorNode,
     maybeCorrelationId: number | undefined,
-): Promise<Type.RecordType | Type.Unknown> {
+): Promise<Type.Type | Type.RecordType | Type.Unknown> {
     const trace: Trace = state.traceManager.entry(
         InspectionTraceConstant.InspectType,
         inspectTypeRecordType.name,
@@ -24,24 +26,37 @@ export async function inspectTypeRecordType(
     state.maybeCancellationToken?.throwIfCancelled();
     XorNodeUtils.assertIsNodeKind<Ast.RecordType>(xorNode, Ast.NodeKind.RecordType);
 
-    const maybeFields: TXorNode | undefined = NodeIdMapUtils.maybeNthChildChecked<Ast.FieldSpecificationList>(
-        state.nodeIdMapCollection,
-        xorNode.node.id,
-        0,
-        Ast.NodeKind.FieldSpecificationList,
-    );
+    let result: Type.Type | Type.RecordType | Type.Unknown;
 
-    let result: Type.TPowerQueryType;
+    switch (state.typeStrategy) {
+        case TypeStrategy.Extended: {
+            const maybeFields: TXorNode | undefined = NodeIdMapUtils.maybeNthChildChecked<Ast.FieldSpecificationList>(
+                state.nodeIdMapCollection,
+                xorNode.node.id,
+                0,
+                Ast.NodeKind.FieldSpecificationList,
+            );
 
-    if (maybeFields === undefined) {
-        result = Type.UnknownInstance;
-    } else {
-        result = {
-            kind: Type.TypeKind.Type,
-            maybeExtendedKind: Type.ExtendedTypeKind.RecordType,
-            isNullable: false,
-            ...(await examineFieldSpecificationList(state, maybeFields, trace.id)),
-        };
+            if (maybeFields === undefined) {
+                result = Type.UnknownInstance;
+            } else {
+                result = {
+                    kind: Type.TypeKind.Type,
+                    maybeExtendedKind: Type.ExtendedTypeKind.RecordType,
+                    isNullable: false,
+                    ...(await examineFieldSpecificationList(state, maybeFields, trace.id)),
+                };
+            }
+
+            break;
+        }
+
+        case TypeStrategy.Primitive:
+            result = Type.TypePrimitiveInstance;
+            break;
+
+        default:
+            Assert.isNever(state.typeStrategy);
     }
 
     trace.exit({ [TraceConstant.Result]: TraceUtils.createTypeDetails(result) });

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeTableType.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeTableType.ts
@@ -4,16 +4,18 @@
 import { Ast, Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 import { NodeIdMapUtils, TXorNode, XorNodeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 import { Trace, TraceConstant } from "@microsoft/powerquery-parser/lib/powerquery-parser/common/trace";
+import { Assert } from "@microsoft/powerquery-parser";
 
 import { InspectionTraceConstant, TraceUtils } from "../../..";
 import { InspectTypeState, inspectXor } from "./common";
 import { examineFieldSpecificationList } from "./examineFieldSpecificationList";
+import { TypeStrategy } from "../../../inspectionSettings";
 
 export async function inspectTypeTableType(
     state: InspectTypeState,
     xorNode: TXorNode,
     maybeCorrelationId: number | undefined,
-): Promise<Type.TableType | Type.TableTypePrimaryExpression | Type.Unknown> {
+): Promise<Type.Type | Type.TableType | Type.TableTypePrimaryExpression | Type.Unknown> {
     const trace: Trace = state.traceManager.entry(
         InspectionTraceConstant.InspectType,
         inspectTypeTableType.name,
@@ -24,30 +26,43 @@ export async function inspectTypeTableType(
     state.maybeCancellationToken?.throwIfCancelled();
     XorNodeUtils.assertIsNodeKind<Ast.TableType>(xorNode, Ast.NodeKind.TableType);
 
-    const maybeRowType: TXorNode | undefined = NodeIdMapUtils.maybeNthChild(
-        state.nodeIdMapCollection,
-        xorNode.node.id,
-        1,
-    );
+    let result: Type.Type | Type.TableType | Type.TableTypePrimaryExpression | Type.Unknown;
 
-    let result: Type.TPowerQueryType;
+    switch (state.typeStrategy) {
+        case TypeStrategy.Extended: {
+            const maybeRowType: TXorNode | undefined = NodeIdMapUtils.maybeNthChild(
+                state.nodeIdMapCollection,
+                xorNode.node.id,
+                1,
+            );
 
-    if (maybeRowType === undefined) {
-        result = Type.UnknownInstance;
-    } else if (maybeRowType.node.kind === Ast.NodeKind.FieldSpecificationList) {
-        result = {
-            kind: Type.TypeKind.Type,
-            maybeExtendedKind: Type.ExtendedTypeKind.TableType,
-            isNullable: false,
-            ...(await examineFieldSpecificationList(state, maybeRowType, trace.id)),
-        };
-    } else {
-        result = {
-            kind: Type.TypeKind.Type,
-            maybeExtendedKind: Type.ExtendedTypeKind.TableTypePrimaryExpression,
-            isNullable: false,
-            primaryExpression: await inspectXor(state, maybeRowType, trace.id),
-        };
+            if (maybeRowType === undefined) {
+                result = Type.UnknownInstance;
+            } else if (maybeRowType.node.kind === Ast.NodeKind.FieldSpecificationList) {
+                result = {
+                    kind: Type.TypeKind.Type,
+                    maybeExtendedKind: Type.ExtendedTypeKind.TableType,
+                    isNullable: false,
+                    ...(await examineFieldSpecificationList(state, maybeRowType, trace.id)),
+                };
+            } else {
+                result = {
+                    kind: Type.TypeKind.Type,
+                    maybeExtendedKind: Type.ExtendedTypeKind.TableTypePrimaryExpression,
+                    isNullable: false,
+                    primaryExpression: await inspectXor(state, maybeRowType, trace.id),
+                };
+            }
+
+            break;
+        }
+
+        case TypeStrategy.Primitive:
+            result = Type.TypePrimitiveInstance;
+            break;
+
+        default:
+            Assert.isNever(state.typeStrategy);
     }
 
     trace.exit({ [TraceConstant.Result]: TraceUtils.createTypeDetails(result) });

--- a/src/powerquery-language-services/inspectionSettings.ts
+++ b/src/powerquery-language-services/inspectionSettings.ts
@@ -6,6 +6,13 @@ import * as PQP from "@microsoft/powerquery-parser";
 import { Library } from "./library";
 import { TypeById } from "./inspection";
 
+export const enum TypeStrategy {
+    // Allow evaluation of extended types (such as AnyUnion).
+    Extended = "Extended",
+    // Strictly Power Query type primitives.
+    Primitive = "Primitive",
+}
+
 export interface InspectionSettings extends PQP.Settings {
     // Allows the caching of scope and Power Query type datastructures built during an inspection.
     readonly isWorkspaceCacheAllowed: boolean;
@@ -20,4 +27,10 @@ export interface InspectionSettings extends PQP.Settings {
     // This is a "simple" hack that enables consumers of language-services to enable those smart type resolvers.
     // An initial pass can be made on InvokeExpressions where it sets the scope for an EachExpression.
     readonly maybeEachScopeById: TypeById | undefined;
+    // The type system for Power Query has been expanded in this layer to include types, such as:
+    //  * AnyUnion, an extension of `any`
+    //  * DefinedTable, an extension of `table`
+    // While useful for in-depth analysis and/or Intellisense operations they can be costly in terms of time.
+    // Changing the strategy determines how types are evaluated during inspections.
+    readonly typeStrategy: TypeStrategy;
 }

--- a/src/powerquery-language-services/inspectionUtils.ts
+++ b/src/powerquery-language-services/inspectionUtils.ts
@@ -9,24 +9,22 @@ import { DocumentSymbol, SignatureHelp, SymbolKind } from "vscode-languageserver
 
 import { AutocompleteItemProviderContext, SignatureProviderContext } from "./providers/commonTypes";
 import { Inspection, PositionUtils } from ".";
+import { InspectionSettings, TypeStrategy } from "./inspectionSettings";
 import { Trace, TraceManager } from "@microsoft/powerquery-parser/lib/powerquery-parser/common/trace";
 import { AutocompleteItemUtils } from "./inspection/autocomplete";
-import { InspectionSettings } from "./inspectionSettings";
 import { InspectionTraceConstant } from "./trace";
 import { Library } from "./library";
-import { TypeById } from "./inspection";
 
 export function createInspectionSettings(
     settings: PQP.Settings,
-    maybeEachScopeById: TypeById | undefined,
-    maybeLibrary: Library.ILibrary | undefined,
-    isWorkspaceCacheAllowed: boolean,
+    overrides?: Partial<InspectionSettings>,
 ): InspectionSettings {
     return {
         ...settings,
-        library: maybeLibrary ?? Library.NoOpLibrary,
-        maybeEachScopeById,
-        isWorkspaceCacheAllowed,
+        isWorkspaceCacheAllowed: overrides?.isWorkspaceCacheAllowed ?? true,
+        library: overrides?.library ?? Library.NoOpLibrary,
+        typeStrategy: overrides?.typeStrategy ?? TypeStrategy.Extended,
+        maybeEachScopeById: overrides?.maybeEachScopeById ?? undefined,
     };
 }
 

--- a/src/powerquery-language-services/validate/validationSettings/validationSettingsUtils.ts
+++ b/src/powerquery-language-services/validate/validationSettings/validationSettingsUtils.ts
@@ -7,15 +7,13 @@ import { ValidationSettings } from "./validationSettings";
 export function createValidationSettings(
     inspectionSettings: InspectionSettings,
     source: string,
-    checkForDuplicateIdentifiers?: boolean,
-    checkInvokeExpressions?: boolean,
-    checkUnknownIdentifiers?: boolean,
+    overrides?: Partial<ValidationSettings>,
 ): ValidationSettings {
     return {
         ...inspectionSettings,
-        checkForDuplicateIdentifiers: checkForDuplicateIdentifiers ?? true,
-        checkInvokeExpressions: checkInvokeExpressions ?? true,
-        checkUnknownIdentifiers: checkUnknownIdentifiers ?? true,
+        checkForDuplicateIdentifiers: overrides?.checkForDuplicateIdentifiers ?? true,
+        checkInvokeExpressions: overrides?.checkInvokeExpressions ?? true,
+        checkUnknownIdentifiers: overrides?.checkUnknownIdentifiers ?? true,
         library: inspectionSettings.library,
         source,
     };

--- a/src/test/inspection/scope.ts
+++ b/src/test/inspection/scope.ts
@@ -9,7 +9,7 @@ import { expect } from "chai";
 import { NodeIdMap } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 import type { Position } from "vscode-languageserver-types";
 
-import { Inspection, InspectionSettings, Library } from "../../powerquery-language-services";
+import { Inspection, InspectionSettings, Library, TypeStrategy } from "../../powerquery-language-services";
 import { TestUtils } from "..";
 
 export type TAbridgedNodeScopeItem =
@@ -27,6 +27,7 @@ const DefaultSettings: InspectionSettings = {
     isWorkspaceCacheAllowed: false,
     maybeEachScopeById: undefined,
     library: Library.NoOpLibrary,
+    typeStrategy: TypeStrategy.Extended,
 };
 
 interface IAbridgedNodeScopeItem {

--- a/src/test/inspection/type.ts
+++ b/src/test/inspection/type.ts
@@ -759,19 +759,19 @@ describe(`Inspection - Type`, () => {
             it(`(foo as number) => foo|`, async () => {
                 const expression: string = "(foo as number) => foo|";
                 const expected: Type.TPowerQueryType = Type.NumberInstance;
-                await assertParseOkScopeTypeEqual(TestSettings, expression, new Map([["foo", expected]]));
+                await assertParseOkScopeTypeEqual(ExtendedTestSettings, expression, new Map([["foo", expected]]));
             });
 
             it(`(optional foo as number) => foo|`, async () => {
                 const expression: string = "(optional foo as number) => foo|";
                 const expected: Type.TPowerQueryType = Type.NullableNumberInstance;
-                await assertParseOkScopeTypeEqual(TestSettings, expression, new Map([["foo", expected]]));
+                await assertParseOkScopeTypeEqual(ExtendedTestSettings, expression, new Map([["foo", expected]]));
             });
 
             it(`(foo) => foo|`, async () => {
                 const expression: string = "(foo) => foo|";
                 const expected: Type.TPowerQueryType = Type.NullableAnyInstance;
-                await assertParseOkScopeTypeEqual(TestSettings, expression, new Map([["foo", expected]]));
+                await assertParseOkScopeTypeEqual(ExtendedTestSettings, expression, new Map([["foo", expected]]));
             });
         });
 

--- a/src/test/testConstants.ts
+++ b/src/test/testConstants.ts
@@ -14,6 +14,7 @@ import {
     Library,
     LibraryUtils,
     LocalDocumentSymbolProvider,
+    TypeStrategy,
     ValidationSettings,
 } from "../powerquery-language-services";
 import { LibrarySymbolProvider } from "../powerquery-language-services/providers/librarySymbolProvider";
@@ -21,8 +22,9 @@ import { LibrarySymbolProvider } from "../powerquery-language-services/providers
 export const DefaultInspectionSettings: InspectionSettings = {
     ...PQP.DefaultSettings,
     isWorkspaceCacheAllowed: false,
-    maybeEachScopeById: undefined,
     library: Library.NoOpLibrary,
+    maybeEachScopeById: undefined,
+    typeStrategy: TypeStrategy.Extended,
 };
 
 export const CreateFooAndBarRecordDefinedFunction: Type.DefinedFunction = TypeUtils.createDefinedFunction(

--- a/src/test/workspaceCacheTest.ts
+++ b/src/test/workspaceCacheTest.ts
@@ -60,7 +60,7 @@ describe("workspaceCache", () => {
             const maybeInspected: Inspection.Inspected | undefined =
                 await WorkspaceCacheUtils.getOrCreateInspectedPromise(
                     document,
-                    PQLS.InspectionUtils.createInspectionSettings(PQP.DefaultSettings, undefined, SimpleLibrary, false),
+                    PQLS.InspectionUtils.createInspectionSettings(PQP.DefaultSettings, { library: SimpleLibrary }),
                     postion,
                 );
 
@@ -74,7 +74,7 @@ describe("workspaceCache", () => {
             const maybeInspected: Inspection.Inspected | undefined =
                 await WorkspaceCacheUtils.getOrCreateInspectedPromise(
                     document,
-                    PQLS.InspectionUtils.createInspectionSettings(PQP.DefaultSettings, undefined, undefined, false),
+                    PQLS.InspectionUtils.createInspectionSettings(PQP.DefaultSettings),
                     postion,
                 );
 
@@ -137,7 +137,7 @@ describe("workspaceCache", () => {
 
         let maybeInspected: Inspection.Inspected | undefined = await WorkspaceCacheUtils.getOrCreateInspectedPromise(
             document,
-            PQLS.InspectionUtils.createInspectionSettings(PQP.DefaultSettings, undefined, SimpleLibrary, false),
+            PQLS.InspectionUtils.createInspectionSettings(PQP.DefaultSettings, { library: SimpleLibrary }),
             postion,
         );
 
@@ -154,7 +154,7 @@ describe("workspaceCache", () => {
 
         maybeInspected = await WorkspaceCacheUtils.getOrCreateInspectedPromise(
             document,
-            PQLS.InspectionUtils.createInspectionSettings(PQP.DefaultSettings, undefined, SimpleLibrary, false),
+            PQLS.InspectionUtils.createInspectionSettings(PQP.DefaultSettings, { library: SimpleLibrary }),
             postion,
         );
 


### PR DESCRIPTION
- Adds TypeStrategy with the variants Primitive and Extended. If extended it'll act as it does today, which includes detailed DefinedRecord/DefinedTable and it's timeout issues. Primitive mode (mostly) limits it to M primitives which resolves type analysis way quicker
- Updates InspectionSettings and ValidationSettings factories