### PR TITLE
Update LibrarySymbolUtils.createLibrary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.10.1",
+    "version": "0.10.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/powerquery-language-services",
-            "version": "0.10.1",
+            "version": "0.10.2",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/powerquery-formatter": "0.3.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.10.1",
+    "version": "0.10.2",
     "author": "Microsoft",
     "license": "MIT",
     "scripts": {

--- a/src/powerquery-language-services/library/librarySymbolUtils.ts
+++ b/src/powerquery-language-services/library/librarySymbolUtils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Assert, PartialResult, PartialResultUtils } from "@microsoft/powerquery-parser";
+import { ArrayUtils, ErrorResult, Result, ResultUtils } from "@microsoft/powerquery-parser";
 import { Constant, ConstantUtils, Type, TypeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 import { NoOpTraceManagerInstance } from "@microsoft/powerquery-parser/lib/powerquery-parser/common/trace";
 
@@ -10,45 +10,61 @@ import { Library, LibraryDefinitionUtils } from "../library";
 import { LibrarySymbol, LibrarySymbolFunctionParameter } from "./librarySymbol";
 import { CompletionItemKind } from "../commonTypes";
 
-export type IncompleteLibrary = {
+// Created when non-zero conversion errors occur.
+export interface IncompleteLibrary {
     readonly library: Library.ILibrary;
-    readonly invalidSymbols: ReadonlyArray<LibrarySymbol>;
-};
+    readonly failedLibrarySymbolConversions: ReadonlyArray<FailedLibrarySymbolConversion>;
+}
 
-export type IncompleteLibraryDefinitions = {
+export interface IncompleteLibraryDefinitions {
     readonly libraryDefinitions: ReadonlyMap<string, Library.TLibraryDefinition>;
-    readonly invalidSymbols: ReadonlyArray<LibrarySymbol>;
-};
+    readonly failedLibrarySymbolConversions: ReadonlyArray<FailedLibrarySymbolConversion>;
+}
 
+export interface FailedLibrarySymbolConversion {
+    readonly librarySymbol: LibrarySymbol;
+    readonly kind: FailedLibrarySymbolConversionKind;
+}
+
+export interface FailedLibrarySymbolParameterConversion extends FailedLibrarySymbolConversion {
+    readonly kind: FailedLibrarySymbolConversionKind.Parameter;
+    readonly index: number;
+}
+
+export enum FailedLibrarySymbolConversionKind {
+    AsPowerQueryType = "AsPowerQueryType",
+    CompletionItemKind = "CompletionItemKind",
+    Parameter = "Parameter",
+    PrimitiveType = "PrimitiveType",
+}
+
+// Always returns a library, even if there are failed library symbol conversions.
+// An Ok result indicates that all library symbols were successfully converted.
+// An Error result indicates that some library symbols failed to convert.
 export function createLibrary(
     librarySymbols: ReadonlyArray<LibrarySymbol>,
     dynamicLibraryDefinitions: () => ReadonlyMap<string, Library.TLibraryDefinition>,
     externalTypeResolverFn: ExternalType.TExternalTypeResolverFn | undefined,
-): PartialResult<Library.ILibrary, IncompleteLibrary, ReadonlyArray<LibrarySymbol>> {
-    const libraryDefinitionsResult: PartialResult<
+): Result<Library.ILibrary, IncompleteLibrary> {
+    const libraryDefinitionsResult: Result<
         ReadonlyMap<string, Library.TLibraryDefinition>,
-        IncompleteLibraryDefinitions,
-        ReadonlyArray<LibrarySymbol>
+        IncompleteLibraryDefinitions
     > = createLibraryDefinitions(librarySymbols);
 
-    let librarySymbolDefinitions: ReadonlyMap<string, Library.TLibraryDefinition>;
-    let invalidSymbols: ReadonlyArray<LibrarySymbol>;
+    let staticLibraryDefinitions: ReadonlyMap<string, Library.TLibraryDefinition>;
+    let failedLibrarySymbolConversions: ReadonlyArray<FailedLibrarySymbolConversion>;
 
-    if (PartialResultUtils.isOk(libraryDefinitionsResult)) {
-        librarySymbolDefinitions = libraryDefinitionsResult.value;
-        invalidSymbols = [];
-    } else if (PartialResultUtils.isIncomplete(libraryDefinitionsResult)) {
-        librarySymbolDefinitions = libraryDefinitionsResult.partial.libraryDefinitions;
-        invalidSymbols = libraryDefinitionsResult.partial.invalidSymbols;
-    } else if (PartialResultUtils.isError(libraryDefinitionsResult)) {
-        return PartialResultUtils.error(libraryDefinitionsResult.error);
+    if (ResultUtils.isOk(libraryDefinitionsResult)) {
+        staticLibraryDefinitions = libraryDefinitionsResult.value;
+        failedLibrarySymbolConversions = [];
     } else {
-        Assert.isNever(libraryDefinitionsResult);
+        staticLibraryDefinitions = libraryDefinitionsResult.error.libraryDefinitions;
+        failedLibrarySymbolConversions = libraryDefinitionsResult.error.failedLibrarySymbolConversions;
     }
 
     const libraryDefinitions: Library.LibraryDefinitions = {
         dynamicLibraryDefinitions,
-        staticLibraryDefinitions: librarySymbolDefinitions,
+        staticLibraryDefinitions,
     };
 
     const definitionResolverFn: ExternalType.TExternalTypeResolverFn =
@@ -61,71 +77,71 @@ export function createLibrary(
         libraryDefinitions,
     };
 
-    if (invalidSymbols.length > 0) {
-        return PartialResultUtils.incomplete({
+    if (failedLibrarySymbolConversions.length > 0) {
+        return ResultUtils.error({
             library,
-            invalidSymbols,
+            failedLibrarySymbolConversions,
         });
     } else {
-        return PartialResultUtils.ok(library);
+        return ResultUtils.ok(library);
     }
 }
 
 export function createLibraryDefinitions(
     librarySymbols: ReadonlyArray<LibrarySymbol>,
-): PartialResult<
-    ReadonlyMap<string, Library.TLibraryDefinition>,
-    IncompleteLibraryDefinitions,
-    ReadonlyArray<LibrarySymbol>
-> {
+): Result<ReadonlyMap<string, Library.TLibraryDefinition>, IncompleteLibraryDefinitions> {
     const libraryDefinitions: Map<string, Library.TLibraryDefinition> = new Map<string, Library.TLibraryDefinition>();
-    const invalidSymbols: LibrarySymbol[] = [];
+    const failedLibrarySymbolConversions: FailedLibrarySymbolConversion[] = [];
 
     for (const librarySymbol of librarySymbols) {
-        const libraryDefinition: Library.TLibraryDefinition | undefined =
+        const libraryDefinitionResult: Result<Library.TLibraryDefinition, FailedLibrarySymbolConversion> =
             librarySymbolToLibraryDefinition(librarySymbol);
 
-        if (libraryDefinition === undefined) {
-            invalidSymbols.push(librarySymbol);
+        if (ResultUtils.isOk(libraryDefinitionResult)) {
+            libraryDefinitions.set(librarySymbol.name, libraryDefinitionResult.value);
         } else {
-            libraryDefinitions.set(librarySymbol.name, libraryDefinition);
+            failedLibrarySymbolConversions.push(libraryDefinitionResult.error);
         }
     }
 
-    if (invalidSymbols.length === 0) {
-        return PartialResultUtils.ok(libraryDefinitions);
-    } else if (libraryDefinitions.size > 0) {
-        return PartialResultUtils.incomplete({
-            libraryDefinitions,
-            invalidSymbols,
-        });
+    if (failedLibrarySymbolConversions.length === 0) {
+        return ResultUtils.ok(libraryDefinitions);
     } else {
-        return PartialResultUtils.error(invalidSymbols);
+        return ResultUtils.error({
+            libraryDefinitions,
+            failedLibrarySymbolConversions,
+        });
     }
 }
 
-export function librarySymbolToLibraryDefinition(librarySymbol: LibrarySymbol): Library.TLibraryDefinition | undefined {
+export function librarySymbolToLibraryDefinition(
+    librarySymbol: LibrarySymbol,
+): Result<Library.TLibraryDefinition, FailedLibrarySymbolConversion> {
     const primitiveType: Type.TPrimitiveType | undefined = stringToPrimitiveType(librarySymbol.type);
 
     const completionItemKind: CompletionItemKind | undefined = numberToCompletionItemKind(
         librarySymbol.completionItemKind,
     );
 
-    if (primitiveType === undefined || completionItemKind === undefined) {
-        return undefined;
+    if (primitiveType === undefined) {
+        return failedConversionError(librarySymbol, FailedLibrarySymbolConversionKind.PrimitiveType);
+    }
+
+    if (completionItemKind === undefined) {
+        return failedConversionError(librarySymbol, FailedLibrarySymbolConversionKind.CompletionItemKind);
     }
 
     const label: string = librarySymbol.name;
     const description: string = librarySymbol.documentation?.description ?? "No description available";
 
     if (primitiveType.kind === Type.TypeKind.Type) {
-        return {
+        return ResultUtils.ok({
             kind: Library.LibraryDefinitionKind.Type,
             label,
             description,
             asPowerQueryType: primitiveType,
             completionItemKind,
-        };
+        });
     } else if (librarySymbol.functionParameters) {
         const asPowerQueryType: Type.DefinedFunction | undefined = librarySymbolFunctionSignatureToType(
             librarySymbol,
@@ -133,39 +149,60 @@ export function librarySymbolToLibraryDefinition(librarySymbol: LibrarySymbol): 
         );
 
         if (asPowerQueryType === undefined) {
-            return undefined;
+            return failedConversionError(librarySymbol, FailedLibrarySymbolConversionKind.AsPowerQueryType);
         }
 
         const parameters: Library.LibraryParameter[] = [];
 
-        for (const parameter of librarySymbol.functionParameters) {
+        for (const [parameter, index] of ArrayUtils.enumerate(librarySymbol.functionParameters)) {
             const libraryParameter: Library.LibraryParameter | undefined =
                 librarySymbolFunctionParameterToLibraryParameter(parameter);
 
             if (libraryParameter === undefined) {
-                return undefined;
+                return failedParameterConversionError(librarySymbol, index);
             }
 
             parameters.push(libraryParameter);
         }
 
-        return {
+        return ResultUtils.ok({
             kind: Library.LibraryDefinitionKind.Function,
             label: TypeUtils.nameOf(asPowerQueryType, NoOpTraceManagerInstance, undefined),
             description,
             asPowerQueryType,
             completionItemKind,
             parameters,
-        };
+        });
     } else {
-        return {
+        return ResultUtils.ok({
             kind: Library.LibraryDefinitionKind.Constant,
             label,
             description,
             asPowerQueryType: primitiveType,
             completionItemKind,
-        };
+        });
     }
+}
+
+function failedConversionError(
+    libarySymbol: LibrarySymbol,
+    kind: FailedLibrarySymbolConversionKind,
+): ErrorResult<FailedLibrarySymbolConversion> {
+    return ResultUtils.error({
+        librarySymbol: libarySymbol,
+        kind,
+    });
+}
+
+function failedParameterConversionError(
+    libarySymbol: LibrarySymbol,
+    index: number,
+): ErrorResult<FailedLibrarySymbolParameterConversion> {
+    return ResultUtils.error({
+        librarySymbol: libarySymbol,
+        kind: FailedLibrarySymbolConversionKind.Parameter,
+        index,
+    });
 }
 
 function librarySymbolFunctionSignatureToType(


### PR DESCRIPTION
1. Simplifies the contract from a `PartialResult` to `Result`
1. Library symbols which failed a conversion will report why they failed