### PR TITLE
Add TActiveLeafIdentifier

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,9 @@
                 "999999",
                 "-r",
                 "ts-node/register",
-                "${workspaceFolder}/src/test/**/*.ts"
+                "${workspaceFolder}/src/test/**/*.ts",
+                "-g",
+                "WIP"
             ],
             "internalConsoleOptions": "openOnSessionStart"
         }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,9 +15,7 @@
                 "999999",
                 "-r",
                 "ts-node/register",
-                "${workspaceFolder}/src/test/**/*.ts",
-                "-g",
-                "WIP"
+                "${workspaceFolder}/src/test/**/*.ts"
             ],
             "internalConsoleOptions": "openOnSessionStart"
         }

--- a/src/powerquery-language-services/analysis/analysisBase.ts
+++ b/src/powerquery-language-services/analysis/analysisBase.ts
@@ -10,7 +10,7 @@ import { TXorNode } from "@microsoft/powerquery-parser/lib/powerquery-parser/par
 
 import * as InspectionUtils from "../inspectionUtils";
 import * as PositionUtils from "../positionUtils";
-import { AutocompleteItem, AutocompleteItemUtils } from "../inspection";
+import { AutocompleteItem, AutocompleteItemUtils, TLeafIdentifier } from "../inspection";
 import type {
     AutocompleteItemProviderContext,
     IAutocompleteItemProvider,
@@ -238,11 +238,9 @@ export abstract class AnalysisBase implements Analysis {
         const maybeInspected: Inspection.Inspected | undefined = await this.promiseMaybeInspected;
         const activeNode: Inspection.ActiveNode | undefined = await this.getMaybeActiveNode();
         const scopeById: Inspection.ScopeById | undefined = maybeInspected?.typeCache.scopeById;
+        const maybeLeafIdentifier: TLeafIdentifier | undefined = activeNode?.maybeInclusiveIdentifierUnderPosition;
 
-        const maybeInclusiveIdentifierUnderPosition: Ast.Identifier | Ast.GeneralizedIdentifier | undefined =
-            activeNode?.maybeInclusiveIdentifierUnderPosition;
-
-        if (maybeInspected === undefined || maybeInclusiveIdentifierUnderPosition === undefined) {
+        if (maybeInspected === undefined || maybeLeafIdentifier === undefined) {
             trace.exit();
 
             return [];
@@ -251,34 +249,41 @@ export abstract class AnalysisBase implements Analysis {
         const identifiersToBeEdited: (Ast.Identifier | Ast.GeneralizedIdentifier)[] = [];
         let valueCreator: Ast.Identifier | Ast.GeneralizedIdentifier | undefined = undefined;
 
-        if (maybeInclusiveIdentifierUnderPosition.kind === Ast.NodeKind.GeneralizedIdentifier) {
-            valueCreator = maybeInclusiveIdentifierUnderPosition;
-        } else if (maybeInclusiveIdentifierUnderPosition.kind === Ast.NodeKind.Identifier && scopeById) {
+        if (maybeLeafIdentifier.node.kind === Ast.NodeKind.GeneralizedIdentifier) {
+            valueCreator = maybeLeafIdentifier.node;
+        } else if (
+            (maybeLeafIdentifier.node.kind === Ast.NodeKind.Identifier ||
+                maybeLeafIdentifier.node.kind === Ast.NodeKind.IdentifierExpression) &&
+            scopeById
+        ) {
             // need to find this key value and modify all referring it
-            const theIdentifierNode: Ast.Identifier = maybeInclusiveIdentifierUnderPosition as Ast.Identifier;
+            const identifierExpression: Ast.Identifier =
+                maybeLeafIdentifier.node.kind === Ast.NodeKind.IdentifierExpression
+                    ? maybeLeafIdentifier.node.identifier
+                    : maybeLeafIdentifier.node;
 
-            switch (theIdentifierNode.identifierContextKind) {
+            switch (identifierExpression.identifierContextKind) {
                 case Ast.IdentifierContextKind.Key:
                 case Ast.IdentifierContextKind.Parameter:
                     // it is the identifier creating the value
-                    valueCreator = theIdentifierNode;
+                    valueCreator = identifierExpression;
                     break;
 
                 case Ast.IdentifierContextKind.Value: {
                     // it is the identifier referring the value
                     let nodeScope: Inspection.NodeScope | undefined = maybeInspected.typeCache.scopeById.get(
-                        theIdentifierNode.id,
+                        identifierExpression.id,
                     );
 
                     // there might be a chance that its scope did not get populated yet, do another try
                     if (!nodeScope) {
-                        await maybeInspected.tryNodeScope(theIdentifierNode.id);
-                        nodeScope = maybeInspected.typeCache.scopeById.get(theIdentifierNode.id);
+                        await maybeInspected.tryNodeScope(identifierExpression.id);
+                        nodeScope = maybeInspected.typeCache.scopeById.get(identifierExpression.id);
                     }
 
                     const scopeItem: Inspection.TScopeItem | undefined = findScopeItemByLiteral(
                         nodeScope,
-                        maybeInclusiveIdentifierUnderPosition.literal,
+                        maybeLeafIdentifier.normalizedLiteral,
                     );
 
                     if (scopeItem) {
@@ -307,7 +312,7 @@ export abstract class AnalysisBase implements Analysis {
                 case Ast.IdentifierContextKind.Keyword:
                 default:
                     // only modify once
-                    identifiersToBeEdited.push(theIdentifierNode);
+                    identifiersToBeEdited.push(identifierExpression);
                     break;
             }
         }
@@ -318,8 +323,12 @@ export abstract class AnalysisBase implements Analysis {
         }
 
         // if none found, directly put maybeInclusiveIdentifierUnderPosition in if it exists
-        if (identifiersToBeEdited.length === 0 && maybeInclusiveIdentifierUnderPosition) {
-            identifiersToBeEdited.push(maybeInclusiveIdentifierUnderPosition);
+        if (identifiersToBeEdited.length === 0 && maybeLeafIdentifier) {
+            identifiersToBeEdited.push(
+                maybeLeafIdentifier.node.kind === Ast.NodeKind.IdentifierExpression
+                    ? maybeLeafIdentifier.node.identifier
+                    : maybeLeafIdentifier.node,
+            );
         }
 
         const result: TextEdit[] = identifiersToBeEdited.map((one: Ast.Identifier | Ast.GeneralizedIdentifier) => ({
@@ -445,7 +454,7 @@ export abstract class AnalysisBase implements Analysis {
 
         const maybeActiveNode: Inspection.ActiveNode | undefined = await this.getMaybeActiveNode();
 
-        const maybeIdentifierUnderPosition: Ast.Identifier | Ast.GeneralizedIdentifier | undefined =
+        const maybeIdentifierUnderPosition: TLeafIdentifier | undefined =
             maybeActiveNode?.maybeExclusiveIdentifierUnderPosition;
 
         if (
@@ -458,7 +467,10 @@ export abstract class AnalysisBase implements Analysis {
             return undefined;
         }
 
-        const identifier: Ast.Identifier | Ast.GeneralizedIdentifier = maybeIdentifierUnderPosition;
+        const identifier: Ast.Identifier | Ast.GeneralizedIdentifier =
+            maybeIdentifierUnderPosition.node.kind === Ast.NodeKind.IdentifierExpression
+                ? maybeIdentifierUnderPosition.node.identifier
+                : maybeIdentifierUnderPosition.node;
 
         const context: OnIdentifierProviderContext = {
             traceManager: this.analysisSettings.traceManager,
@@ -475,7 +487,14 @@ export abstract class AnalysisBase implements Analysis {
     private async getMaybePositionIdentifier(): Promise<Ast.Identifier | Ast.GeneralizedIdentifier | undefined> {
         const maybeActiveNode: Inspection.ActiveNode | undefined = await this.getMaybeActiveNode();
 
-        return maybeActiveNode?.maybeExclusiveIdentifierUnderPosition;
+        if (!maybeActiveNode?.maybeExclusiveIdentifierUnderPosition) {
+            return undefined;
+        }
+
+        const identifier: Ast.Identifier | Ast.IdentifierExpression | Ast.GeneralizedIdentifier =
+            maybeActiveNode.maybeExclusiveIdentifierUnderPosition.node;
+
+        return identifier.kind === Ast.NodeKind.IdentifierExpression ? identifier.identifier : identifier;
     }
 
     private async getMaybeActiveNode(): Promise<Inspection.ActiveNode | undefined> {

--- a/src/powerquery-language-services/inspection/activeNode/activeNode.ts
+++ b/src/powerquery-language-services/inspection/activeNode/activeNode.ts
@@ -31,13 +31,29 @@ export interface ActiveNode extends IActiveNode {
     // Must contain at least one element, otherwise it should be an OutOfBoundPosition.
     readonly ancestry: ReadonlyArray<TXorNode>;
     // A conditional indirection to the leaf if it's an Ast identifier exclusively in (identifierStart, identifierEnd].
-    readonly maybeExclusiveIdentifierUnderPosition: Ast.Identifier | Ast.GeneralizedIdentifier | undefined;
+    readonly maybeExclusiveIdentifierUnderPosition: TLeafIdentifier | undefined;
     // A conditional indirection to the leaf if it's an Ast identifier inclusively in [identifierStart, identifierEnd].
-    readonly maybeInclusiveIdentifierUnderPosition: Ast.Identifier | Ast.GeneralizedIdentifier | undefined;
+    readonly maybeInclusiveIdentifierUnderPosition: TLeafIdentifier | undefined;
 }
 
 export interface OutOfBoundPosition extends IActiveNode {
     readonly kind: ActiveNodeKind.OutOfBoundPosition;
+}
+
+export type TLeafIdentifier = LeafIdentifierExpression | LeafIdentifier;
+
+export interface LeafIdentifierExpression {
+    readonly node: Ast.IdentifierExpression;
+    readonly normalizedLiteral: string;
+    readonly maybeNormalizedRecursiveLiteral: string;
+    readonly isRecursive: boolean;
+}
+
+export interface LeafIdentifier {
+    readonly node: Ast.GeneralizedIdentifier | Ast.Identifier;
+    readonly normalizedLiteral: string;
+    readonly maybeNormalizedRecursiveLiteral: undefined;
+    readonly isRecursive: boolean;
 }
 
 export const enum ActiveNodeLeafKind {

--- a/src/powerquery-language-services/inspection/activeNode/activeNode.ts
+++ b/src/powerquery-language-services/inspection/activeNode/activeNode.ts
@@ -31,29 +31,31 @@ export interface ActiveNode extends IActiveNode {
     // Must contain at least one element, otherwise it should be an OutOfBoundPosition.
     readonly ancestry: ReadonlyArray<TXorNode>;
     // A conditional indirection to the leaf if it's an Ast identifier exclusively in (identifierStart, identifierEnd].
-    readonly maybeExclusiveIdentifierUnderPosition: TLeafIdentifier | undefined;
+    readonly maybeExclusiveIdentifierUnderPosition: TActiveLeafIdentifier | undefined;
     // A conditional indirection to the leaf if it's an Ast identifier inclusively in [identifierStart, identifierEnd].
-    readonly maybeInclusiveIdentifierUnderPosition: TLeafIdentifier | undefined;
+    readonly maybeInclusiveIdentifierUnderPosition: TActiveLeafIdentifier | undefined;
 }
 
 export interface OutOfBoundPosition extends IActiveNode {
     readonly kind: ActiveNodeKind.OutOfBoundPosition;
 }
 
-export type TLeafIdentifier = LeafIdentifierExpression | LeafIdentifier;
+export type TActiveLeafIdentifier = ActiveLeafIdentifierExpression | ActiveLeafIdentifier;
 
-export interface ILeafIdentifier<T extends Ast.GeneralizedIdentifier | Ast.Identifier | Ast.IdentifierExpression> {
+export interface IActiveLeafIdentifier<
+    T extends Ast.GeneralizedIdentifier | Ast.Identifier | Ast.IdentifierExpression,
+> {
     readonly node: T;
     readonly normalizedLiteral: string;
     readonly maybeNormalizedRecursiveLiteral: string | undefined;
     readonly isRecursive: boolean;
 }
 
-export interface LeafIdentifierExpression extends ILeafIdentifier<Ast.IdentifierExpression> {
+export interface ActiveLeafIdentifierExpression extends IActiveLeafIdentifier<Ast.IdentifierExpression> {
     readonly node: Ast.IdentifierExpression;
 }
 
-export interface LeafIdentifier extends ILeafIdentifier<Ast.GeneralizedIdentifier | Ast.Identifier> {
+export interface ActiveLeafIdentifier extends IActiveLeafIdentifier<Ast.GeneralizedIdentifier | Ast.Identifier> {
     readonly node: Ast.GeneralizedIdentifier | Ast.Identifier;
     readonly maybeNormalizedRecursiveLiteral: undefined;
     readonly isRecursive: false;

--- a/src/powerquery-language-services/inspection/activeNode/activeNode.ts
+++ b/src/powerquery-language-services/inspection/activeNode/activeNode.ts
@@ -42,18 +42,21 @@ export interface OutOfBoundPosition extends IActiveNode {
 
 export type TLeafIdentifier = LeafIdentifierExpression | LeafIdentifier;
 
-export interface LeafIdentifierExpression {
-    readonly node: Ast.IdentifierExpression;
+export interface ILeafIdentifier<T extends Ast.GeneralizedIdentifier | Ast.Identifier | Ast.IdentifierExpression> {
+    readonly node: T;
     readonly normalizedLiteral: string;
-    readonly maybeNormalizedRecursiveLiteral: string;
+    readonly maybeNormalizedRecursiveLiteral: string | undefined;
     readonly isRecursive: boolean;
 }
 
-export interface LeafIdentifier {
+export interface LeafIdentifierExpression extends ILeafIdentifier<Ast.IdentifierExpression> {
+    readonly node: Ast.IdentifierExpression;
+}
+
+export interface LeafIdentifier extends ILeafIdentifier<Ast.GeneralizedIdentifier | Ast.Identifier> {
     readonly node: Ast.GeneralizedIdentifier | Ast.Identifier;
-    readonly normalizedLiteral: string;
     readonly maybeNormalizedRecursiveLiteral: undefined;
-    readonly isRecursive: boolean;
+    readonly isRecursive: false;
 }
 
 export const enum ActiveNodeLeafKind {

--- a/src/powerquery-language-services/inspection/activeNode/activeNodeUtils.ts
+++ b/src/powerquery-language-services/inspection/activeNode/activeNodeUtils.ts
@@ -84,29 +84,15 @@ export function maybeActiveNode(nodeIdMapCollection: NodeIdMap.Collection, posit
             ? maybeInclusiveIdentifierUnderPosition
             : undefined;
 
-    return createActiveNode(
-        leafKind,
-        position,
-        AncestryUtils.assertGetAncestry(nodeIdMapCollection, leaf.node.id),
-        maybeExclusiveIdentifierUnderPosition,
-        maybeInclusiveIdentifierUnderPosition,
-    );
-}
+    const ancestry: ReadonlyArray<TXorNode> = AncestryUtils.assertGetAncestry(nodeIdMapCollection, leaf.node.id);
 
-export function createActiveNode(
-    leafKind: ActiveNodeLeafKind,
-    position: Position,
-    ancestry: ReadonlyArray<TXorNode>,
-    maybeExclusiveIdentifierUnderPosition: Ast.Identifier | Ast.GeneralizedIdentifier | undefined,
-    maybeInclusiveIdentifierUnderPosition: Ast.Identifier | Ast.GeneralizedIdentifier | undefined,
-): ActiveNode {
     return {
+        ancestry,
         kind: ActiveNodeKind.ActiveNode,
         leafKind,
-        position,
-        ancestry,
         maybeExclusiveIdentifierUnderPosition,
         maybeInclusiveIdentifierUnderPosition,
+        position,
     };
 }
 

--- a/src/powerquery-language-services/inspection/activeNode/activeNodeUtils.ts
+++ b/src/powerquery-language-services/inspection/activeNode/activeNodeUtils.ts
@@ -18,7 +18,7 @@ import {
     ActiveNodeKind,
     ActiveNodeLeafKind,
     OutOfBoundPosition,
-    TLeafIdentifier,
+    TActiveLeafIdentifier,
     TMaybeActiveNode,
 } from "./activeNode";
 import { PositionUtils } from "../..";
@@ -82,12 +82,12 @@ export function maybeActiveNode(nodeIdMapCollection: NodeIdMap.Collection, posit
 
     const leaf: TXorNode = maybeLeaf;
 
-    const maybeInclusiveIdentifierUnderPosition: TLeafIdentifier | undefined = findLeafIdentifier(
+    const maybeInclusiveIdentifierUnderPosition: TActiveLeafIdentifier | undefined = findLeafIdentifier(
         nodeIdMapCollection,
         leaf,
     );
 
-    const maybeExclusiveIdentifierUnderPosition: TLeafIdentifier | undefined =
+    const maybeExclusiveIdentifierUnderPosition: TActiveLeafIdentifier | undefined =
         maybeInclusiveIdentifierUnderPosition &&
         PositionUtils.isInAst(position, maybeInclusiveIdentifierUnderPosition.node, false, true)
             ? maybeInclusiveIdentifierUnderPosition
@@ -332,7 +332,7 @@ function maybeFindContext(
 function findLeafIdentifier(
     nodeIdMapCollection: NodeIdMap.Collection,
     leafXorNode: TXorNode,
-): TLeafIdentifier | undefined {
+): TActiveLeafIdentifier | undefined {
     if (XorNodeUtils.isContextXor(leafXorNode)) {
         return undefined;
     }
@@ -379,7 +379,7 @@ function findLeafIdentifier(
         return undefined;
     }
 
-    let result: TLeafIdentifier;
+    let result: TActiveLeafIdentifier;
 
     switch (identifier.kind) {
         case Ast.NodeKind.Identifier:

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeyword.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteKeyword/autocompleteKeyword.ts
@@ -52,7 +52,7 @@ export async function autocompleteKeyword(
 
     if (PositionUtils.isInXor(nodeIdMapCollection, activeNode.position, ancestryLeaf, false, true)) {
         if (activeNode.maybeExclusiveIdentifierUnderPosition !== undefined) {
-            maybePositionName = activeNode.maybeExclusiveIdentifierUnderPosition.literal;
+            maybePositionName = activeNode.maybeExclusiveIdentifierUnderPosition.normalizedLiteral;
         }
         // Matches 'null', 'true', and 'false'.
         else if (

--- a/src/powerquery-language-services/validate/validateLexAndParse.ts
+++ b/src/powerquery-language-services/validate/validateLexAndParse.ts
@@ -111,24 +111,7 @@ async function validateParse(
     const innerError: PQP.Parser.ParseError.TInnerParseError = error.innerError;
     const message: string = error.message;
     const parseContextState: PQP.Parser.ParseContext.State = error.state.contextState;
-
-    let maybeErrorToken: PQP.Language.Token.Token | undefined;
-
-    if (
-        (innerError instanceof PQP.Parser.ParseError.ExpectedAnyTokenKindError ||
-            innerError instanceof PQP.Parser.ParseError.ExpectedTokenKindError) &&
-        innerError.maybeFoundToken !== undefined
-    ) {
-        maybeErrorToken = innerError.maybeFoundToken.token;
-    } else if (innerError instanceof PQP.Parser.ParseError.InvalidPrimitiveTypeError) {
-        maybeErrorToken = innerError.token;
-    } else if (innerError instanceof PQP.Parser.ParseError.UnterminatedSequence) {
-        maybeErrorToken = innerError.startToken;
-    } else if (innerError instanceof PQP.Parser.ParseError.UnusedTokensRemainError) {
-        maybeErrorToken = innerError.firstUnusedToken;
-    } else {
-        maybeErrorToken = undefined;
-    }
+    const maybeErrorToken: PQP.Language.Token.Token | undefined = PQP.Parser.ParseError.maybeTokenFrom(innerError);
 
     let range: Range;
 

--- a/src/test/inspection.ts
+++ b/src/test/inspection.ts
@@ -125,15 +125,15 @@ describe("InspectedInvokeExpression", () => {
 
                 TestUtils.assertIsDefined(activeNode.maybeExclusiveIdentifierUnderPosition);
 
-                expect(activeNode.maybeExclusiveIdentifierUnderPosition.node.kind).equals(
-                    Ast.NodeKind.IdentifierExpression,
-                    "expecting identifierExpression",
+                expect(activeNode.maybeExclusiveIdentifierUnderPosition.kind).equals(
+                    Ast.NodeKind.Identifier,
+                    "expecting identifier",
                 );
 
-                const identifier: Ast.GeneralizedIdentifier | Ast.Identifier | Ast.IdentifierExpression =
-                    activeNode.maybeExclusiveIdentifierUnderPosition.node;
+                const identifier: Ast.GeneralizedIdentifier | Ast.Identifier =
+                    activeNode.maybeExclusiveIdentifierUnderPosition;
 
-                expect(activeNode.maybeExclusiveIdentifierUnderPosition.normalizedLiteral).equals("OdbcDataSource");
+                expect(identifier.literal).equals("OdbcDataSource");
                 expect(identifier.tokenRange.positionStart.lineNumber).equals(68);
             });
         });

--- a/src/test/inspection.ts
+++ b/src/test/inspection.ts
@@ -125,15 +125,15 @@ describe("InspectedInvokeExpression", () => {
 
                 TestUtils.assertIsDefined(activeNode.maybeExclusiveIdentifierUnderPosition);
 
-                expect(activeNode.maybeExclusiveIdentifierUnderPosition.kind).equals(
-                    Ast.NodeKind.Identifier,
+                expect(activeNode.maybeExclusiveIdentifierUnderPosition.node.kind).equals(
+                    Ast.NodeKind.IdentifierExpression,
                     "expecting identifier",
                 );
 
-                const identifier: Ast.GeneralizedIdentifier | Ast.Identifier =
-                    activeNode.maybeExclusiveIdentifierUnderPosition;
+                const identifier: Ast.GeneralizedIdentifier | Ast.Identifier | Ast.IdentifierExpression =
+                    activeNode.maybeExclusiveIdentifierUnderPosition.node;
 
-                expect(identifier.literal).equals("OdbcDataSource");
+                expect(activeNode.maybeExclusiveIdentifierUnderPosition.normalizedLiteral).equals("OdbcDataSource");
                 expect(identifier.tokenRange.positionStart.lineNumber).equals(68);
             });
         });

--- a/src/test/inspection.ts
+++ b/src/test/inspection.ts
@@ -125,15 +125,15 @@ describe("InspectedInvokeExpression", () => {
 
                 TestUtils.assertIsDefined(activeNode.maybeExclusiveIdentifierUnderPosition);
 
-                expect(activeNode.maybeExclusiveIdentifierUnderPosition.kind).equals(
-                    Ast.NodeKind.Identifier,
-                    "expecting identifier",
+                expect(activeNode.maybeExclusiveIdentifierUnderPosition.node.kind).equals(
+                    Ast.NodeKind.IdentifierExpression,
+                    "expecting identifierExpression",
                 );
 
-                const identifier: Ast.GeneralizedIdentifier | Ast.Identifier =
-                    activeNode.maybeExclusiveIdentifierUnderPosition;
+                const identifier: Ast.GeneralizedIdentifier | Ast.Identifier | Ast.IdentifierExpression =
+                    activeNode.maybeExclusiveIdentifierUnderPosition.node;
 
-                expect(identifier.literal).equals("OdbcDataSource");
+                expect(activeNode.maybeExclusiveIdentifierUnderPosition.normalizedLiteral).equals("OdbcDataSource");
                 expect(identifier.tokenRange.positionStart.lineNumber).equals(68);
             });
         });

--- a/src/test/inspection/renameEdits.ts
+++ b/src/test/inspection/renameEdits.ts
@@ -450,7 +450,7 @@ describe(`Inspection - RenameEdits - Identifiers`, () => {
 
                     const res: Ast.TNode | undefined = findDirectUpperScopeExpression(
                         inspectionInstance.nodeIdMapCollection,
-                        (inspectionInstance.maybeActiveNode as ActiveNode).maybeInclusiveIdentifierUnderPosition?.node
+                        (inspectionInstance.maybeActiveNode as ActiveNode).maybeInclusiveIdentifierUnderPosition
                             ?.id as number,
                     );
 

--- a/src/test/inspection/renameEdits.ts
+++ b/src/test/inspection/renameEdits.ts
@@ -450,7 +450,7 @@ describe(`Inspection - RenameEdits - Identifiers`, () => {
 
                     const res: Ast.TNode | undefined = findDirectUpperScopeExpression(
                         inspectionInstance.nodeIdMapCollection,
-                        (inspectionInstance.maybeActiveNode as ActiveNode).maybeInclusiveIdentifierUnderPosition
+                        (inspectionInstance.maybeActiveNode as ActiveNode).maybeInclusiveIdentifierUnderPosition?.node
                             ?.id as number,
                     );
 

--- a/src/test/inspection/renameEdits.ts
+++ b/src/test/inspection/renameEdits.ts
@@ -289,7 +289,7 @@ describe(`Inspection - RenameEdits - Identifiers`, () => {
             expect(textEdits[0].range.end.character).eq(183);
         });
 
-        it(`WIP Rename one identifier within a statement`, async () => {
+        it(`Rename one identifier within a statement`, async () => {
             const rawText: string = `let
                 foo| = 1,
                 bar = 1,
@@ -414,23 +414,23 @@ describe(`Inspection - RenameEdits - Identifiers`, () => {
         describe("findDirectUpperScopeExpression", () => {
             (
                 [
-                    ["SectionMember", `section foo; x| = 1; y = 2; z = let a = x in a;`, NodeKind.SectionMember],
-                    [
-                        "RecordLiteral",
-                        `section foo; [u| = "v" ]shared x = 1; y = 2; z = let a = x in a;`,
-                        NodeKind.RecordLiteral,
-                    ],
-                    [
-                        "RecordExpression",
-                        `[
-                            |a = "yoo"
-                        ]`,
-                        NodeKind.RecordExpression,
-                    ],
-                    ["LetExpression", `let a| = x in a`, NodeKind.LetExpression],
+                    // ["SectionMember", `section foo; x| = 1; y = 2; z = let a = x in a;`, NodeKind.SectionMember],
+                    // [
+                    //     "RecordLiteral",
+                    //     `section foo; [u| = "v" ]shared x = 1; y = 2; z = let a = x in a;`,
+                    //     NodeKind.RecordLiteral,
+                    // ],
+                    // [
+                    //     "RecordExpression",
+                    //     `[
+                    //         |a = "yoo"
+                    //     ]`,
+                    //     NodeKind.RecordExpression,
+                    // ],
+                    // ["LetExpression", `let a| = x in a`, NodeKind.LetExpression],
                     ["FunctionExpression", `(a|) => let x  = a in x`, NodeKind.FunctionExpression],
-                    ["EachExpression", `each x|;`, NodeKind.EachExpression],
-                    ["undefined", `x| + 1`, undefined],
+                    // ["EachExpression", `each x|;`, NodeKind.EachExpression],
+                    // ["undefined", `x| + 1`, undefined],
                 ] as Array<[string, string, NodeKind | undefined]>
             ).forEach(([nodeKindString, rawTextString, nodeKind]: [string, string, NodeKind | undefined]) => {
                 it(`Find ${nodeKindString}`, async () => {
@@ -450,7 +450,7 @@ describe(`Inspection - RenameEdits - Identifiers`, () => {
 
                     const res: Ast.TNode | undefined = findDirectUpperScopeExpression(
                         inspectionInstance.nodeIdMapCollection,
-                        (inspectionInstance.maybeActiveNode as ActiveNode).maybeInclusiveIdentifierUnderPosition
+                        (inspectionInstance.maybeActiveNode as ActiveNode).maybeInclusiveIdentifierUnderPosition?.node
                             ?.id as number,
                     );
 

--- a/src/test/inspection/renameEdits.ts
+++ b/src/test/inspection/renameEdits.ts
@@ -289,7 +289,7 @@ describe(`Inspection - RenameEdits - Identifiers`, () => {
             expect(textEdits[0].range.end.character).eq(183);
         });
 
-        it(`Rename one identifier within a statement`, async () => {
+        it(`WIP Rename one identifier within a statement`, async () => {
             const rawText: string = `let
                 foo| = 1,
                 bar = 1,

--- a/src/test/inspection/renameEdits.ts
+++ b/src/test/inspection/renameEdits.ts
@@ -428,7 +428,7 @@ describe(`Inspection - RenameEdits - Identifiers`, () => {
                     //     NodeKind.RecordExpression,
                     // ],
                     // ["LetExpression", `let a| = x in a`, NodeKind.LetExpression],
-                    ["FunctionExpression", `(a|) => let x  = a in x`, NodeKind.FunctionExpression],
+                    ["WIP FunctionExpression", `(a|) => let x  = a in x`, NodeKind.FunctionExpression],
                     // ["EachExpression", `each x|;`, NodeKind.EachExpression],
                     // ["undefined", `x| + 1`, undefined],
                 ] as Array<[string, string, NodeKind | undefined]>

--- a/src/test/inspection/renameEdits.ts
+++ b/src/test/inspection/renameEdits.ts
@@ -414,23 +414,23 @@ describe(`Inspection - RenameEdits - Identifiers`, () => {
         describe("findDirectUpperScopeExpression", () => {
             (
                 [
-                    // ["SectionMember", `section foo; x| = 1; y = 2; z = let a = x in a;`, NodeKind.SectionMember],
-                    // [
-                    //     "RecordLiteral",
-                    //     `section foo; [u| = "v" ]shared x = 1; y = 2; z = let a = x in a;`,
-                    //     NodeKind.RecordLiteral,
-                    // ],
-                    // [
-                    //     "RecordExpression",
-                    //     `[
-                    //         |a = "yoo"
-                    //     ]`,
-                    //     NodeKind.RecordExpression,
-                    // ],
-                    // ["LetExpression", `let a| = x in a`, NodeKind.LetExpression],
-                    ["WIP FunctionExpression", `(a|) => let x  = a in x`, NodeKind.FunctionExpression],
-                    // ["EachExpression", `each x|;`, NodeKind.EachExpression],
-                    // ["undefined", `x| + 1`, undefined],
+                    ["SectionMember", `section foo; x| = 1; y = 2; z = let a = x in a;`, NodeKind.SectionMember],
+                    [
+                        "RecordLiteral",
+                        `section foo; [u| = "v" ]shared x = 1; y = 2; z = let a = x in a;`,
+                        NodeKind.RecordLiteral,
+                    ],
+                    [
+                        "RecordExpression",
+                        `[
+                            |a = "yoo"
+                        ]`,
+                        NodeKind.RecordExpression,
+                    ],
+                    ["LetExpression", `let a| = x in a`, NodeKind.LetExpression],
+                    ["FunctionExpression", `(a|) => let x  = a in x`, NodeKind.FunctionExpression],
+                    ["EachExpression", `each x|;`, NodeKind.EachExpression],
+                    ["undefined", `x| + 1`, undefined],
                 ] as Array<[string, string, NodeKind | undefined]>
             ).forEach(([nodeKindString, rawTextString, nodeKind]: [string, string, NodeKind | undefined]) => {
                 it(`Find ${nodeKindString}`, async () => {


### PR DESCRIPTION
Adds a new contract for what's under the position of an ActiveNode. Replaces the previous attribute of a union of Identifier and GeneralizedIdentifier. 