### PR TITLE
Remove unneeded O(N) passes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.3.24",
+    "version": "0.3.25",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/powerquery-language-services",
-            "version": "0.3.24",
+            "version": "0.3.25",
             "license": "MIT",
             "dependencies": {
-                "@microsoft/powerquery-formatter": "0.0.53",
-                "@microsoft/powerquery-parser": "0.8.5",
+                "@microsoft/powerquery-formatter": "0.0.54",
+                "@microsoft/powerquery-parser": "0.8.6",
                 "vscode-languageserver-textdocument": "1.0.4",
                 "vscode-languageserver-types": "3.17.1"
             },
@@ -112,20 +112,20 @@
             "dev": true
         },
         "node_modules/@microsoft/powerquery-formatter": {
-            "version": "0.0.53",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.0.53.tgz",
-            "integrity": "sha512-0fNqK3aIPauaiMH3D+ihrX1CtXOCsBEXEf76jykxl6YmVYr3bMOQ+lEFxedge3z45ZqOYWCvfwlstsVYF22Z+A==",
+            "version": "0.0.54",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.0.54.tgz",
+            "integrity": "sha512-q54rA6snWwaFcOKB4nQ+Fk0mNvR9XhIatq6fMMY3QvHo1SIFQszlZC3cLHjSFdh5WqTV4C9UJaQyG92VmuVZHA==",
             "dependencies": {
-                "@microsoft/powerquery-parser": "0.8.5"
+                "@microsoft/powerquery-parser": "0.8.6"
             },
             "engines": {
                 "node": ">=16.13.2"
             }
         },
         "node_modules/@microsoft/powerquery-parser": {
-            "version": "0.8.5",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.8.5.tgz",
-            "integrity": "sha512-nl7Oh8nBekd98VFBslrMceNuPPVRfbm3tErwviOJdMAPmbIeCB0a9g7EfIg5k1hBOd5lZNp1Qff58IWTfkUEHw==",
+            "version": "0.8.6",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.8.6.tgz",
+            "integrity": "sha512-5tR4LVNgDB3vJAsWlj7NHWNBO6qJO0oplMXrjZVuvmwuhncjs/T3oM8ogvm7dFncyDfUdI1rBt5yhe1e0Sd0rw==",
             "dependencies": {
                 "grapheme-splitter": "^1.0.4",
                 "performance-now": "^2.1.0"
@@ -2854,17 +2854,17 @@
             "dev": true
         },
         "@microsoft/powerquery-formatter": {
-            "version": "0.0.53",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.0.53.tgz",
-            "integrity": "sha512-0fNqK3aIPauaiMH3D+ihrX1CtXOCsBEXEf76jykxl6YmVYr3bMOQ+lEFxedge3z45ZqOYWCvfwlstsVYF22Z+A==",
+            "version": "0.0.54",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.0.54.tgz",
+            "integrity": "sha512-q54rA6snWwaFcOKB4nQ+Fk0mNvR9XhIatq6fMMY3QvHo1SIFQszlZC3cLHjSFdh5WqTV4C9UJaQyG92VmuVZHA==",
             "requires": {
-                "@microsoft/powerquery-parser": "0.8.5"
+                "@microsoft/powerquery-parser": "0.8.6"
             }
         },
         "@microsoft/powerquery-parser": {
-            "version": "0.8.5",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.8.5.tgz",
-            "integrity": "sha512-nl7Oh8nBekd98VFBslrMceNuPPVRfbm3tErwviOJdMAPmbIeCB0a9g7EfIg5k1hBOd5lZNp1Qff58IWTfkUEHw==",
+            "version": "0.8.6",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.8.6.tgz",
+            "integrity": "sha512-5tR4LVNgDB3vJAsWlj7NHWNBO6qJO0oplMXrjZVuvmwuhncjs/T3oM8ogvm7dFncyDfUdI1rBt5yhe1e0Sd0rw==",
             "requires": {
                 "grapheme-splitter": "^1.0.4",
                 "performance-now": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.3.24",
+    "version": "0.3.25",
     "author": "Microsoft",
     "license": "MIT",
     "scripts": {
@@ -49,8 +49,8 @@
         "typescript": "4.6.4"
     },
     "dependencies": {
-        "@microsoft/powerquery-formatter": "0.0.53",
-        "@microsoft/powerquery-parser": "0.8.5",
+        "@microsoft/powerquery-formatter": "0.0.54",
+        "@microsoft/powerquery-parser": "0.8.6",
         "vscode-languageserver-textdocument": "1.0.4",
         "vscode-languageserver-types": "3.17.1"
     },


### PR DESCRIPTION
We're able to remove some O(N) passes and O(N) length array allocations (where N is the number of records or identifier paired expressions) with some smarter code logic.