### PR TITLE
Refactor validate to follow the standard API return type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.6.4",
+    "version": "0.6.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/powerquery-language-services",
-            "version": "0.6.4",
+            "version": "0.6.5",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/powerquery-formatter": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.6.4",
+    "version": "0.6.5",
     "author": "Microsoft",
     "license": "MIT",
     "scripts": {

--- a/src/powerquery-language-services/validate/index.ts
+++ b/src/powerquery-language-services/validate/index.ts
@@ -3,4 +3,4 @@
 
 export { validate } from "./validate";
 export * from "./validationSettings";
-export * from "./validationOk";
+export * from "./validateOk";

--- a/src/powerquery-language-services/validate/index.ts
+++ b/src/powerquery-language-services/validate/index.ts
@@ -3,4 +3,4 @@
 
 export { validate } from "./validate";
 export * from "./validationSettings";
-export * from "./validationResult";
+export * from "./validationOk";

--- a/src/powerquery-language-services/validate/validate.ts
+++ b/src/powerquery-language-services/validate/validate.ts
@@ -7,92 +7,92 @@ import { TextDocument } from "vscode-languageserver-textdocument";
 import { Trace } from "@microsoft/powerquery-parser/lib/powerquery-parser/common/trace";
 
 import { Analysis, AnalysisSettings, AnalysisUtils } from "../analysis";
+import { CommonError, Result, ResultUtils } from "@microsoft/powerquery-parser";
 import { TypeCache } from "../inspection";
 import { validateDuplicateIdentifiers } from "./validateDuplicateIdentifiers";
 import { validateFunctionExpression } from "./validateFunctionExpression";
 import { validateInvokeExpression } from "./validateInvokeExpression";
 import { validateParse } from "./validateParse";
 import { validateUnknownIdentifiers } from "./validateUnknownIdentifiers";
-import type { ValidationResult } from "./validationResult";
+import type { ValidationOk } from "./validationOk";
 import type { ValidationSettings } from "./validationSettings";
 import { ValidationTraceConstant } from "../trace";
 
-export async function validate(
+export function validate(
     textDocument: TextDocument,
     analysisSettings: AnalysisSettings,
     validationSettings: ValidationSettings,
-): Promise<ValidationResult> {
-    const trace: Trace = validationSettings.traceManager.entry(
-        ValidationTraceConstant.Validation,
-        validate.name,
-        validationSettings.initialCorrelationId,
-    );
+): Promise<Result<ValidationOk | undefined, CommonError.CommonError>> {
+    return ResultUtils.ensureResultAsync(async () => {
+        const trace: Trace = validationSettings.traceManager.entry(
+            ValidationTraceConstant.Validation,
+            validate.name,
+            validationSettings.initialCorrelationId,
+        );
 
-    const updatedSettings: ValidationSettings = {
-        ...validationSettings,
-        initialCorrelationId: trace.id,
-    };
+        const updatedSettings: ValidationSettings = {
+            ...validationSettings,
+            initialCorrelationId: trace.id,
+        };
 
-    const analysis: Analysis = AnalysisUtils.createAnalysis(textDocument, analysisSettings);
-    const parseState: ParseState | undefined = await analysis.getParseState();
-    const parseError: ParseError.ParseError | undefined = await analysis.getParseError();
+        const analysis: Analysis = AnalysisUtils.createAnalysis(textDocument, analysisSettings);
+        const parseState: ParseState | undefined = await analysis.getParseState();
+        const parseError: ParseError.ParseError | undefined = await analysis.getParseError();
 
-    if (parseState === undefined) {
+        if (parseState === undefined) {
+            trace.exit();
+
+            return undefined;
+        }
+
+        let functionExpressionDiagnostics: Diagnostic[];
+        let invokeExpressionDiagnostics: Diagnostic[];
+        let unknownIdentifiersDiagnostics: Diagnostic[];
+
+        const nodeIdMapCollection: NodeIdMap.Collection = parseState.contextState.nodeIdMapCollection;
+        const typeCache: TypeCache = analysis.getTypeCache();
+
+        if (validationSettings.checkInvokeExpressions && nodeIdMapCollection) {
+            functionExpressionDiagnostics = validateFunctionExpression(validationSettings, nodeIdMapCollection);
+
+            invokeExpressionDiagnostics = await validateInvokeExpression(
+                validationSettings,
+                nodeIdMapCollection,
+                typeCache,
+            );
+        } else {
+            functionExpressionDiagnostics = [];
+            invokeExpressionDiagnostics = [];
+        }
+
+        if (validationSettings.checkUnknownIdentifiers && nodeIdMapCollection) {
+            unknownIdentifiersDiagnostics = await validateUnknownIdentifiers(
+                validationSettings,
+                nodeIdMapCollection,
+                typeCache,
+            );
+        } else {
+            unknownIdentifiersDiagnostics = [];
+        }
+
+        const result: ValidationOk = {
+            diagnostics: [
+                ...validateDuplicateIdentifiers(
+                    textDocument,
+                    nodeIdMapCollection,
+                    updatedSettings,
+                    validationSettings.cancellationToken,
+                ),
+                ...(await validateParse(parseError, updatedSettings)),
+                ...functionExpressionDiagnostics,
+                ...invokeExpressionDiagnostics,
+                ...unknownIdentifiersDiagnostics,
+            ],
+            hasSyntaxError: Boolean(await analysis.getParseError()),
+        };
+
         trace.exit();
 
-        return {
-            diagnostics: [],
-            hasSyntaxError: false,
-        };
-    }
-
-    let functionExpressionDiagnostics: Diagnostic[];
-    let invokeExpressionDiagnostics: Diagnostic[];
-    let unknownIdentifiersDiagnostics: Diagnostic[];
-
-    const nodeIdMapCollection: NodeIdMap.Collection = parseState.contextState.nodeIdMapCollection;
-    const typeCache: TypeCache = analysis.getTypeCache();
-
-    if (validationSettings.checkInvokeExpressions && nodeIdMapCollection) {
-        functionExpressionDiagnostics = validateFunctionExpression(validationSettings, nodeIdMapCollection);
-
-        invokeExpressionDiagnostics = await validateInvokeExpression(
-            validationSettings,
-            nodeIdMapCollection,
-            typeCache,
-        );
-    } else {
-        functionExpressionDiagnostics = [];
-        invokeExpressionDiagnostics = [];
-    }
-
-    if (validationSettings.checkUnknownIdentifiers && nodeIdMapCollection) {
-        unknownIdentifiersDiagnostics = await validateUnknownIdentifiers(
-            validationSettings,
-            nodeIdMapCollection,
-            typeCache,
-        );
-    } else {
-        unknownIdentifiersDiagnostics = [];
-    }
-
-    const result: ValidationResult = {
-        diagnostics: [
-            ...validateDuplicateIdentifiers(
-                textDocument,
-                nodeIdMapCollection,
-                updatedSettings,
-                validationSettings.cancellationToken,
-            ),
-            ...(await validateParse(parseError, updatedSettings)),
-            ...functionExpressionDiagnostics,
-            ...invokeExpressionDiagnostics,
-            ...unknownIdentifiersDiagnostics,
-        ],
-        hasSyntaxError: Boolean(await analysis.getParseError()),
-    };
-
-    trace.exit();
-
-    return result;
+        return result;
+    }, validationSettings.locale);
 }

--- a/src/powerquery-language-services/validate/validate.ts
+++ b/src/powerquery-language-services/validate/validate.ts
@@ -12,9 +12,9 @@ import { TypeCache } from "../inspection";
 import { validateDuplicateIdentifiers } from "./validateDuplicateIdentifiers";
 import { validateFunctionExpression } from "./validateFunctionExpression";
 import { validateInvokeExpression } from "./validateInvokeExpression";
+import type { ValidateOk } from "./validateOk";
 import { validateParse } from "./validateParse";
 import { validateUnknownIdentifiers } from "./validateUnknownIdentifiers";
-import type { ValidationOk } from "./validationOk";
 import type { ValidationSettings } from "./validationSettings";
 import { ValidationTraceConstant } from "../trace";
 
@@ -22,7 +22,7 @@ export function validate(
     textDocument: TextDocument,
     analysisSettings: AnalysisSettings,
     validationSettings: ValidationSettings,
-): Promise<Result<ValidationOk | undefined, CommonError.CommonError>> {
+): Promise<Result<ValidateOk | undefined, CommonError.CommonError>> {
     return ResultUtils.ensureResultAsync(async () => {
         const trace: Trace = validationSettings.traceManager.entry(
             ValidationTraceConstant.Validation,
@@ -75,7 +75,7 @@ export function validate(
             unknownIdentifiersDiagnostics = [];
         }
 
-        const result: ValidationOk = {
+        const result: ValidateOk = {
             diagnostics: [
                 ...validateDuplicateIdentifiers(
                     textDocument,

--- a/src/powerquery-language-services/validate/validateOk.ts
+++ b/src/powerquery-language-services/validate/validateOk.ts
@@ -3,7 +3,7 @@
 
 import type { Diagnostic } from "vscode-languageserver-types";
 
-export interface ValidationOk {
+export interface ValidateOk {
     readonly diagnostics: Diagnostic[];
     readonly hasSyntaxError: boolean;
 }

--- a/src/powerquery-language-services/validate/validationOk.ts
+++ b/src/powerquery-language-services/validate/validationOk.ts
@@ -3,7 +3,7 @@
 
 import type { Diagnostic } from "vscode-languageserver-types";
 
-export interface ValidationResult {
+export interface ValidationOk {
     readonly diagnostics: Diagnostic[];
     readonly hasSyntaxError: boolean;
 }

--- a/src/test/testUtils/assert.ts
+++ b/src/test/testUtils/assert.ts
@@ -26,7 +26,7 @@ import {
 } from "../../powerquery-language-services/inspection";
 import { Inspection, InspectionSettings, TextDocument, validate } from "../../powerquery-language-services";
 import { TriedExpectedType, tryExpectedType } from "../../powerquery-language-services/inspection/expectedType";
-import { ValidationResult } from "../../powerquery-language-services/validate/validationResult";
+import { ValidationOk } from "../../powerquery-language-services/validate/validationOk";
 
 export function assertAsMarkupContent(value: Hover["contents"]): MarkupContent {
     assertIsMarkupContent(value);
@@ -195,7 +195,7 @@ export function assertGetTextWithPosition(text: string): [string, Position] {
     return [text.replace("|", ""), position];
 }
 
-export async function assertGetValidationResult(document: TextDocument): Promise<ValidationResult> {
+export async function assertGetValidationResult(document: TextDocument): Promise<ValidationOk> {
     return await validate(
         document,
         TestConstants.SimpleLibraryAnalysisSettings,

--- a/src/test/validation/common.ts
+++ b/src/test/validation/common.ts
@@ -14,13 +14,13 @@ export async function expectLessWhenSurpressed(
 ): Promise<void> {
     const textDocument: PQLS.TextDocument = TestUtils.createTextMockDocument(text);
 
-    const withCheckResult: PQLS.ValidationOk = await PQLS.validate(
+    const withCheckResult: PQLS.ValidateOk = await TestUtils.assertGetValidateOk(
         textDocument,
         TestConstants.SimpleLibraryAnalysisSettings,
         withCheckSettings,
     );
 
-    const withoutCheckResult: PQLS.ValidationOk = await PQLS.validate(
+    const withoutCheckResult: PQLS.ValidateOk = await TestUtils.assertGetValidateOk(
         textDocument,
         TestConstants.SimpleLibraryAnalysisSettings,
         withoutCheckSettings,

--- a/src/test/validation/common.ts
+++ b/src/test/validation/common.ts
@@ -14,13 +14,13 @@ export async function expectLessWhenSurpressed(
 ): Promise<void> {
     const textDocument: PQLS.TextDocument = TestUtils.createTextMockDocument(text);
 
-    const withCheckResult: PQLS.ValidationResult = await PQLS.validate(
+    const withCheckResult: PQLS.ValidationOk = await PQLS.validate(
         textDocument,
         TestConstants.SimpleLibraryAnalysisSettings,
         withCheckSettings,
     );
 
-    const withoutCheckResult: PQLS.ValidationResult = await PQLS.validate(
+    const withoutCheckResult: PQLS.ValidationOk = await PQLS.validate(
         textDocument,
         TestConstants.SimpleLibraryAnalysisSettings,
         withoutCheckSettings,

--- a/src/test/validation/duplicateIdentifier.ts
+++ b/src/test/validation/duplicateIdentifier.ts
@@ -11,12 +11,11 @@ import {
     DiagnosticRelatedInformation,
     DiagnosticSeverity,
     Position,
-    validate,
     ValidationSettings,
 } from "../../powerquery-language-services";
 import { TestConstants, TestUtils } from "..";
 import { MockDocument } from "../mockDocument";
-import { ValidationOk } from "../../powerquery-language-services/validate/validationOk";
+import { ValidateOk } from "../../powerquery-language-services/validate/validateOk";
 
 function assertValidationError(diagnostic: Diagnostic, startPosition: Position): void {
     assert.isDefined(diagnostic.code);
@@ -27,7 +26,7 @@ function assertValidationError(diagnostic: Diagnostic, startPosition: Position):
 }
 
 async function expectNoValidationErrors(textDocument: MockDocument): Promise<void> {
-    const validationResult: ValidationOk = await validate(
+    const validationResult: ValidateOk = await TestUtils.assertGetValidateOk(
         textDocument,
         TestConstants.SimpleLibraryAnalysisSettings,
         DuplicateIdentifierSettings,
@@ -52,7 +51,7 @@ async function validateDuplicateIdentifierDiagnostics(
     textDocument: MockDocument,
     expected: ReadonlyArray<DuplicateIdentifierError>,
 ): Promise<void> {
-    const validationResult: ValidationOk = await validate(
+    const validationResult: ValidateOk = await TestUtils.assertGetValidateOk(
         textDocument,
         TestConstants.SimpleLibraryAnalysisSettings,
         DuplicateIdentifierSettings,
@@ -96,7 +95,7 @@ describe(`Validation - duplicateIdentifier`, () => {
         it("let 1", async () => {
             const errorSource: string = DuplicateIdentifierSettings.source;
 
-            const validationResult: ValidationOk = await validate(
+            const validationResult: ValidateOk = await TestUtils.assertGetValidateOk(
                 TestUtils.createTextMockDocument(`let 1`),
                 TestConstants.SimpleLibraryAnalysisSettings,
                 DuplicateIdentifierSettings,

--- a/src/test/validation/duplicateIdentifier.ts
+++ b/src/test/validation/duplicateIdentifier.ts
@@ -16,7 +16,7 @@ import {
 } from "../../powerquery-language-services";
 import { TestConstants, TestUtils } from "..";
 import { MockDocument } from "../mockDocument";
-import { ValidationResult } from "../../powerquery-language-services/validate/validationResult";
+import { ValidationOk } from "../../powerquery-language-services/validate/validationOk";
 
 function assertValidationError(diagnostic: Diagnostic, startPosition: Position): void {
     assert.isDefined(diagnostic.code);
@@ -27,7 +27,7 @@ function assertValidationError(diagnostic: Diagnostic, startPosition: Position):
 }
 
 async function expectNoValidationErrors(textDocument: MockDocument): Promise<void> {
-    const validationResult: ValidationResult = await validate(
+    const validationResult: ValidationOk = await validate(
         textDocument,
         TestConstants.SimpleLibraryAnalysisSettings,
         DuplicateIdentifierSettings,
@@ -52,7 +52,7 @@ async function validateDuplicateIdentifierDiagnostics(
     textDocument: MockDocument,
     expected: ReadonlyArray<DuplicateIdentifierError>,
 ): Promise<void> {
-    const validationResult: ValidationResult = await validate(
+    const validationResult: ValidationOk = await validate(
         textDocument,
         TestConstants.SimpleLibraryAnalysisSettings,
         DuplicateIdentifierSettings,
@@ -96,7 +96,7 @@ describe(`Validation - duplicateIdentifier`, () => {
         it("let 1", async () => {
             const errorSource: string = DuplicateIdentifierSettings.source;
 
-            const validationResult: ValidationResult = await validate(
+            const validationResult: ValidationOk = await validate(
                 TestUtils.createTextMockDocument(`let 1`),
                 TestConstants.SimpleLibraryAnalysisSettings,
                 DuplicateIdentifierSettings,

--- a/src/test/validation/functionExpression.ts
+++ b/src/test/validation/functionExpression.ts
@@ -4,16 +4,10 @@
 import "mocha";
 import { assert, expect } from "chai";
 
-import {
-    Diagnostic,
-    DiagnosticErrorCode,
-    DiagnosticSeverity,
-    Position,
-    validate,
-} from "../../powerquery-language-services";
+import { Diagnostic, DiagnosticErrorCode, DiagnosticSeverity, Position } from "../../powerquery-language-services";
 import { TestConstants, TestUtils } from "..";
 import { MockDocument } from "../mockDocument";
-import { ValidationOk } from "../../powerquery-language-services/validate/validationOk";
+import { ValidateOk } from "../../powerquery-language-services/validate/validateOk";
 
 function assertValidationError(diagnostic: Diagnostic, startPosition: Position): void {
     assert.isDefined(diagnostic.code);
@@ -24,7 +18,7 @@ function assertValidationError(diagnostic: Diagnostic, startPosition: Position):
 }
 
 async function expectNoValidationErrors(textDocument: MockDocument): Promise<void> {
-    const validationResult: ValidationOk = await validate(
+    const validationResult: ValidateOk = await TestUtils.assertGetValidateOk(
         textDocument,
         TestConstants.SimpleLibraryAnalysisSettings,
         TestConstants.SimpleValidateAllSettings,
@@ -45,7 +39,7 @@ describe(`Validation - functionExpression`, () => {
         it("(foo as number, foo as number) => foo * 2", async () => {
             const errorSource: string = TestConstants.SimpleValidateAllSettings.source;
 
-            const validationResult: ValidationOk = await validate(
+            const validationResult: ValidateOk = await TestUtils.assertGetValidateOk(
                 TestUtils.createTextMockDocument(`(foo as number, foo as number) => foo * 2`),
                 TestConstants.SimpleLibraryAnalysisSettings,
                 TestConstants.SimpleValidateAllSettings,

--- a/src/test/validation/functionExpression.ts
+++ b/src/test/validation/functionExpression.ts
@@ -13,7 +13,7 @@ import {
 } from "../../powerquery-language-services";
 import { TestConstants, TestUtils } from "..";
 import { MockDocument } from "../mockDocument";
-import { ValidationResult } from "../../powerquery-language-services/validate/validationResult";
+import { ValidationOk } from "../../powerquery-language-services/validate/validationOk";
 
 function assertValidationError(diagnostic: Diagnostic, startPosition: Position): void {
     assert.isDefined(diagnostic.code);
@@ -24,7 +24,7 @@ function assertValidationError(diagnostic: Diagnostic, startPosition: Position):
 }
 
 async function expectNoValidationErrors(textDocument: MockDocument): Promise<void> {
-    const validationResult: ValidationResult = await validate(
+    const validationResult: ValidationOk = await validate(
         textDocument,
         TestConstants.SimpleLibraryAnalysisSettings,
         TestConstants.SimpleValidateAllSettings,
@@ -45,7 +45,7 @@ describe(`Validation - functionExpression`, () => {
         it("(foo as number, foo as number) => foo * 2", async () => {
             const errorSource: string = TestConstants.SimpleValidateAllSettings.source;
 
-            const validationResult: ValidationResult = await validate(
+            const validationResult: ValidationOk = await validate(
                 TestUtils.createTextMockDocument(`(foo as number, foo as number) => foo * 2`),
                 TestConstants.SimpleLibraryAnalysisSettings,
                 TestConstants.SimpleValidateAllSettings,

--- a/src/test/validation/invokeExpression.ts
+++ b/src/test/validation/invokeExpression.ts
@@ -15,7 +15,7 @@ import {
 import { TestConstants, TestUtils } from "..";
 import { expectLessWhenSurpressed } from "./common";
 import { SimpleValidateAllSettings } from "../testConstants";
-import { ValidationOk } from "../../powerquery-language-services/validate/validationOk";
+import { ValidateOk } from "../../powerquery-language-services/validate/validateOk";
 
 interface AbridgedInvocationDiagnostic {
     readonly message: string;
@@ -32,7 +32,7 @@ const NumArgumentsPattern: RegExp = /Expected between (\d+)-(\d+) arguments, but
 async function expectGetInvokeExpressionDiagnostics(
     textDocument: TextDocument,
 ): Promise<ReadonlyArray<AbridgedInvocationDiagnostic>> {
-    const validationResult: ValidationOk = await TestUtils.assertGetValidationResult(textDocument);
+    const validationResult: ValidateOk = await TestUtils.assertGetValidateOk(textDocument);
     const diagnostics: Diagnostic[] = validationResult.diagnostics;
 
     return diagnostics

--- a/src/test/validation/invokeExpression.ts
+++ b/src/test/validation/invokeExpression.ts
@@ -15,7 +15,7 @@ import {
 import { TestConstants, TestUtils } from "..";
 import { expectLessWhenSurpressed } from "./common";
 import { SimpleValidateAllSettings } from "../testConstants";
-import { ValidationResult } from "../../powerquery-language-services/validate/validationResult";
+import { ValidationOk } from "../../powerquery-language-services/validate/validationOk";
 
 interface AbridgedInvocationDiagnostic {
     readonly message: string;
@@ -32,7 +32,7 @@ const NumArgumentsPattern: RegExp = /Expected between (\d+)-(\d+) arguments, but
 async function expectGetInvokeExpressionDiagnostics(
     textDocument: TextDocument,
 ): Promise<ReadonlyArray<AbridgedInvocationDiagnostic>> {
-    const validationResult: ValidationResult = await TestUtils.assertGetValidationResult(textDocument);
+    const validationResult: ValidationOk = await TestUtils.assertGetValidationResult(textDocument);
     const diagnostics: Diagnostic[] = validationResult.diagnostics;
 
     return diagnostics

--- a/src/test/validation/unknownIdentifiers.ts
+++ b/src/test/validation/unknownIdentifiers.ts
@@ -15,7 +15,7 @@ import {
 import { SimpleValidateNoneSettings, TestLibraryName } from "../testConstants";
 import { expectLessWhenSurpressed } from "./common";
 import { TestUtils } from "..";
-import { ValidationOk } from "../../powerquery-language-services/validate/validationOk";
+import { ValidateOk } from "../../powerquery-language-services/validate/validateOk";
 
 interface AbridgedUnknownIdentifierDiagnostic {
     readonly message: string;
@@ -32,7 +32,7 @@ const UnknownIdentifierSettings: ValidationSettings = {
 async function expectGetInvokeExpressionDiagnostics(
     textDocument: TextDocument,
 ): Promise<ReadonlyArray<AbridgedUnknownIdentifierDiagnostic>> {
-    const validationResult: ValidationOk = await TestUtils.assertGetValidationResult(textDocument);
+    const validationResult: ValidateOk = await TestUtils.assertGetValidateOk(textDocument);
     const diagnostics: Diagnostic[] = validationResult.diagnostics;
 
     return diagnostics

--- a/src/test/validation/unknownIdentifiers.ts
+++ b/src/test/validation/unknownIdentifiers.ts
@@ -15,7 +15,7 @@ import {
 import { SimpleValidateNoneSettings, TestLibraryName } from "../testConstants";
 import { expectLessWhenSurpressed } from "./common";
 import { TestUtils } from "..";
-import { ValidationResult } from "../../powerquery-language-services/validate/validationResult";
+import { ValidationOk } from "../../powerquery-language-services/validate/validationOk";
 
 interface AbridgedUnknownIdentifierDiagnostic {
     readonly message: string;
@@ -32,7 +32,7 @@ const UnknownIdentifierSettings: ValidationSettings = {
 async function expectGetInvokeExpressionDiagnostics(
     textDocument: TextDocument,
 ): Promise<ReadonlyArray<AbridgedUnknownIdentifierDiagnostic>> {
-    const validationResult: ValidationResult = await TestUtils.assertGetValidationResult(textDocument);
+    const validationResult: ValidationOk = await TestUtils.assertGetValidationResult(textDocument);
     const diagnostics: Diagnostic[] = validationResult.diagnostics;
 
     return diagnostics


### PR DESCRIPTION
Most public APIs on this layer return `Result<T | undefined, CommonError>`. The validate API should do the same.