### PR TITLE
Add getPartialSemanticToken

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.3.37",
+    "version": "0.3.38",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/powerquery-language-services",
-            "version": "0.3.37",
+            "version": "0.3.38",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/powerquery-formatter": "0.1.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.3.37",
+    "version": "0.3.38",
     "author": "Microsoft",
     "license": "MIT",
     "scripts": {

--- a/src/powerquery-language-services/analysis/analysis.ts
+++ b/src/powerquery-language-services/analysis/analysis.ts
@@ -3,13 +3,14 @@
 
 import type { Hover, Location, SignatureHelp, TextEdit } from "vscode-languageserver-types";
 
+import { Inspection, PartialSemanticToken } from "..";
 import { IDisposable } from "../commonTypes";
-import { Inspection } from "..";
 
 export interface Analysis extends IDisposable {
     getAutocompleteItems(): Promise<Inspection.AutocompleteItem[]>;
     getDefinition(): Promise<Location[]>;
     getHover(): Promise<Hover>;
+    getPartialSemanticTokens(): Promise<PartialSemanticToken[]>;
     getSignatureHelp(): Promise<SignatureHelp>;
     getRenameEdits(newName: string): Promise<TextEdit[]>;
 }

--- a/src/powerquery-language-services/analysis/analysisBase.ts
+++ b/src/powerquery-language-services/analysis/analysisBase.ts
@@ -18,6 +18,7 @@ import type {
     ILocalDocumentProvider,
     ISymbolProvider,
     OnIdentifierProviderContext,
+    PartialSemanticToken,
     SignatureHelpProvider,
     SignatureProviderContext,
 } from "../providers/commonTypes";
@@ -168,6 +169,23 @@ export abstract class AnalysisBase implements Analysis {
             ),
             EmptyHover,
         );
+
+        trace.exit();
+
+        return result;
+    }
+
+    public async getPartialSemanticTokens(): Promise<PartialSemanticToken[]> {
+        const trace: Trace = this.analysisSettings.traceManager.entry(
+            ValidationTraceConstant.AnalysisBase,
+            this.getPartialSemanticTokens.name,
+            this.analysisSettings.maybeInitialCorrelationId,
+        );
+
+        const result: PartialSemanticToken[] = await this.localDocumentProvider.getPartialSemanticTokens({
+            traceManager: this.analysisSettings.traceManager,
+            maybeInitialCorrelationId: trace.id,
+        });
 
         trace.exit();
 

--- a/src/powerquery-language-services/providers/commonTypes.ts
+++ b/src/powerquery-language-services/providers/commonTypes.ts
@@ -2,7 +2,14 @@
 // Licensed under the MIT license.
 
 import type { Ast, Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
-import type { Hover, Location, Range, SignatureHelp } from "vscode-languageserver-types";
+import type {
+    Hover,
+    Location,
+    Range,
+    SemanticTokenModifiers,
+    SemanticTokenTypes,
+    SignatureHelp,
+} from "vscode-languageserver-types";
 import { TraceManager } from "@microsoft/powerquery-parser/lib/powerquery-parser/common/trace";
 
 import type { AutocompleteItem } from "../inspection/autocomplete/autocompleteItem";
@@ -25,16 +32,28 @@ export interface IHoverProvider {
     getHover(context: OnIdentifierProviderContext): Promise<Hover | null>;
 }
 
-export interface OnIdentifierProviderContext extends ProviderContext {
-    readonly identifier: Ast.GeneralizedIdentifier | Ast.Identifier;
-}
+export interface ILocalDocumentProvider extends IDefinitionProvider, ISemanticTokenProvider, ISymbolProvider {}
 
-export interface ILocalDocumentProvider extends IDefinitionProvider, ISymbolProvider {}
+export interface ISemanticTokenProvider {
+    getPartialSemanticTokens(context: ProviderContext): Promise<PartialSemanticToken[]>;
+}
 
 export interface ProviderContext {
     readonly traceManager: TraceManager;
     readonly maybeInitialCorrelationId: number | undefined;
     readonly range?: Range;
+}
+
+export interface OnIdentifierProviderContext extends ProviderContext {
+    readonly identifier: Ast.GeneralizedIdentifier | Ast.Identifier;
+}
+
+// Almost the same interface as the parameters to a `SemanticTokensBuilder.push` function overload,
+// except tokenType isn't a string nor is tokenModifiers a string array.
+export interface PartialSemanticToken {
+    readonly range: Range;
+    readonly tokenType: SemanticTokenTypes;
+    readonly tokenModifiers: ReadonlyArray<SemanticTokenModifiers>;
 }
 
 export interface SignatureHelpProvider {

--- a/src/powerquery-language-services/providers/index.ts
+++ b/src/powerquery-language-services/providers/index.ts
@@ -5,5 +5,5 @@ export * from "./commonTypes";
 
 export { LibrarySymbolProvider } from "./librarySymbolProvider";
 export { LanguageAutocompleteItemProvider } from "./languageCompletionItemProvider";
-export { LocalDocumentProvider } from "./localDocumentProvider";
+export { LocalDocumentProvider } from "./localDocumentProvider/localDocumentProvider";
 export { NullSymbolProvider } from "./nullSymbolProvider";

--- a/src/powerquery-language-services/providers/localDocumentProvider/index.ts
+++ b/src/powerquery-language-services/providers/localDocumentProvider/index.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export * from "./localDocumentProvider";

--- a/src/powerquery-language-services/providers/localDocumentProvider/partialSemanticToken.ts
+++ b/src/powerquery-language-services/providers/localDocumentProvider/partialSemanticToken.ts
@@ -118,12 +118,12 @@ function getFieldSelectorTokens(
             tokenType: SemanticTokenTypes.variable,
         });
 
-        const maybeQuestionMarkAst: Ast.GeneralizedIdentifier | undefined =
-            NodeIdMapUtils.maybeUnboxNthChildIfAstChecked<Ast.GeneralizedIdentifier>(
+        const maybeQuestionMarkAst: Ast.TConstant | undefined =
+            NodeIdMapUtils.maybeUnboxNthChildIfAstChecked<Ast.TConstant>(
                 nodeIdMapCollection,
                 nodeId,
                 3,
-                Ast.NodeKind.GeneralizedIdentifier,
+                Ast.NodeKind.Constant,
             );
 
         if (maybeQuestionMarkAst === undefined) {
@@ -156,12 +156,12 @@ function getFieldProjectionTokens(
     const tokens: PartialSemanticToken[] = [];
 
     for (const nodeId of nodeIdMapCollection.idsByNodeKind.get(Ast.NodeKind.FieldProjection) ?? []) {
-        const maybeQuestionMarkAst: Ast.GeneralizedIdentifier | undefined =
-            NodeIdMapUtils.maybeUnboxNthChildIfAstChecked<Ast.GeneralizedIdentifier>(
+        const maybeQuestionMarkAst: Ast.TConstant | undefined =
+            NodeIdMapUtils.maybeUnboxNthChildIfAstChecked<Ast.TConstant>(
                 nodeIdMapCollection,
                 nodeId,
                 3,
-                Ast.NodeKind.GeneralizedIdentifier,
+                Ast.NodeKind.Constant,
             );
 
         if (maybeQuestionMarkAst === undefined) {

--- a/src/powerquery-language-services/providers/localDocumentProvider/partialSemanticToken.ts
+++ b/src/powerquery-language-services/providers/localDocumentProvider/partialSemanticToken.ts
@@ -1,0 +1,473 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import {
+    NodeIdMap,
+    NodeIdMapUtils,
+    TXorNode,
+    XorNodeUtils,
+} from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
+import { SemanticTokenModifiers, SemanticTokenTypes } from "vscode-languageserver-types";
+import { Trace, TraceManager } from "@microsoft/powerquery-parser/lib/powerquery-parser/common/trace";
+import { Ast } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+
+import { Library, PositionUtils } from "../..";
+import { PartialSemanticToken } from "../commonTypes";
+import { ProviderTraceConstant } from "../../trace";
+
+export function createPartialSemanticTokens(
+    nodeIdMapCollection: NodeIdMap.Collection,
+    libraryDefinitions: Library.LibraryDefinitions,
+    traceManager: TraceManager,
+    correlationId: number,
+): PartialSemanticToken[] {
+    const trace: Trace = traceManager.entry(
+        ProviderTraceConstant.LocalDocumentSymbolProvider,
+        createPartialSemanticTokens.name,
+        correlationId,
+    );
+
+    let tokens: PartialSemanticToken[] = [];
+
+    tokens = tokens
+        .concat(getAsNullablePrimitiveTypeTokens(nodeIdMapCollection, traceManager, trace.id))
+        .concat(getFieldSelectorTokens(nodeIdMapCollection, traceManager, trace.id))
+        .concat(getFieldProjectionTokens(nodeIdMapCollection, traceManager, trace.id))
+        .concat(getIdentifierTokens(nodeIdMapCollection, libraryDefinitions, traceManager, trace.id))
+        .concat(getLiteralTokens(nodeIdMapCollection, traceManager, trace.id))
+        .concat(getTBinOpExpressionTokens(nodeIdMapCollection, traceManager, trace.id))
+        .concat(getNullablePrimitiveTypeTokens(nodeIdMapCollection, traceManager, trace.id))
+        .concat(getParameterTokens(nodeIdMapCollection, traceManager, trace.id))
+        .concat(getPrimitiveTypeTokens(nodeIdMapCollection, traceManager, trace.id));
+
+    trace.exit();
+
+    return tokens;
+}
+
+// TBinOpExpressions takes care of the `as` token.
+// NullablePrimitiveType | PrimitiveType take care of the TNullablePrimitiveType
+function getAsNullablePrimitiveTypeTokens(
+    nodeIdMapCollection: NodeIdMap.Collection,
+    traceManager: TraceManager,
+    correlationId: number,
+): PartialSemanticToken[] {
+    const trace: Trace = traceManager.entry(
+        ProviderTraceConstant.LocalDocumentSymbolProvider,
+        getAsNullablePrimitiveTypeTokens.name,
+        correlationId,
+    );
+
+    const tokens: PartialSemanticToken[] = [];
+
+    for (const parentId of nodeIdMapCollection.idsByNodeKind.get(Ast.NodeKind.AsNullablePrimitiveType) ?? []) {
+        const maybeAsXor: TXorNode | undefined = NodeIdMapUtils.maybeNthChild(nodeIdMapCollection, parentId, 0);
+
+        if (maybeAsXor === undefined || !XorNodeUtils.isAstXor(maybeAsXor)) {
+            continue;
+        }
+
+        tokens.push({
+            range: PositionUtils.createRangeFromTokenRange(maybeAsXor.node.tokenRange),
+            tokenModifiers: [],
+            tokenType: SemanticTokenTypes.keyword,
+        });
+    }
+
+    trace.exit();
+
+    return tokens;
+}
+
+function getFieldSelectorTokens(
+    nodeIdMapCollection: NodeIdMap.Collection,
+    traceManager: TraceManager,
+    correlationId: number,
+): PartialSemanticToken[] {
+    const trace: Trace = traceManager.entry(
+        ProviderTraceConstant.LocalDocumentSymbolProvider,
+        getFieldSelectorTokens.name,
+        correlationId,
+    );
+
+    const tokens: PartialSemanticToken[] = [];
+
+    for (const nodeId of nodeIdMapCollection.idsByNodeKind.get(Ast.NodeKind.FieldSelector) ?? []) {
+        const maybeGeneraliezdIdentifier: Ast.GeneralizedIdentifier | undefined =
+            NodeIdMapUtils.maybeUnboxNthChildIfAstChecked<Ast.GeneralizedIdentifier>(
+                nodeIdMapCollection,
+                nodeId,
+                1,
+                Ast.NodeKind.GeneralizedIdentifier,
+            );
+
+        if (maybeGeneraliezdIdentifier === undefined) {
+            continue;
+        }
+
+        tokens.push({
+            range: PositionUtils.createRangeFromTokenRange(maybeGeneraliezdIdentifier.tokenRange),
+            tokenModifiers: [],
+            tokenType: SemanticTokenTypes.variable,
+        });
+
+        const maybeQuestionMarkAst: Ast.GeneralizedIdentifier | undefined =
+            NodeIdMapUtils.maybeUnboxNthChildIfAstChecked<Ast.GeneralizedIdentifier>(
+                nodeIdMapCollection,
+                nodeId,
+                3,
+                Ast.NodeKind.GeneralizedIdentifier,
+            );
+
+        if (maybeQuestionMarkAst === undefined) {
+            continue;
+        }
+
+        tokens.push({
+            range: PositionUtils.createRangeFromTokenRange(maybeQuestionMarkAst.tokenRange),
+            tokenModifiers: [],
+            tokenType: SemanticTokenTypes.operator,
+        });
+    }
+
+    trace.exit();
+
+    return tokens;
+}
+
+function getFieldProjectionTokens(
+    nodeIdMapCollection: NodeIdMap.Collection,
+    traceManager: TraceManager,
+    correlationId: number,
+): PartialSemanticToken[] {
+    const trace: Trace = traceManager.entry(
+        ProviderTraceConstant.LocalDocumentSymbolProvider,
+        getFieldProjectionTokens.name,
+        correlationId,
+    );
+
+    const tokens: PartialSemanticToken[] = [];
+
+    for (const nodeId of nodeIdMapCollection.idsByNodeKind.get(Ast.NodeKind.FieldProjection) ?? []) {
+        const maybeQuestionMarkAst: Ast.GeneralizedIdentifier | undefined =
+            NodeIdMapUtils.maybeUnboxNthChildIfAstChecked<Ast.GeneralizedIdentifier>(
+                nodeIdMapCollection,
+                nodeId,
+                3,
+                Ast.NodeKind.GeneralizedIdentifier,
+            );
+
+        if (maybeQuestionMarkAst === undefined) {
+            continue;
+        }
+
+        tokens.push({
+            range: PositionUtils.createRangeFromTokenRange(maybeQuestionMarkAst.tokenRange),
+            tokenModifiers: [],
+            tokenType: SemanticTokenTypes.operator,
+        });
+    }
+
+    trace.exit();
+
+    return tokens;
+}
+
+function getIdentifierTokens(
+    nodeIdMapCollection: NodeIdMap.Collection,
+    libraryDefinitions: Library.LibraryDefinitions,
+    traceManager: TraceManager,
+    correlationId: number,
+): PartialSemanticToken[] {
+    const trace: Trace = traceManager.entry(
+        ProviderTraceConstant.LocalDocumentSymbolProvider,
+        getIdentifierTokens.name,
+        correlationId,
+    );
+
+    const tokens: PartialSemanticToken[] = [];
+
+    for (const identifierId of nodeIdMapCollection.idsByNodeKind.get(Ast.NodeKind.IdentifierExpression) ?? []) {
+        const identifierExpr: Ast.IdentifierExpression = nodeIdMapCollection.astNodeById.get(
+            identifierId,
+        ) as Ast.IdentifierExpression;
+
+        let maybeTokenType: SemanticTokenTypes | undefined;
+        let maybeTokenModifiers: SemanticTokenModifiers[] = [];
+
+        switch (identifierExpr.identifier.identifierContextKind) {
+            case Ast.IdentifierContextKind.Key:
+                maybeTokenType = SemanticTokenTypes.property;
+                maybeTokenModifiers = [SemanticTokenModifiers.declaration];
+                break;
+
+            case Ast.IdentifierContextKind.Parameter:
+                maybeTokenType = SemanticTokenTypes.parameter;
+                break;
+
+            case Ast.IdentifierContextKind.Value:
+                maybeTokenType = SemanticTokenTypes.variable;
+
+                if (libraryDefinitions.has(identifierExpr.identifier.literal)) {
+                    maybeTokenModifiers = [SemanticTokenModifiers.defaultLibrary];
+                }
+
+                break;
+
+            default:
+                continue;
+        }
+
+        tokens.push({
+            range: PositionUtils.createRangeFromTokenRange(identifierExpr.tokenRange),
+            tokenModifiers: maybeTokenModifiers,
+            tokenType: maybeTokenType,
+        });
+    }
+
+    trace.exit();
+
+    return tokens;
+}
+
+function getLiteralTokens(
+    nodeIdMapCollection: NodeIdMap.Collection,
+    traceManager: TraceManager,
+    correlationId: number,
+): PartialSemanticToken[] {
+    const trace: Trace = traceManager.entry(
+        ProviderTraceConstant.LocalDocumentSymbolProvider,
+        getLiteralTokens.name,
+        correlationId,
+    );
+
+    const tokens: PartialSemanticToken[] = [];
+
+    for (const literalId of nodeIdMapCollection.idsByNodeKind.get(Ast.NodeKind.LiteralExpression) ?? []) {
+        const literal: Ast.LiteralExpression = nodeIdMapCollection.astNodeById.get(literalId) as Ast.LiteralExpression;
+
+        let maybeTokenType: SemanticTokenTypes | undefined;
+
+        switch (literal.literalKind) {
+            case Ast.LiteralKind.Numeric:
+                maybeTokenType = SemanticTokenTypes.number;
+                break;
+
+            case Ast.LiteralKind.Text:
+                maybeTokenType = SemanticTokenTypes.string;
+                break;
+
+            default:
+                continue;
+        }
+
+        tokens.push({
+            range: PositionUtils.createRangeFromTokenRange(literal.tokenRange),
+            tokenModifiers: [],
+            tokenType: maybeTokenType,
+        });
+    }
+
+    trace.exit();
+
+    return tokens;
+}
+
+// getPrimitiveTypeTokens takes care of primitive type token.
+function getNullablePrimitiveTypeTokens(
+    nodeIdMapCollection: NodeIdMap.Collection,
+    traceManager: TraceManager,
+    correlationId: number,
+): PartialSemanticToken[] {
+    const trace: Trace = traceManager.entry(
+        ProviderTraceConstant.LocalDocumentSymbolProvider,
+        getNullablePrimitiveTypeTokens.name,
+        correlationId,
+    );
+
+    const tokens: PartialSemanticToken[] = [];
+
+    for (const parentId of nodeIdMapCollection.idsByNodeKind.get(Ast.NodeKind.NullablePrimitiveType) ?? []) {
+        const maybeNullableXor: TXorNode | undefined = NodeIdMapUtils.maybeNthChild(nodeIdMapCollection, parentId, 0);
+
+        if (maybeNullableXor === undefined || !XorNodeUtils.isAstXor(maybeNullableXor)) {
+            continue;
+        }
+
+        tokens.push({
+            range: PositionUtils.createRangeFromTokenRange(maybeNullableXor.node.tokenRange),
+            tokenModifiers: [],
+            tokenType: SemanticTokenTypes.keyword,
+        });
+    }
+
+    trace.exit();
+
+    return tokens;
+}
+
+// AsTypeTokens | AsNullablePrimitiveTypeTokens takes care of `maybeParameterType`
+function getParameterTokens(
+    nodeIdMapCollection: NodeIdMap.Collection,
+    traceManager: TraceManager,
+    correlationId: number,
+): PartialSemanticToken[] {
+    const trace: Trace = traceManager.entry(
+        ProviderTraceConstant.LocalDocumentSymbolProvider,
+        getParameterTokens.name,
+        correlationId,
+    );
+
+    const tokens: PartialSemanticToken[] = [];
+
+    for (const parameterId of nodeIdMapCollection.idsByNodeKind.get(Ast.NodeKind.Parameter) ?? []) {
+        const xorNode: TXorNode = NodeIdMapUtils.assertGetXor(nodeIdMapCollection, parameterId);
+
+        const maybeOptionalXorNode: TXorNode | undefined = NodeIdMapUtils.maybeNthChild(
+            nodeIdMapCollection,
+            xorNode.node.id,
+            0,
+        );
+
+        if (maybeOptionalXorNode !== undefined) {
+            if (!XorNodeUtils.isAstXor(maybeOptionalXorNode)) {
+                continue;
+            }
+
+            tokens.push({
+                range: PositionUtils.createRangeFromTokenRange(maybeOptionalXorNode.node.tokenRange),
+                tokenModifiers: [],
+                tokenType: SemanticTokenTypes.keyword,
+            });
+        }
+
+        const maybeNameXorNode: TXorNode | undefined = NodeIdMapUtils.maybeNthChild(
+            nodeIdMapCollection,
+            xorNode.node.id,
+            1,
+        );
+
+        if (maybeNameXorNode === undefined || !XorNodeUtils.isAstXor(maybeNameXorNode)) {
+            continue;
+        }
+
+        tokens.push({
+            range: PositionUtils.createRangeFromTokenRange(maybeNameXorNode.node.tokenRange),
+            tokenModifiers: [SemanticTokenModifiers.declaration],
+            tokenType: SemanticTokenTypes.parameter,
+        });
+    }
+
+    trace.exit();
+
+    return tokens;
+}
+
+// getPrimitiveTypeTokens takes care of primitive type token.
+function getPrimitiveTypeTokens(
+    nodeIdMapCollection: NodeIdMap.Collection,
+    traceManager: TraceManager,
+    correlationId: number,
+): PartialSemanticToken[] {
+    const trace: Trace = traceManager.entry(
+        ProviderTraceConstant.LocalDocumentSymbolProvider,
+        getPrimitiveTypeTokens.name,
+        correlationId,
+    );
+
+    const tokens: PartialSemanticToken[] = [];
+
+    for (const nodeId of nodeIdMapCollection.idsByNodeKind.get(Ast.NodeKind.PrimitiveType) ?? []) {
+        const maybeNode: Ast.PrimitiveType | undefined = NodeIdMapUtils.maybeUnboxIfAstChecked<Ast.PrimitiveType>(
+            nodeIdMapCollection,
+            nodeId,
+            Ast.NodeKind.PrimitiveType,
+        );
+
+        if (maybeNode === undefined) {
+            continue;
+        }
+
+        tokens.push({
+            range: PositionUtils.createRangeFromTokenRange(maybeNode.tokenRange),
+            tokenModifiers: [],
+            tokenType: SemanticTokenTypes.type,
+        });
+    }
+
+    trace.exit();
+
+    return tokens;
+}
+
+function getTBinOpExpressionTokens(
+    nodeIdMapCollection: NodeIdMap.Collection,
+    traceManager: TraceManager,
+    correlationId: number,
+): PartialSemanticToken[] {
+    const trace: Trace = traceManager.entry(
+        ProviderTraceConstant.LocalDocumentSymbolProvider,
+        getTBinOpExpressionTokens.name,
+        correlationId,
+    );
+
+    const binOpExprNodeKinds: ReadonlyArray<Ast.NodeKind> = [
+        Ast.NodeKind.ArithmeticExpression,
+        Ast.NodeKind.AsExpression,
+        Ast.NodeKind.EqualityExpression,
+        Ast.NodeKind.IsExpression,
+        Ast.NodeKind.LogicalExpression,
+        Ast.NodeKind.MetadataExpression,
+        Ast.NodeKind.NullCoalescingExpression,
+        Ast.NodeKind.RelationalExpression,
+    ];
+
+    const binOpExprNodeIds: number[] = [];
+    const tokens: PartialSemanticToken[] = [];
+
+    for (const nodeKind of binOpExprNodeKinds) {
+        const maybeNodeIds: Set<number> | undefined = nodeIdMapCollection.idsByNodeKind.get(nodeKind);
+
+        if (maybeNodeIds?.size) {
+            binOpExprNodeIds.push(...maybeNodeIds.values());
+        }
+    }
+
+    for (const binOpExprId of binOpExprNodeIds) {
+        const maybeExprXorNode: TXorNode | undefined = NodeIdMapUtils.maybeXor(nodeIdMapCollection, binOpExprId);
+
+        if (maybeExprXorNode === undefined) {
+            continue;
+        }
+
+        const maybeOperatorXorNode: TXorNode | undefined = NodeIdMapUtils.maybeNthChild(
+            nodeIdMapCollection,
+            maybeExprXorNode.node.id,
+            1,
+        );
+
+        if (maybeOperatorXorNode === undefined || !XorNodeUtils.isAstXor(maybeOperatorXorNode)) {
+            continue;
+        }
+
+        const operatorAstNode: Ast.TConstant = maybeOperatorXorNode.node as Ast.TConstant;
+
+        const tokenType: SemanticTokenTypes = [
+            Ast.NodeKind.AsExpression,
+            Ast.NodeKind.IsExpression,
+            Ast.NodeKind.MetadataExpression,
+        ].includes(maybeExprXorNode.node.kind)
+            ? SemanticTokenTypes.keyword
+            : SemanticTokenTypes.operator;
+
+        tokens.push({
+            range: PositionUtils.createRangeFromTokenRange(operatorAstNode.tokenRange),
+            tokenModifiers: [],
+            tokenType,
+        });
+    }
+
+    trace.exit();
+
+    return tokens;
+}

--- a/src/powerquery-language-services/providers/nullSymbolProvider.ts
+++ b/src/powerquery-language-services/providers/nullSymbolProvider.ts
@@ -5,15 +5,17 @@ import { Location } from "vscode-languageserver-types";
 
 import {
     AutocompleteItemProviderContext,
-    ISymbolProvider,
+    ILocalDocumentProvider,
     OnIdentifierProviderContext,
+    PartialSemanticToken,
+    ProviderContext,
     SignatureProviderContext,
 } from "./commonTypes";
 import { Hover, SignatureHelp } from "../commonTypes";
 import { Inspection, Library } from "..";
 import { AutocompleteItem } from "../inspection/autocomplete";
 
-export class NullSymbolProvider implements ISymbolProvider {
+export class NullSymbolProvider implements ILocalDocumentProvider {
     public readonly externalTypeResolver: Inspection.ExternalType.TExternalTypeResolverFn =
         Inspection.ExternalType.noOpExternalTypeResolver;
     public readonly libraryDefinitions: Library.LibraryDefinitions = new Map();
@@ -43,6 +45,11 @@ export class NullSymbolProvider implements ISymbolProvider {
     // eslint-disable-next-line require-await
     public async getHover(_context: OnIdentifierProviderContext): Promise<Hover | null> {
         return null;
+    }
+
+    // eslint-disable-next-line require-await
+    public async getPartialSemanticTokens(_context: ProviderContext): Promise<PartialSemanticToken[]> {
+        return [];
     }
 
     // eslint-disable-next-line require-await

--- a/src/test/providers/slowSymbolProvider.ts
+++ b/src/test/providers/slowSymbolProvider.ts
@@ -7,15 +7,18 @@ import {
     AutocompleteItemProviderContext,
     Hover,
     IDefinitionProvider,
+    ISemanticTokenProvider,
     Library,
     LibrarySymbolProvider,
     OnIdentifierProviderContext,
+    PartialSemanticToken,
+    ProviderContext,
     SignatureHelp,
     SignatureProviderContext,
 } from "../../powerquery-language-services";
 import { AutocompleteItem } from "../../powerquery-language-services/inspection";
 
-export class SlowSymbolProvider extends LibrarySymbolProvider implements IDefinitionProvider {
+export class SlowSymbolProvider extends LibrarySymbolProvider implements IDefinitionProvider, ISemanticTokenProvider {
     private readonly delayInMS: number;
 
     constructor(library: Library.ILibrary, delayInMS: number) {
@@ -40,6 +43,11 @@ export class SlowSymbolProvider extends LibrarySymbolProvider implements IDefini
         await this.delay();
 
         return super.getHover(context);
+    }
+
+    // eslint-disable-next-line require-await
+    public async getPartialSemanticTokens(_context: ProviderContext): Promise<PartialSemanticToken[]> {
+        throw new Error("Method not implemented.");
     }
 
     public override async getSignatureHelp(context: SignatureProviderContext): Promise<SignatureHelp | null> {

--- a/src/test/testUtils/testUtils.ts
+++ b/src/test/testUtils/testUtils.ts
@@ -8,7 +8,7 @@ import { DocumentSymbol, Hover, Location, Position, SignatureHelp, SymbolKind } 
 
 import * as AnalysisUtils from "../../powerquery-language-services/analysis/analysisUtils";
 import * as TestConstants from "../testConstants";
-import { Analysis, Inspection } from "../../powerquery-language-services";
+import { Analysis, Inspection, PartialSemanticToken } from "../../powerquery-language-services";
 import { AnalysisSettings } from "../..";
 import { MockDocument } from "../mockDocument";
 
@@ -96,6 +96,13 @@ export function createDefinition(text: string, maybeAnalysisSettings?: AnalysisS
 
 export function createHover(text: string, maybeAnalysisSettings?: AnalysisSettings): Promise<Hover> {
     return createAnalysis(text, maybeAnalysisSettings).getHover();
+}
+
+export function createPartialSemanticTokens(
+    text: string,
+    maybeAnalysisSettings?: AnalysisSettings,
+): Promise<PartialSemanticToken[]> {
+    return createAnalysis(text, maybeAnalysisSettings).getPartialSemanticTokens();
 }
 
 export function createSignatureHelp(text: string, maybeAnalysisSettings?: AnalysisSettings): Promise<SignatureHelp> {


### PR DESCRIPTION
This is a MVP, not a final iteration. I'd like to get this in the hands of people to test it out.

The typing for semantic token isn't completely 1:1 across the packages, so it's packaged in this intermediary form designed to be consumed by the extension.