### PR TITLE
Add contextual keyword catch to autocomplete

### DIFF
--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordErrorHandlingExpression.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeywordErrorHandlingExpression.ts
@@ -22,7 +22,7 @@ export function autocompleteKeywordErrorHandlingExpression(
         return [Keyword.KeywordKind.Try];
     } else if (maybeChildAttributeIndex === 1) {
         // 'try true o|' creates a ParseError.
-        // It's ambiguous if the next token should be either 'otherwise' or 'or'.
+        // It's ambiguous if the next token should be either 'otherwise', 'or', or 'catch'.
         if (maybeTrailingText !== undefined) {
             const trailingToken: TrailingToken = maybeTrailingText;
 

--- a/src/powerquery-language-services/inspection/autocomplete/task.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/task.ts
@@ -72,6 +72,7 @@ export async function autocomplete(
 
     const triedLanguageConstant: TriedAutocompleteLanguageConstant = tryAutocompleteLanguageConstant(
         updatedSettings,
+        nodeIdMapCollection,
         maybeActiveNode,
     );
 

--- a/src/powerquery-language-services/inspection/autocomplete/task.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/task.ts
@@ -74,6 +74,7 @@ export async function autocomplete(
         updatedSettings,
         nodeIdMapCollection,
         maybeActiveNode,
+        maybeTrailingToken,
     );
 
     const triedPrimitiveType: TriedAutocompletePrimitiveType = tryAutocompletePrimitiveType(

--- a/src/test/inspection/autocomplete/autocompleteLanguageConstant.ts
+++ b/src/test/inspection/autocomplete/autocompleteLanguageConstant.ts
@@ -74,6 +74,54 @@ describe(`Inspection - Autocomplete - Language constants`, () => {
 
             expect(actual).to.deep.equal(expected);
         });
+
+        it(`try 1 + 1 c|`, async () => {
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`try 1 + 1 c|`);
+
+            const expected: AbridgedAutocompleteItem | undefined = {
+                jaroWinklerScore: 1,
+                label: Constant.LanguageConstant.Catch,
+            };
+
+            const actual: AbridgedAutocompleteItem | undefined = await assertGetLanguageConstantAutocomplete(
+                TestConstants.DefaultInspectionSettings,
+                text,
+                position,
+            );
+
+            expect(actual).to.deep.equal(expected);
+        });
+
+        it(`try 1 + 1 |`, async () => {
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`try 1 + 1 |`);
+
+            const expected: AbridgedAutocompleteItem | undefined = {
+                jaroWinklerScore: 1,
+                label: Constant.LanguageConstant.Catch,
+            };
+
+            const actual: AbridgedAutocompleteItem | undefined = await assertGetLanguageConstantAutocomplete(
+                TestConstants.DefaultInspectionSettings,
+                text,
+                position,
+            );
+
+            expect(actual).to.deep.equal(expected);
+        });
+
+        it(`try 1 + 1 o|`, async () => {
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`try 1 + 1 o|`);
+
+            const expected: AbridgedAutocompleteItem | undefined = undefined;
+
+            const actual: AbridgedAutocompleteItem | undefined = await assertGetLanguageConstantAutocomplete(
+                TestConstants.DefaultInspectionSettings,
+                text,
+                position,
+            );
+
+            expect(actual).to.deep.equal(expected);
+        });
     });
 
     describe(`${LanguageConstant.Nullable}`, () => {

--- a/src/test/inspection/autocomplete/autocompleteLanguageConstant.ts
+++ b/src/test/inspection/autocomplete/autocompleteLanguageConstant.ts
@@ -10,6 +10,7 @@ import type { Position } from "vscode-languageserver-types";
 import { AbridgedAutocompleteItem, createAbridgedAutocompleteItem } from "./common";
 import { Inspection, InspectionSettings } from "../../../powerquery-language-services";
 import { TestConstants, TestUtils } from "../..";
+import { LanguageConstant } from "@microsoft/powerquery-parser/lib/powerquery-parser/language/constant/constant";
 
 async function assertGetLanguageConstantAutocomplete(
     settings: InspectionSettings,
@@ -25,105 +26,159 @@ async function assertGetLanguageConstantAutocomplete(
 }
 
 describe(`Inspection - Autocomplete - Language constants`, () => {
-    it(`a as |`, async () => {
-        const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`a as |`);
+    describe(`${LanguageConstant.Catch}`, () => {
+        it(`try 1|`, async () => {
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`try 1|`);
 
-        const expected: AbridgedAutocompleteItem | undefined = {
-            jaroWinklerScore: 1,
-            label: Constant.LanguageConstant.Nullable,
-        };
+            const expected: AbridgedAutocompleteItem | undefined = undefined;
 
-        const actual: AbridgedAutocompleteItem | undefined = await assertGetLanguageConstantAutocomplete(
-            TestConstants.DefaultInspectionSettings,
-            text,
-            position,
-        );
+            const actual: AbridgedAutocompleteItem | undefined = await assertGetLanguageConstantAutocomplete(
+                TestConstants.DefaultInspectionSettings,
+                text,
+                position,
+            );
 
-        expect(actual).to.deep.equal(expected);
+            expect(actual).to.deep.equal(expected);
+        });
+
+        it(`try 1 |`, async () => {
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`try 1 |`);
+
+            const expected: AbridgedAutocompleteItem | undefined = {
+                jaroWinklerScore: 1,
+                label: Constant.LanguageConstant.Catch,
+            };
+
+            const actual: AbridgedAutocompleteItem | undefined = await assertGetLanguageConstantAutocomplete(
+                TestConstants.DefaultInspectionSettings,
+                text,
+                position,
+            );
+
+            expect(actual).to.deep.equal(expected);
+        });
+
+        it(`try 1 c|`, async () => {
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`try 1 c|`);
+
+            const expected: AbridgedAutocompleteItem | undefined = {
+                jaroWinklerScore: 1,
+                label: Constant.LanguageConstant.Catch,
+            };
+
+            const actual: AbridgedAutocompleteItem | undefined = await assertGetLanguageConstantAutocomplete(
+                TestConstants.DefaultInspectionSettings,
+                text,
+                position,
+            );
+
+            expect(actual).to.deep.equal(expected);
+        });
     });
 
-    it(`a as n|`, async () => {
-        const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`a as n|`);
+    describe(`${LanguageConstant.Nullable}`, () => {
+        it(`a as |`, async () => {
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`a as |`);
 
-        const expected: AbridgedAutocompleteItem | undefined = {
-            jaroWinklerScore: 1,
-            label: Constant.LanguageConstant.Nullable,
-        };
+            const expected: AbridgedAutocompleteItem | undefined = {
+                jaroWinklerScore: 1,
+                label: Constant.LanguageConstant.Nullable,
+            };
 
-        const actual: AbridgedAutocompleteItem | undefined = await assertGetLanguageConstantAutocomplete(
-            TestConstants.DefaultInspectionSettings,
-            text,
-            position,
-        );
+            const actual: AbridgedAutocompleteItem | undefined = await assertGetLanguageConstantAutocomplete(
+                TestConstants.DefaultInspectionSettings,
+                text,
+                position,
+            );
 
-        expect(actual).to.deep.equal(expected);
+            expect(actual).to.deep.equal(expected);
+        });
+
+        it(`a as n|`, async () => {
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`a as n|`);
+
+            const expected: AbridgedAutocompleteItem | undefined = {
+                jaroWinklerScore: 1,
+                label: Constant.LanguageConstant.Nullable,
+            };
+
+            const actual: AbridgedAutocompleteItem | undefined = await assertGetLanguageConstantAutocomplete(
+                TestConstants.DefaultInspectionSettings,
+                text,
+                position,
+            );
+
+            expect(actual).to.deep.equal(expected);
+        });
+
+        it(`(a as |`, async () => {
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(a as |`);
+
+            const expected: AbridgedAutocompleteItem | undefined = {
+                jaroWinklerScore: 1,
+                label: Constant.LanguageConstant.Nullable,
+            };
+
+            const actual: AbridgedAutocompleteItem | undefined = await assertGetLanguageConstantAutocomplete(
+                TestConstants.DefaultInspectionSettings,
+                text,
+                position,
+            );
+
+            expect(actual).to.deep.equal(expected);
+        });
+
+        it(`(a as n|`, async () => {
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(a as n|`);
+
+            const expected: AbridgedAutocompleteItem | undefined = {
+                jaroWinklerScore: 1,
+                label: Constant.LanguageConstant.Nullable,
+            };
+
+            const actual: AbridgedAutocompleteItem | undefined = await assertGetLanguageConstantAutocomplete(
+                TestConstants.DefaultInspectionSettings,
+                text,
+                position,
+            );
+
+            expect(actual).to.deep.equal(expected);
+        });
     });
 
-    it(`(a as |`, async () => {
-        const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(a as |`);
+    describe(`${LanguageConstant.Optional}`, () => {
+        it(`(x, |`, async () => {
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(x, |`);
 
-        const expected: AbridgedAutocompleteItem | undefined = {
-            jaroWinklerScore: 1,
-            label: Constant.LanguageConstant.Nullable,
-        };
+            const expected: AbridgedAutocompleteItem | undefined = {
+                jaroWinklerScore: 1,
+                label: Constant.LanguageConstant.Optional,
+            };
 
-        const actual: AbridgedAutocompleteItem | undefined = await assertGetLanguageConstantAutocomplete(
-            TestConstants.DefaultInspectionSettings,
-            text,
-            position,
-        );
+            const actual: AbridgedAutocompleteItem | undefined = await assertGetLanguageConstantAutocomplete(
+                TestConstants.DefaultInspectionSettings,
+                text,
+                position,
+            );
 
-        expect(actual).to.deep.equal(expected);
-    });
+            expect(actual).to.deep.equal(expected);
+        });
 
-    it(`(a as n|`, async () => {
-        const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(a as n|`);
+        it(`(x, op|`, async () => {
+            const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(x, op|`);
 
-        const expected: AbridgedAutocompleteItem | undefined = {
-            jaroWinklerScore: 1,
-            label: Constant.LanguageConstant.Nullable,
-        };
+            const expected: AbridgedAutocompleteItem | undefined = {
+                jaroWinklerScore: 1,
+                label: Constant.LanguageConstant.Optional,
+            };
 
-        const actual: AbridgedAutocompleteItem | undefined = await assertGetLanguageConstantAutocomplete(
-            TestConstants.DefaultInspectionSettings,
-            text,
-            position,
-        );
+            const actual: AbridgedAutocompleteItem | undefined = await assertGetLanguageConstantAutocomplete(
+                TestConstants.DefaultInspectionSettings,
+                text,
+                position,
+            );
 
-        expect(actual).to.deep.equal(expected);
-    });
-
-    it(`(x, |`, async () => {
-        const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(x, |`);
-
-        const expected: AbridgedAutocompleteItem | undefined = {
-            jaroWinklerScore: 1,
-            label: Constant.LanguageConstant.Optional,
-        };
-
-        const actual: AbridgedAutocompleteItem | undefined = await assertGetLanguageConstantAutocomplete(
-            TestConstants.DefaultInspectionSettings,
-            text,
-            position,
-        );
-
-        expect(actual).to.deep.equal(expected);
-    });
-
-    it(`(x, op|`, async () => {
-        const [text, position]: [string, Position] = TestUtils.assertGetTextWithPosition(`(x, op|`);
-
-        const expected: AbridgedAutocompleteItem | undefined = {
-            jaroWinklerScore: 1,
-            label: Constant.LanguageConstant.Optional,
-        };
-
-        const actual: AbridgedAutocompleteItem | undefined = await assertGetLanguageConstantAutocomplete(
-            TestConstants.DefaultInspectionSettings,
-            text,
-            position,
-        );
-
-        expect(actual).to.deep.equal(expected);
+            expect(actual).to.deep.equal(expected);
+        });
     });
 });


### PR DESCRIPTION
- Adds `catch` to autocomplete
- Organizes autocomplete language constant tests by the constant kind