### PR TITLE
Remove deltaTypeById

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.3.27",
+    "version": "0.3.28",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/powerquery-language-services",
-            "version": "0.3.27",
+            "version": "0.3.28",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/powerquery-formatter": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.3.27",
+    "version": "0.3.28",
     "author": "Microsoft",
     "license": "MIT",
     "scripts": {


### PR DESCRIPTION
Removes deltaTypeById and collapses it together with `givenTypeById`. It was useful to help me debug issues while things were still being developed, but now it adds needless complexity and additional O(n) overhead. 