### PR TITLE
Fix infinite recursion for "each _"

### DIFF
--- a/src/powerquery-language-services/inspection/type/inspectType/common.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/common.ts
@@ -42,7 +42,7 @@ import { TypeById } from "../../typeCache";
 // Drops PQP.LexSettings and PQP.ParseSettings as they're not needed.
 export interface InspectTypeState
     extends PQP.CommonSettings,
-    Omit<InspectionSettings, keyof PQP.Lexer.LexSettings | keyof PQP.Parser.ParseSettings> {
+        Omit<InspectionSettings, keyof PQP.Lexer.LexSettings | keyof PQP.Parser.ParseSettings> {
     readonly typeById: TypeById;
     readonly nodeIdMapCollection: NodeIdMap.Collection;
     readonly scopeById: ScopeById;
@@ -473,6 +473,10 @@ export async function dereferencedIdentifierType(
         scopeItem = nodeScope.get(deferencedLiteral.slice(1));
     }
 
+    if (deferencedLiteral === "_" && scopeItem?.kind === ScopeItemKind.Each) {
+        return Type.UnknownInstance;
+    }
+
     // The deferenced identifier can't be resolved within the local scope.
     // It either is either an invalid identifier or an external identifier (e.g `Odbc.Database`).
     if (scopeItem === undefined) {
@@ -513,10 +517,6 @@ export async function dereferencedIdentifierType(
     // There's no good way to handle the type of this as it requires evaluation, so mark it as any.
     if (deferencedLiteral.startsWith("@") && nextXorNode?.node.id === xorNode.node.id) {
         return Type.AnyInstance;
-    }
-
-    if (deferencedLiteral === "_") {
-        return Type.UnknownInstance;
     }
 
     const result: PQP.Language.Type.TPowerQueryType | undefined = nextXorNode

--- a/src/powerquery-language-services/inspection/type/inspectType/common.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/common.ts
@@ -42,7 +42,7 @@ import { TypeById } from "../../typeCache";
 // Drops PQP.LexSettings and PQP.ParseSettings as they're not needed.
 export interface InspectTypeState
     extends PQP.CommonSettings,
-        Omit<InspectionSettings, keyof PQP.Lexer.LexSettings | keyof PQP.Parser.ParseSettings> {
+    Omit<InspectionSettings, keyof PQP.Lexer.LexSettings | keyof PQP.Parser.ParseSettings> {
     readonly typeById: TypeById;
     readonly nodeIdMapCollection: NodeIdMap.Collection;
     readonly scopeById: ScopeById;
@@ -513,6 +513,10 @@ export async function dereferencedIdentifierType(
     // There's no good way to handle the type of this as it requires evaluation, so mark it as any.
     if (deferencedLiteral.startsWith("@") && nextXorNode?.node.id === xorNode.node.id) {
         return Type.AnyInstance;
+    }
+
+    if (deferencedLiteral === "_") {
+        return Type.UnknownInstance;
     }
 
     const result: PQP.Language.Type.TPowerQueryType | undefined = nextXorNode

--- a/src/test/inspection/type.ts
+++ b/src/test/inspection/type.ts
@@ -384,6 +384,9 @@ describe(`Inspection - Type`, () => {
 
             it(`let x = 1 in x`, async () =>
                 await assertEqualRootType(`let x = 1 in x`, TypeUtils.numberLiteral(false, `1`)));
+
+            it(`let _ = 1 in 1`, async () =>
+                await assertEqualRootType(`let _ = 1 in 1`, TypeUtils.numberLiteral(false, `1`)));
         });
 
         describe(`${Ast.NodeKind.IfExpression}`, () => {

--- a/src/test/inspection/type.ts
+++ b/src/test/inspection/type.ts
@@ -111,6 +111,23 @@ describe(`Inspection - Type`, () => {
                         TypeUtils.numberLiteral(false, `1`),
                     ),
                 ));
+
+            it(`each _`, async () =>
+                await assertEqualRootType(
+                    `each _`,
+                    TypeUtils.definedFunction(
+                        false,
+                        [
+                            {
+                                isNullable: false,
+                                isOptional: false,
+                                type: Type.TypeKind.Any,
+                                nameLiteral: `_`,
+                            },
+                        ],
+                        Type.UnknownInstance,
+                    ),
+                ));
         });
 
         describe(`${Ast.NodeKind.ErrorHandlingExpression}`, () => {


### PR DESCRIPTION
Until we come up with a better solution for evaluating the type of "_" in each expressions, we will need to report the type as "Unknown". Right now, there is an infinite recursion when trying to determine its type