### PR TITLE
Bugfix onDefinition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.3.32",
+    "version": "0.3.33",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/powerquery-language-services",
-            "version": "0.3.32",
+            "version": "0.3.33",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/powerquery-formatter": "0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.3.32",
+    "version": "0.3.33",
     "author": "Microsoft",
     "license": "MIT",
     "scripts": {

--- a/src/powerquery-language-services/analysis/analysisBase.ts
+++ b/src/powerquery-language-services/analysis/analysisBase.ts
@@ -17,7 +17,7 @@ import type {
     IHoverProvider,
     ILocalDocumentProvider,
     ISymbolProvider,
-    OverIdentifierProviderContext,
+    OnIdentifierProviderContext,
     SignatureHelpProvider,
     SignatureProviderContext,
 } from "../providers/commonTypes";
@@ -128,7 +128,7 @@ export abstract class AnalysisBase implements Analysis {
             this.analysisSettings.maybeInitialCorrelationId,
         );
 
-        const maybeIdentifierContext: OverIdentifierProviderContext | undefined = await this.getMaybeIdentifierContext(
+        const maybeIdentifierContext: OnIdentifierProviderContext | undefined = await this.getMaybeIdentifierContext(
             trace.id,
         );
 
@@ -152,7 +152,7 @@ export abstract class AnalysisBase implements Analysis {
             this.analysisSettings.maybeInitialCorrelationId,
         );
 
-        const maybeIdentifierContext: OverIdentifierProviderContext | undefined = await this.getMaybeIdentifierContext(
+        const maybeIdentifierContext: OnIdentifierProviderContext | undefined = await this.getMaybeIdentifierContext(
             trace.id,
         );
 
@@ -385,7 +385,7 @@ export abstract class AnalysisBase implements Analysis {
     }
 
     private static createHoverCalls(
-        context: OverIdentifierProviderContext,
+        context: OnIdentifierProviderContext,
         providers: IHoverProvider[],
         timeoutInMS?: number,
     ): ReadonlyArray<Promise<Hover | null>> {
@@ -436,7 +436,7 @@ export abstract class AnalysisBase implements Analysis {
         return true;
     }
 
-    private async getMaybeIdentifierContext(correlationId: number): Promise<OverIdentifierProviderContext | undefined> {
+    private async getMaybeIdentifierContext(correlationId: number): Promise<OnIdentifierProviderContext | undefined> {
         const trace: Trace = this.analysisSettings.traceManager.entry(
             ValidationTraceConstant.AnalysisBase,
             this.getDefinition.name,
@@ -460,10 +460,10 @@ export abstract class AnalysisBase implements Analysis {
 
         const identifier: Ast.Identifier | Ast.GeneralizedIdentifier = maybeIdentifierUnderPosition;
 
-        const context: OverIdentifierProviderContext = {
+        const context: OnIdentifierProviderContext = {
             traceManager: this.analysisSettings.traceManager,
             range: CommonTypesUtils.rangeFromTokenRange(identifier.tokenRange),
-            identifier: identifier.literal,
+            identifier,
             maybeInitialCorrelationId: trace.id,
         };
 

--- a/src/powerquery-language-services/providers/commonTypes.ts
+++ b/src/powerquery-language-services/providers/commonTypes.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import type { Ast, Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 import type { Hover, Location, Range, SignatureHelp } from "vscode-languageserver-types";
 import { TraceManager } from "@microsoft/powerquery-parser/lib/powerquery-parser/common/trace";
-import type { Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 
 import type { AutocompleteItem } from "../inspection/autocomplete/autocompleteItem";
 import type { ILibrary } from "../library/library";
@@ -18,15 +18,15 @@ export interface AutocompleteItemProviderContext extends ProviderContext {
 }
 
 export interface IDefinitionProvider {
-    getDefinition(context: OverIdentifierProviderContext): Promise<Location[] | null>;
+    getDefinition(context: OnIdentifierProviderContext): Promise<Location[] | null>;
 }
 
 export interface IHoverProvider {
-    getHover(context: OverIdentifierProviderContext): Promise<Hover | null>;
+    getHover(context: OnIdentifierProviderContext): Promise<Hover | null>;
 }
 
-export interface OverIdentifierProviderContext extends ProviderContext {
-    readonly identifier: string;
+export interface OnIdentifierProviderContext extends ProviderContext {
+    readonly identifier: Ast.GeneralizedIdentifier | Ast.Identifier;
 }
 
 export interface ILocalDocumentProvider extends IDefinitionProvider, ISymbolProvider {}

--- a/src/powerquery-language-services/providers/librarySymbolProvider.ts
+++ b/src/powerquery-language-services/providers/librarySymbolProvider.ts
@@ -9,7 +9,7 @@ import { TypeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/la
 import {
     AutocompleteItemProviderContext,
     ISymbolProvider,
-    OverIdentifierProviderContext,
+    OnIdentifierProviderContext,
     SignatureProviderContext,
 } from "./commonTypes";
 import { Library, LibraryUtils } from "../library";
@@ -57,7 +57,7 @@ export class LibrarySymbolProvider implements ISymbolProvider {
     }
 
     // eslint-disable-next-line require-await
-    public async getHover(context: OverIdentifierProviderContext): Promise<Hover | null> {
+    public async getHover(context: OnIdentifierProviderContext): Promise<Hover | null> {
         const trace: Trace = context.traceManager.entry(
             ProviderTraceConstant.LibrarySymbolProvider,
             this.getHover.name,
@@ -70,8 +70,8 @@ export class LibrarySymbolProvider implements ISymbolProvider {
             return null;
         }
 
-        const identifierLiteral: string = context.identifier;
-        const maybeDefinition: Library.TLibraryDefinition | undefined = this.libraryDefinitions.get(context.identifier);
+        const identifierLiteral: string = context.identifier.literal;
+        const maybeDefinition: Library.TLibraryDefinition | undefined = this.libraryDefinitions.get(identifierLiteral);
 
         if (maybeDefinition === undefined) {
             trace.exit({ invalidContext: true });

--- a/src/powerquery-language-services/providers/nullSymbolProvider.ts
+++ b/src/powerquery-language-services/providers/nullSymbolProvider.ts
@@ -6,7 +6,7 @@ import { Location } from "vscode-languageserver-types";
 import {
     AutocompleteItemProviderContext,
     ISymbolProvider,
-    OverIdentifierProviderContext,
+    OnIdentifierProviderContext,
     SignatureProviderContext,
 } from "./commonTypes";
 import { Hover, SignatureHelp } from "../commonTypes";
@@ -36,12 +36,12 @@ export class NullSymbolProvider implements ISymbolProvider {
     }
 
     // eslint-disable-next-line require-await
-    public async getDefinition(_context: OverIdentifierProviderContext): Promise<Location[] | null> {
+    public async getDefinition(_context: OnIdentifierProviderContext): Promise<Location[] | null> {
         return [];
     }
 
     // eslint-disable-next-line require-await
-    public async getHover(_context: OverIdentifierProviderContext): Promise<Hover | null> {
+    public async getHover(_context: OnIdentifierProviderContext): Promise<Hover | null> {
         return null;
     }
 

--- a/src/test/providers/localDocumentProvider.ts
+++ b/src/test/providers/localDocumentProvider.ts
@@ -259,6 +259,14 @@ describe(`SimpleLocalDocumentSymbolProvider`, () => {
             TestUtils.assertEqualLocation(expected, actual);
         });
 
+        it(`WIP record expression, not on key`, async () => {
+            const expected: Range[] = [];
+
+            const actual: Location[] | undefined = await TestUtils.createDefinition("[foo = 1, bar = [foo| = 2]]");
+            Assert.isDefined(actual);
+            TestUtils.assertEqualLocation(expected, actual);
+        });
+
         it(`section expression`, async () => {
             const expected: Range[] = [
                 {

--- a/src/test/providers/slowSymbolProvider.ts
+++ b/src/test/providers/slowSymbolProvider.ts
@@ -9,7 +9,7 @@ import {
     IDefinitionProvider,
     Library,
     LibrarySymbolProvider,
-    OverIdentifierProviderContext,
+    OnIdentifierProviderContext,
     SignatureHelp,
     SignatureProviderContext,
 } from "../../powerquery-language-services";
@@ -32,11 +32,11 @@ export class SlowSymbolProvider extends LibrarySymbolProvider implements IDefini
     }
 
     // eslint-disable-next-line require-await
-    public async getDefinition(_context: OverIdentifierProviderContext): Promise<Location[] | null> {
+    public async getDefinition(_context: OnIdentifierProviderContext): Promise<Location[] | null> {
         throw new Error("Method not implemented.");
     }
 
-    public override async getHover(context: OverIdentifierProviderContext): Promise<Hover | null> {
+    public override async getHover(context: OnIdentifierProviderContext): Promise<Hover | null> {
         await this.delay();
 
         return super.getHover(context);


### PR DESCRIPTION
I didn't limit to what identifiers would have a jump to definition. This restricts it to identifiers in a value context.