### PR TITLE
Autocomplete items generated via scope should replace text where possible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.10.5",
+    "version": "0.10.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/powerquery-language-services",
-            "version": "0.10.5",
+            "version": "0.10.6",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/powerquery-formatter": "0.3.17",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.10.5",
+    "version": "0.10.6",
     "author": "Microsoft",
     "license": "MIT",
     "scripts": {

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteItem/autocompleteItemUtils.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteItem/autocompleteItemUtils.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { CompletionItemKind, TextEdit } from "vscode-languageserver-types";
 import { Keyword, Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 import { Assert } from "@microsoft/powerquery-parser";
-import { CompletionItemKind } from "vscode-languageserver-types";
 import { XorNodeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
+import { AutocompleteItemProviderContext, Inspection } from "../../..";
 import type { AutocompleteItem } from "./autocompleteItem";
 import { calculateJaroWinkler } from "../../../jaroWinkler";
-import { Inspection } from "../../..";
 import { Library } from "../../../library";
 
 export function fromKeywordKind(label: Keyword.KeywordKind, other?: string): AutocompleteItem {
@@ -41,7 +41,7 @@ export function fromScopeItem(
     label: string,
     scopeItem: Inspection.TScopeItem,
     powerQueryType: Type.TPowerQueryType,
-    other?: string,
+    context: AutocompleteItemProviderContext,
 ): AutocompleteItem | undefined {
     switch (scopeItem.kind) {
         case Inspection.ScopeItemKind.LetVariable:
@@ -72,13 +72,12 @@ export function fromScopeItem(
             throw Assert.isNever(scopeItem);
     }
 
-    const jaroWinklerScore: number = other !== undefined ? calculateJaroWinkler(label, other) : 1;
-
     return {
-        jaroWinklerScore,
+        jaroWinklerScore: context?.text ? calculateJaroWinkler(label, context.text) : 1,
         kind: CompletionItemKind.Variable,
         label,
         powerQueryType,
+        textEdit: context.range ? TextEdit.replace(context.range, label) : undefined,
     };
 }
 

--- a/src/powerquery-language-services/inspectionUtils.ts
+++ b/src/powerquery-language-services/inspectionUtils.ts
@@ -38,23 +38,22 @@ export function getAutocompleteItemsFromScope(
     const nodeScope: Inspection.NodeScope = triedNodeScope.value;
     const scopeTypeByKey: Inspection.ScopeTypeByKey = ResultUtils.okOrDefault(triedScopeType, new Map());
 
-    const contextText: string | undefined = context.text;
-    const partial: Inspection.AutocompleteItem[] = [];
+    const result: Inspection.AutocompleteItem[] = [];
 
     for (const [label, scopeItem] of nodeScope.entries()) {
         const autocompleteItem: Inspection.AutocompleteItem | undefined = AutocompleteItemUtils.fromScopeItem(
             label,
             scopeItem,
             scopeTypeByKey.get(label) ?? Type.UnknownInstance,
-            contextText,
+            context,
         );
 
         if (autocompleteItem) {
-            partial.push(autocompleteItem);
+            result.push(autocompleteItem);
         }
     }
 
-    return partial;
+    return result;
 }
 
 export async function getIdentifierType(

--- a/src/test/providers/localDocumentProvider.test.ts
+++ b/src/test/providers/localDocumentProvider.test.ts
@@ -34,10 +34,18 @@ describe(`SimpleLocalDocumentSymbolProvider`, () => {
             readonly isTextEdit: boolean;
         };
         readonly cancellationToken?: ICancellationToken;
-    }): Promise<AutocompleteItem[] | undefined> {
-        return await TestUtils.assertAutocompleteAnalysis({
+    }): Promise<void> {
+        const actual: ReadonlyArray<AutocompleteItem> | undefined = await TestUtils.assertAutocompleteAnalysis({
             ...params,
             analysisSettings: IsolatedAnalysisSettings,
+        });
+
+        TestUtils.assertEqualAbridgedAutocompleteItems({
+            expected: params.expected.labels.map((label: string) => ({
+                label,
+                isTextEdit: params.expected.isTextEdit,
+            })),
+            actual: (actual ?? []).map(TestUtils.abridgedAutocompleteItem),
         });
     }
 
@@ -84,7 +92,7 @@ describe(`SimpleLocalDocumentSymbolProvider`, () => {
                                 `#"foobar"`,
                                 `@#"foobar"`,
                             ],
-                            isTextEdit: false,
+                            isTextEdit: true,
                         },
                     }));
             });
@@ -104,7 +112,7 @@ describe(`SimpleLocalDocumentSymbolProvider`, () => {
                         textWithPipe: `(foo, bar, foobar) => foo|`,
                         expected: {
                             labels: [`foo`, `#"foo"`, `bar`, `#"bar"`, `foobar`, `#"foobar"`],
-                            isTextEdit: false,
+                            isTextEdit: true,
                         },
                     }));
             });
@@ -154,7 +162,7 @@ describe(`SimpleLocalDocumentSymbolProvider`, () => {
                                 `@x`,
                                 `@#"x"`,
                             ],
-                            isTextEdit: false,
+                            isTextEdit: true,
                         },
                     }));
             });
@@ -204,7 +212,7 @@ describe(`SimpleLocalDocumentSymbolProvider`, () => {
                                 `@x`,
                                 `@#"x"`,
                             ],
-                            isTextEdit: false,
+                            isTextEdit: true,
                         },
                     }));
             });

--- a/src/test/testUtils/abridgedTestUtils.ts
+++ b/src/test/testUtils/abridgedTestUtils.ts
@@ -69,6 +69,13 @@ export interface AbridgedAutocompleteItem {
     readonly isTextEdit: boolean;
 }
 
+export function abridgedAutocompleteItem(value: Inspection.AutocompleteItem): AbridgedAutocompleteItem {
+    return {
+        label: value.label,
+        isTextEdit: value.textEdit !== undefined,
+    };
+}
+
 export function abridgedDocumentSymbols(
     documentSymbols: ReadonlyArray<DocumentSymbol>,
 ): ReadonlyArray<AbridgedDocumentSymbol> {

--- a/src/test/testUtils/autocompleteTestUtils.ts
+++ b/src/test/testUtils/autocompleteTestUtils.ts
@@ -15,7 +15,7 @@ export async function expectAbridgedAutocompleteItems(params: {
         autocomplete: Inspection.Autocomplete,
     ) => ReadonlyArray<Inspection.AutocompleteItem>;
 }): Promise<ReadonlyArray<AbridgedAutocompleteItem>> {
-    return (await expectAutocompleteItems(params)).map(createAbridgedAutocompleteItem);
+    return (await expectAutocompleteItems(params)).map(TestUtils.abridgedAutocompleteItem);
 }
 
 export async function expectAutocomplete(textWithPipe: string): Promise<Inspection.Autocomplete> {
@@ -84,7 +84,7 @@ export async function expectTopSuggestions(params: {
 
     const topN: ReadonlyArray<AbridgedAutocompleteItem> = byJaroWinklerScore
         .slice(0, params.expected.length)
-        .map(createAbridgedAutocompleteItem);
+        .map(TestUtils.abridgedAutocompleteItem);
 
     const remainderAboveThreshold: ReadonlyArray<Inspection.AutocompleteItem> = byJaroWinklerScore
         .slice(params.expected.length)
@@ -92,11 +92,4 @@ export async function expectTopSuggestions(params: {
 
     expect(topN).to.deep.equal(params.expected);
     expect(remainderAboveThreshold).to.be.empty;
-}
-
-function createAbridgedAutocompleteItem(value: Inspection.AutocompleteItem): AbridgedAutocompleteItem {
-    return {
-        label: value.label,
-        isTextEdit: value.textEdit !== undefined,
-    };
 }


### PR DESCRIPTION
Take the following scenario:

`let foo = 42 in go|o`

The key `foo` (and its variants) would be a recommended autocomplete item. However, if you were to select `foo` it would result in:

`let foo = 42 in gofooo`

i.e. it performed an insertion rather than than a replacement. With this change it'll replace the current word with your scope generated suggestion.