### PR TITLE
Update LibraryDefinitions to have a dynamicLibraryDefinitions property

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.9.6",
+    "version": "0.10.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/powerquery-language-services",
-            "version": "0.9.6",
+            "version": "0.10.0",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/powerquery-formatter": "0.3.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.9.6",
+    "version": "0.10.0",
     "author": "Microsoft",
     "license": "MIT",
     "scripts": {

--- a/src/powerquery-language-services/library/index.ts
+++ b/src/powerquery-language-services/library/index.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 export * as Library from "./library";
+export * as LibraryDefinitionUtils from "./libraryDefinitionUtils";
 export * as LibrarySymbol from "./librarySymbol";
 export * as LibrarySymbolUtils from "./librarySymbolUtils";
 export * as LibraryUtils from "./libraryUtils";

--- a/src/powerquery-language-services/library/library.ts
+++ b/src/powerquery-language-services/library/library.ts
@@ -6,8 +6,6 @@ import { Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/languag
 
 import { ExternalType } from "../externalType";
 
-export type LibraryDefinitions = ReadonlyMap<string, TLibraryDefinition>;
-
 export type TLibraryDefinition = LibraryConstant | LibraryFunction | LibraryType;
 
 export enum LibraryDefinitionKind {
@@ -27,6 +25,13 @@ export interface ILibraryDefinition {
     readonly description: string;
     readonly kind: LibraryDefinitionKind;
     readonly label: string;
+}
+
+export interface LibraryDefinitions {
+    // Used by the host to inject library definitions, such as other files/queries.
+    readonly dynamicLibraryDefinitions: () => ReadonlyMap<string, TLibraryDefinition>;
+    // Standard library, not expected to change.
+    readonly staticLibraryDefinitions: ReadonlyMap<string, TLibraryDefinition>;
 }
 
 export interface LibraryConstant extends ILibraryDefinition {
@@ -52,5 +57,8 @@ export interface LibraryType extends ILibraryDefinition {
 
 export const NoOpLibrary: ILibrary = {
     externalTypeResolver: ExternalType.noOpExternalTypeResolver,
-    libraryDefinitions: new Map(),
+    libraryDefinitions: {
+        dynamicLibraryDefinitions: () => new Map<string, TLibraryDefinition>(),
+        staticLibraryDefinitions: new Map<string, TLibraryDefinition>(),
+    },
 };

--- a/src/powerquery-language-services/library/library.ts
+++ b/src/powerquery-language-services/library/library.ts
@@ -28,9 +28,10 @@ export interface ILibraryDefinition {
 }
 
 export interface LibraryDefinitions {
-    // Used by the host to inject library definitions, such as other files/queries.
+    /** Used by the host to inject library definitions,
+     * either because they're dynamically generated or if they prefer lazy evaluation. */
     readonly dynamicLibraryDefinitions: () => ReadonlyMap<string, TLibraryDefinition>;
-    // Standard library, not expected to change.
+    /** Represents an unchanging standard library. It's expected to never change. */
     readonly staticLibraryDefinitions: ReadonlyMap<string, TLibraryDefinition>;
 }
 

--- a/src/powerquery-language-services/library/libraryDefinitionUtils.ts
+++ b/src/powerquery-language-services/library/libraryDefinitionUtils.ts
@@ -1,0 +1,149 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { CompletionItemKind, ParameterInformation, SignatureInformation } from "vscode-languageserver-types";
+import { Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+
+import {
+    LibraryConstant,
+    LibraryDefinitionKind,
+    LibraryDefinitions,
+    LibraryFunction,
+    LibraryParameter,
+    LibraryType,
+    TLibraryDefinition,
+} from "./library";
+import { ExternalType } from "../externalType";
+
+export function assertAsConstant(definition: TLibraryDefinition | undefined): LibraryConstant {
+    assertIsConstant(definition);
+
+    return definition;
+}
+
+export function assertAsFunction(definition: TLibraryDefinition | undefined): LibraryFunction {
+    assertIsFunction(definition);
+
+    return definition;
+}
+
+export function assertAsType(definition: TLibraryDefinition | undefined): LibraryType {
+    assertIsType(definition);
+
+    return definition;
+}
+
+export function assertIsConstant(definition: TLibraryDefinition | undefined): asserts definition is LibraryConstant {
+    if (!isConstant(definition)) {
+        throw new Error(`expected definition to be ${LibraryDefinitionKind.Constant}`);
+    }
+}
+
+export function assertIsFunction(definition: TLibraryDefinition | undefined): asserts definition is LibraryFunction {
+    if (!isFunction(definition)) {
+        throw new Error(`expected definition to be ${LibraryDefinitionKind.Function}`);
+    }
+}
+
+export function assertIsType(definition: TLibraryDefinition | undefined): asserts definition is LibraryType {
+    if (!isType(definition)) {
+        throw new Error(`expected definition to be ${LibraryDefinitionKind.Type}`);
+    }
+}
+
+export function constantDefinition(
+    label: string,
+    description: string,
+    asType: Type.TPowerQueryType,
+    completionItemKind: CompletionItemKind,
+): LibraryConstant {
+    return {
+        kind: LibraryDefinitionKind.Constant,
+        asPowerQueryType: asType,
+        completionItemKind,
+        description,
+        label,
+    };
+}
+
+export function externalTypeResolver(libraryDefinitions: LibraryDefinitions): ExternalType.TExternalTypeResolverFn {
+    return (request: ExternalType.TExternalTypeRequest): Type.TPowerQueryType | undefined =>
+        getDefinition(libraryDefinitions, request.identifierLiteral)?.asPowerQueryType;
+}
+
+export function functionDefinition(
+    label: string,
+    description: string,
+    asType: Type.TPowerQueryType,
+    completionItemKind: CompletionItemKind,
+    parameters: ReadonlyArray<LibraryParameter>,
+): LibraryFunction {
+    return {
+        kind: LibraryDefinitionKind.Function,
+        asPowerQueryType: asType,
+        completionItemKind,
+        description,
+        label,
+        parameters,
+    };
+}
+
+export function getDefinition(
+    libraryDefinitions: LibraryDefinitions,
+    identifierLiteral: string,
+): TLibraryDefinition | undefined {
+    const staticDefinition: TLibraryDefinition | undefined =
+        libraryDefinitions.staticLibraryDefinitions.get(identifierLiteral);
+
+    if (staticDefinition) {
+        return staticDefinition;
+    }
+
+    const dynamicDefinition: TLibraryDefinition | undefined = libraryDefinitions
+        .dynamicLibraryDefinitions()
+        .get(identifierLiteral);
+
+    if (dynamicDefinition) {
+        return dynamicDefinition;
+    }
+
+    return undefined;
+}
+
+export function getKeys(libraryDefinitions: LibraryDefinitions): ReadonlyArray<string> {
+    return [
+        ...libraryDefinitions.staticLibraryDefinitions.keys(),
+        ...libraryDefinitions.dynamicLibraryDefinitions().keys(),
+    ];
+}
+
+export function hasDefinition(libraryDefinitions: LibraryDefinitions, key: string): boolean {
+    return getDefinition(libraryDefinitions, key) !== undefined;
+}
+
+export function isConstant(definition: TLibraryDefinition | undefined): definition is LibraryConstant {
+    return definition?.kind === LibraryDefinitionKind.Constant;
+}
+
+export function isFunction(definition: TLibraryDefinition | undefined): definition is LibraryFunction {
+    return definition?.kind === LibraryDefinitionKind.Function;
+}
+
+export function isType(definition: TLibraryDefinition | undefined): definition is LibraryType {
+    return definition?.kind === LibraryDefinitionKind.Type;
+}
+
+export function signatureInformation(libraryFunctionSignature: LibraryFunction): SignatureInformation {
+    return {
+        label: libraryFunctionSignature.label,
+        documentation: libraryFunctionSignature.description,
+        parameters: libraryFunctionSignature.parameters.map(parameterInformation),
+    };
+}
+
+export function parameterInformation(libraryParameter: LibraryParameter): ParameterInformation {
+    return {
+        label: libraryParameter.label,
+        documentation: undefined,
+    };
+}

--- a/src/powerquery-language-services/library/libraryDefinitionUtils.ts
+++ b/src/powerquery-language-services/library/libraryDefinitionUtils.ts
@@ -103,11 +103,7 @@ export function getDefinition(
         .dynamicLibraryDefinitions()
         .get(identifierLiteral);
 
-    if (dynamicDefinition) {
-        return dynamicDefinition;
-    }
-
-    return undefined;
+    return dynamicDefinition;
 }
 
 export function getKeys(libraryDefinitions: LibraryDefinitions): ReadonlyArray<string> {

--- a/src/powerquery-language-services/library/libraryDefinitionUtils.ts
+++ b/src/powerquery-language-services/library/libraryDefinitionUtils.ts
@@ -92,18 +92,10 @@ export function getDefinition(
     libraryDefinitions: LibraryDefinitions,
     identifierLiteral: string,
 ): TLibraryDefinition | undefined {
-    const staticDefinition: TLibraryDefinition | undefined =
-        libraryDefinitions.staticLibraryDefinitions.get(identifierLiteral);
-
-    if (staticDefinition) {
-        return staticDefinition;
-    }
-
-    const dynamicDefinition: TLibraryDefinition | undefined = libraryDefinitions
-        .dynamicLibraryDefinitions()
-        .get(identifierLiteral);
-
-    return dynamicDefinition;
+    return (
+        libraryDefinitions.staticLibraryDefinitions.get(identifierLiteral) ??
+        libraryDefinitions.dynamicLibraryDefinitions().get(identifierLiteral)
+    );
 }
 
 export function getKeys(libraryDefinitions: LibraryDefinitions): ReadonlyArray<string> {

--- a/src/powerquery-language-services/library/libraryUtils.ts
+++ b/src/powerquery-language-services/library/libraryUtils.ts
@@ -1,104 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { CompletionItemKind, ParameterInformation, SignatureInformation } from "vscode-languageserver-types";
+import { ParameterInformation, SignatureInformation } from "vscode-languageserver-types";
 import { Assert } from "@microsoft/powerquery-parser";
-import { Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 
-import {
-    LibraryConstant,
-    LibraryDefinitionKind,
-    LibraryDefinitions,
-    LibraryFunction,
-    LibraryParameter,
-    LibraryType,
-    TLibraryDefinition,
-} from "./library";
-import { ExternalType } from "../externalType";
+import { ILibrary, LibraryDefinitionKind, LibraryFunction, LibraryParameter, TLibraryDefinition } from "./library";
+import { LibraryDefinitionUtils } from ".";
 
-export function assertAsConstant(definition: TLibraryDefinition | undefined): LibraryConstant {
-    assertIsConstant(definition);
-
-    return definition;
+export function getDefinition(library: ILibrary, identifierLiteral: string): TLibraryDefinition | undefined {
+    return LibraryDefinitionUtils.getDefinition(library.libraryDefinitions, identifierLiteral);
 }
 
-export function assertAsFunction(definition: TLibraryDefinition | undefined): LibraryFunction {
-    assertIsFunction(definition);
-
-    return definition;
+export function getDefinitionKeys(library: ILibrary): ReadonlyArray<string> {
+    return LibraryDefinitionUtils.getKeys(library.libraryDefinitions);
 }
 
-export function assertAsType(definition: TLibraryDefinition | undefined): LibraryType {
-    assertIsType(definition);
-
-    return definition;
-}
-
-export function assertIsConstant(definition: TLibraryDefinition | undefined): asserts definition is LibraryConstant {
-    if (!isConstant(definition)) {
-        throw new Error(`expected definition to be ${LibraryDefinitionKind.Constant}`);
-    }
-}
-
-export function assertIsFunction(definition: TLibraryDefinition | undefined): asserts definition is LibraryFunction {
-    if (!isFunction(definition)) {
-        throw new Error(`expected definition to be ${LibraryDefinitionKind.Function}`);
-    }
-}
-
-export function assertIsType(definition: TLibraryDefinition | undefined): asserts definition is LibraryType {
-    if (!isType(definition)) {
-        throw new Error(`expected definition to be ${LibraryDefinitionKind.Type}`);
-    }
-}
-
-export function constantDefinition(
-    label: string,
-    description: string,
-    asType: Type.TPowerQueryType,
-    completionItemKind: CompletionItemKind,
-): LibraryConstant {
-    return {
-        kind: LibraryDefinitionKind.Constant,
-        asPowerQueryType: asType,
-        completionItemKind,
-        description,
-        label,
-    };
-}
-
-export function externalTypeResolver(libraryDefinitions: LibraryDefinitions): ExternalType.TExternalTypeResolverFn {
-    return (request: ExternalType.TExternalTypeRequest): Type.TPowerQueryType | undefined =>
-        libraryDefinitions.get(request.identifierLiteral)?.asPowerQueryType;
-}
-
-export function functionDefinition(
-    label: string,
-    description: string,
-    asType: Type.TPowerQueryType,
-    completionItemKind: CompletionItemKind,
-    parameters: ReadonlyArray<LibraryParameter>,
-): LibraryFunction {
-    return {
-        kind: LibraryDefinitionKind.Function,
-        asPowerQueryType: asType,
-        completionItemKind,
-        description,
-        label,
-        parameters,
-    };
-}
-
-export function isConstant(definition: TLibraryDefinition | undefined): definition is LibraryConstant {
-    return definition?.kind === LibraryDefinitionKind.Constant;
-}
-
-export function isFunction(definition: TLibraryDefinition | undefined): definition is LibraryFunction {
-    return definition?.kind === LibraryDefinitionKind.Function;
-}
-
-export function isType(definition: TLibraryDefinition | undefined): definition is LibraryType {
-    return definition?.kind === LibraryDefinitionKind.Type;
+export function hasDefinition(library: ILibrary, key: string): boolean {
+    return LibraryDefinitionUtils.hasDefinition(library.libraryDefinitions, key);
 }
 
 export function signatureInformation(libraryFunctionSignature: LibraryFunction): SignatureInformation {

--- a/src/powerquery-language-services/providers/localDocumentProvider/partialSemanticToken.ts
+++ b/src/powerquery-language-services/providers/localDocumentProvider/partialSemanticToken.ts
@@ -259,7 +259,7 @@ function getIdentifierExpressionTokens(
             case Ast.IdentifierContextKind.Value:
                 tokenType = SemanticTokenTypes.variable;
 
-                if (libraryDefinitions.has(identifierExpr.identifier.literal)) {
+                if (libraryDefinitions.staticLibraryDefinitions.has(identifierExpr.identifier.literal)) {
                     tokenModifiers = [SemanticTokenModifiers.defaultLibrary];
                 }
 

--- a/src/powerquery-language-services/providers/nullSymbolProvider.ts
+++ b/src/powerquery-language-services/providers/nullSymbolProvider.ts
@@ -36,7 +36,10 @@ export class NullSymbolProvider
         ISignatureHelpProvider
 {
     public readonly externalTypeResolver: ExternalType.TExternalTypeResolverFn = ExternalType.noOpExternalTypeResolver;
-    public readonly libraryDefinitions: Library.LibraryDefinitions = new Map();
+    public readonly libraryDefinitions: Library.LibraryDefinitions = {
+        dynamicLibraryDefinitions: () => new Map(),
+        staticLibraryDefinitions: new Map(),
+    };
 
     private static instance: NullSymbolProvider | undefined;
 

--- a/src/powerquery-language-services/validate/validateUnknownIdentifiers.ts
+++ b/src/powerquery-language-services/validate/validateUnknownIdentifiers.ts
@@ -7,7 +7,7 @@ import { NodeIdMap, NodeIdMapUtils } from "@microsoft/powerquery-parser/lib/powe
 import { Ast } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 import { Trace } from "@microsoft/powerquery-parser/lib/powerquery-parser/common/trace";
 
-import { Inspection, PositionUtils } from "..";
+import { Inspection, LibraryUtils, PositionUtils } from "..";
 import { Localization, LocalizationUtils } from "../localization";
 import { calculateJaroWinklers } from "../jaroWinkler";
 import { DiagnosticErrorCode } from "../diagnosticErrorCode";
@@ -140,7 +140,7 @@ function findUnknownIdentifiers(
         if (
             !nodeScope.has(literal) &&
             !(literal[0] === "@" && nodeScope.has(literal.slice(1))) &&
-            !validationSettings.library.libraryDefinitions.has(literal) &&
+            !LibraryUtils.hasDefinition(validationSettings.library, literal) &&
             // even no external type found
             !validationSettings.library.externalTypeResolver({
                 kind: ExternalTypeRequestKind.Value,
@@ -149,7 +149,7 @@ function findUnknownIdentifiers(
         ) {
             const knownIdentifiers: ReadonlyArray<string> = [
                 ...nodeScope.keys(),
-                ...validationSettings.library.libraryDefinitions.keys(),
+                ...LibraryUtils.getDefinitionKeys(validationSettings.library),
             ];
 
             const [jaroWinklerScore, suggestion]: [number, string] = calculateJaroWinklers(literal, knownIdentifiers);

--- a/src/test/inspection/type.ts
+++ b/src/test/inspection/type.ts
@@ -50,7 +50,10 @@ describe(`Inspection - Type`, () => {
         isWorkspaceCacheAllowed: false,
         library: {
             externalTypeResolver: ExternalTypeResolver,
-            libraryDefinitions: new Map(),
+            libraryDefinitions: {
+                dynamicLibraryDefinitions: () => new Map(),
+                staticLibraryDefinitions: new Map(),
+            },
         },
         eachScopeById: undefined,
         typeStrategy: TypeStrategy.Extended,

--- a/src/test/library.ts
+++ b/src/test/library.ts
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { expect } from "chai";
+import { Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+
+import { CompletionItemKind, Library, LibraryDefinitionUtils } from "../powerquery-language-services";
+import { TestConstants } from ".";
+
+describe("Library", () => {
+    function createLibrary(params: {
+        readonly staticLibraryDefinitions?: ReadonlyMap<string, Library.TLibraryDefinition>;
+        readonly dynamicLibraryDefinitions?: () => ReadonlyMap<string, Library.TLibraryDefinition>;
+    }): Library.ILibrary {
+        const dynamicLibraryDefinitions: () => ReadonlyMap<string, Library.TLibraryDefinition> =
+            params.dynamicLibraryDefinitions ?? TestConstants.EmptyLibrary.libraryDefinitions.dynamicLibraryDefinitions;
+
+        const staticLibraryDefinitions: ReadonlyMap<string, Library.TLibraryDefinition> =
+            params.staticLibraryDefinitions ?? TestConstants.EmptyLibrary.libraryDefinitions.staticLibraryDefinitions;
+
+        return {
+            ...TestConstants.EmptyLibrary,
+            externalTypeResolver: TestConstants.EmptyLibrary.externalTypeResolver,
+            libraryDefinitions: {
+                ...TestConstants.EmptyLibrary.libraryDefinitions,
+                dynamicLibraryDefinitions,
+                staticLibraryDefinitions,
+            },
+        };
+    }
+
+    describe("LibraryDefinitionUtils", () => {
+        describe("getDefinition and hasDefinition", () => {
+            function runTest(params: {
+                readonly library: Library.ILibrary;
+                readonly key: string;
+                readonly isExpected: boolean;
+            }): void {
+                const hasResult: boolean = LibraryDefinitionUtils.hasDefinition(
+                    params.library.libraryDefinitions,
+                    params.key,
+                );
+
+                const getResult: Library.TLibraryDefinition | undefined = LibraryDefinitionUtils.getDefinition(
+                    params.library.libraryDefinitions,
+                    params.key,
+                );
+
+                if (params.isExpected) {
+                    expect(hasResult).to.equal(true);
+                    expect(getResult).to.not.equal(undefined);
+                } else {
+                    expect(hasResult).to.equal(false);
+                    expect(getResult).to.equal(undefined);
+                }
+            }
+
+            const numberDefinition: Library.TLibraryDefinition = LibraryDefinitionUtils.constantDefinition(
+                TestConstants.TestLibraryName.Number,
+                "number",
+                Type.NumberInstance,
+                CompletionItemKind.Constant,
+            );
+
+            it("static ", () => {
+                const library: Library.ILibrary = createLibrary({
+                    staticLibraryDefinitions: new Map([[TestConstants.TestLibraryName.Number, numberDefinition]]),
+                });
+
+                runTest({ library, key: TestConstants.TestLibraryName.Number, isExpected: true });
+                runTest({ library, key: "doesn't exist", isExpected: false });
+            });
+
+            it("dynamic ", () => {
+                const library: Library.ILibrary = createLibrary({
+                    dynamicLibraryDefinitions: () =>
+                        new Map([[TestConstants.TestLibraryName.Number, numberDefinition]]),
+                });
+
+                runTest({ library, key: TestConstants.TestLibraryName.Number, isExpected: true });
+                runTest({ library, key: "doesn't exist", isExpected: false });
+            });
+        });
+    });
+});

--- a/src/test/testConstants.ts
+++ b/src/test/testConstants.ts
@@ -12,15 +12,17 @@ import {
     ExternalType,
     InspectionSettings,
     Library,
-    LibraryUtils,
+    LibraryDefinitionUtils,
     TypeStrategy,
     ValidationSettings,
 } from "../powerquery-language-services";
 
 export enum TestLibraryName {
-    CreateFooAndBarRecord = "Test.CreateFooAndBarRecord",
     CombineNumberAndOptionalText = "Test.CombineNumberAndOptionalText",
+    CreateFooAndBarRecord = "Test.CreateFooAndBarRecord",
     DuplicateText = "Test.DuplicateText",
+    DynamicFunction = "Test.DynamicFunction",
+    DynamicValue = "Test.DynamicValue",
     Number = "Test.Number",
     NumberOne = "Test.NumberOne",
     SquareIfNumber = "Test.SquareIfNumber",
@@ -92,80 +94,104 @@ export const DuplicateTextDefinedFunction: Type.DefinedFunction = TypeUtils.defi
     Type.TextInstance,
 );
 
-export const SimpleLibraryDefinitions: Library.LibraryDefinitions = new Map<string, Library.TLibraryDefinition>([
-    [
-        TestLibraryName.CreateFooAndBarRecord,
-        LibraryUtils.functionDefinition(
+export const SimpleLibraryDefinitions: Library.LibraryDefinitions = {
+    dynamicLibraryDefinitions: () =>
+        new Map<string, Library.TLibraryDefinition>([
+            [
+                TestLibraryName.DynamicFunction,
+                LibraryDefinitionUtils.functionDefinition(
+                    TestLibraryName.DynamicFunction,
+                    `The name is ${TestLibraryName.DynamicFunction}`,
+                    TypeUtils.definedFunction(false, [], Type.AnyInstance),
+                    CompletionItemKind.Function,
+                    [],
+                ),
+            ],
+            [
+                TestLibraryName.DynamicValue,
+                LibraryDefinitionUtils.constantDefinition(
+                    TestLibraryName.DynamicValue,
+                    `The name is ${TestLibraryName.DynamicValue}`,
+                    Type.AnyInstance,
+                    CompletionItemKind.Value,
+                ),
+            ],
+        ]),
+    staticLibraryDefinitions: new Map<string, Library.TLibraryDefinition>([
+        [
             TestLibraryName.CreateFooAndBarRecord,
-            `The name is ${TestLibraryName.CreateFooAndBarRecord}`,
-            CreateFooAndBarRecordDefinedFunction,
-            CompletionItemKind.Function,
-            [],
-        ),
-    ],
-    [
-        TestLibraryName.Number,
-        LibraryUtils.constantDefinition(
+            LibraryDefinitionUtils.functionDefinition(
+                TestLibraryName.CreateFooAndBarRecord,
+                `The name is ${TestLibraryName.CreateFooAndBarRecord}`,
+                CreateFooAndBarRecordDefinedFunction,
+                CompletionItemKind.Function,
+                [],
+            ),
+        ],
+        [
             TestLibraryName.Number,
-            `The name is ${TestLibraryName.Number}`,
-            Type.NumberInstance,
-            CompletionItemKind.Value,
-        ),
-    ],
-    [
-        TestLibraryName.CombineNumberAndOptionalText,
-        LibraryUtils.functionDefinition(
+            LibraryDefinitionUtils.constantDefinition(
+                TestLibraryName.Number,
+                `The name is ${TestLibraryName.Number}`,
+                Type.NumberInstance,
+                CompletionItemKind.Value,
+            ),
+        ],
+        [
             TestLibraryName.CombineNumberAndOptionalText,
-            `The name is ${TestLibraryName.CombineNumberAndOptionalText}`,
-            CombineNumberAndOptionalTextDefinedFunction,
-            CompletionItemKind.Function,
-            [
-                {
-                    isNullable: false,
-                    isOptional: false,
-                    label: "firstArg",
-                    documentation: undefined,
-                    typeKind: Type.TypeKind.Number,
-                },
-                {
-                    isNullable: false,
-                    isOptional: true,
-                    label: "secondArg",
-                    documentation: undefined,
-                    typeKind: Type.TypeKind.Text,
-                },
-            ],
-        ),
-    ],
-    [
-        TestLibraryName.NumberOne,
-        LibraryUtils.constantDefinition(
+            LibraryDefinitionUtils.functionDefinition(
+                TestLibraryName.CombineNumberAndOptionalText,
+                `The name is ${TestLibraryName.CombineNumberAndOptionalText}`,
+                CombineNumberAndOptionalTextDefinedFunction,
+                CompletionItemKind.Function,
+                [
+                    {
+                        isNullable: false,
+                        isOptional: false,
+                        label: "firstArg",
+                        documentation: undefined,
+                        typeKind: Type.TypeKind.Number,
+                    },
+                    {
+                        isNullable: false,
+                        isOptional: true,
+                        label: "secondArg",
+                        documentation: undefined,
+                        typeKind: Type.TypeKind.Text,
+                    },
+                ],
+            ),
+        ],
+        [
             TestLibraryName.NumberOne,
-            `The name is ${TestLibraryName.NumberOne}`,
-            TypeUtils.numberLiteral(false, "1"),
-            CompletionItemKind.Constant,
-        ),
-    ],
-    [
-        TestLibraryName.SquareIfNumber,
-        LibraryUtils.functionDefinition(
+            LibraryDefinitionUtils.constantDefinition(
+                TestLibraryName.NumberOne,
+                `The name is ${TestLibraryName.NumberOne}`,
+                TypeUtils.numberLiteral(false, "1"),
+                CompletionItemKind.Constant,
+            ),
+        ],
+        [
             TestLibraryName.SquareIfNumber,
-            `The name is ${TestLibraryName.SquareIfNumber}`,
-            SquareIfNumberDefinedFunction,
-            CompletionItemKind.Function,
-            [
-                {
-                    isNullable: false,
-                    isOptional: false,
-                    label: "x",
-                    documentation:
-                        "If the argument is a number then multiply it by itself, otherwise return argument as-is.",
-                    typeKind: Type.TypeKind.Any,
-                },
-            ],
-        ),
-    ],
-]);
+            LibraryDefinitionUtils.functionDefinition(
+                TestLibraryName.SquareIfNumber,
+                `The name is ${TestLibraryName.SquareIfNumber}`,
+                SquareIfNumberDefinedFunction,
+                CompletionItemKind.Function,
+                [
+                    {
+                        isNullable: false,
+                        isOptional: false,
+                        label: "x",
+                        documentation:
+                            "If the argument is a number then multiply it by itself, otherwise return argument as-is.",
+                        typeKind: Type.TypeKind.Any,
+                    },
+                ],
+            ),
+        ],
+    ]),
+};
 
 export const SimpleExternalTypeResolver: ExternalType.TExternalTypeResolverFn = (
     request: ExternalType.TExternalTypeRequest,
@@ -231,6 +257,14 @@ export const SimpleExternalTypeResolver: ExternalType.TExternalTypeResolverFn = 
 export const SimpleLibrary: Library.ILibrary = {
     externalTypeResolver: SimpleExternalTypeResolver,
     libraryDefinitions: SimpleLibraryDefinitions,
+};
+
+export const EmptyLibrary: Library.ILibrary = {
+    externalTypeResolver: (_request: ExternalType.TExternalTypeRequest) => undefined,
+    libraryDefinitions: {
+        dynamicLibraryDefinitions: () => new Map<string, Library.TLibraryDefinition>(),
+        staticLibraryDefinitions: new Map<string, Library.TLibraryDefinition>(),
+    },
 };
 
 export const SimpleInspectionSettings: InspectionSettings = {


### PR DESCRIPTION
- Shifts several functions from `LibraryUtils` to `LibraryDefinitionUtils`
- Modified `LibraryDefinitions` from being a map to an interface holding two maps:
    - `dynamicLibraryDefinitions`: a function which returns a map of definitions. It allows the host to do lazy/dynamic injections of definitions
    - `staticLibraryDefinitions`: a map which is expected to never change once given

I like the name `staticLibraryDefinitions`, but I'm not sold on the dynamic name.