### PR TITLE
Completion improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.11.10",
+    "version": "0.12.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/powerquery-language-services",
-            "version": "0.11.10",
+            "version": "0.12.0",
             "license": "MIT",
             "dependencies": {
                 "vscode-languageserver-textdocument": "1.0.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,6 @@
             "version": "0.11.10",
             "license": "MIT",
             "dependencies": {
-                "@microsoft/powerquery-formatter": "0.3.20",
-                "@microsoft/powerquery-parser": "0.18.5",
                 "vscode-languageserver-textdocument": "1.0.12",
                 "vscode-languageserver-types": "3.17.5"
             },
@@ -408,31 +406,6 @@
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.0.3",
                 "@jridgewell/sourcemap-codec": "^1.4.10"
-            }
-        },
-        "node_modules/@microsoft/powerquery-formatter": {
-            "version": "0.3.20",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.3.20.tgz",
-            "integrity": "sha512-8EA+1GAO1qaQqxy8iGm6n7gp3ac2FCboJ9A0gbusdqhOpbs3RAjInna6chk8mT0vixusShL57VWPEdXG4LxHxQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@microsoft/powerquery-parser": "0.18.5"
-            },
-            "engines": {
-                "node": ">=22"
-            }
-        },
-        "node_modules/@microsoft/powerquery-parser": {
-            "version": "0.18.5",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.18.5.tgz",
-            "integrity": "sha512-9h7gp3fJ7p2Nb+2hE/xeMMw3wGVs1sJ65JTKxXu7YHISLhHuaA68u1FEgzhWt9qu3M0iOXcSZDV26WMa0lteng==",
-            "license": "MIT",
-            "dependencies": {
-                "grapheme-splitter": "^1.0.4",
-                "performance-now": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=22"
             }
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -2204,12 +2177,6 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/grapheme-splitter": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-            "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
-            "license": "MIT"
-        },
         "node_modules/graphemer": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -2900,12 +2867,6 @@
             "engines": {
                 "node": "*"
             }
-        },
-        "node_modules/performance-now": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-            "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-            "license": "MIT"
         },
         "node_modules/picocolors": {
             "version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
             "version": "0.12.0",
             "license": "MIT",
             "dependencies": {
+                "@microsoft/powerquery-formatter": "0.3.20",
+                "@microsoft/powerquery-parser": "0.18.5",
                 "vscode-languageserver-textdocument": "1.0.12",
                 "vscode-languageserver-types": "3.17.5"
             },
@@ -406,6 +408,31 @@
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.0.3",
                 "@jridgewell/sourcemap-codec": "^1.4.10"
+            }
+        },
+        "node_modules/@microsoft/powerquery-formatter": {
+            "version": "0.3.20",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.3.20.tgz",
+            "integrity": "sha512-8EA+1GAO1qaQqxy8iGm6n7gp3ac2FCboJ9A0gbusdqhOpbs3RAjInna6chk8mT0vixusShL57VWPEdXG4LxHxQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@microsoft/powerquery-parser": "0.18.5"
+            },
+            "engines": {
+                "node": ">=22"
+            }
+        },
+        "node_modules/@microsoft/powerquery-parser": {
+            "version": "0.18.5",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.18.5.tgz",
+            "integrity": "sha512-9h7gp3fJ7p2Nb+2hE/xeMMw3wGVs1sJ65JTKxXu7YHISLhHuaA68u1FEgzhWt9qu3M0iOXcSZDV26WMa0lteng==",
+            "license": "MIT",
+            "dependencies": {
+                "grapheme-splitter": "^1.0.4",
+                "performance-now": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=22"
             }
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -2177,6 +2204,12 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/grapheme-splitter": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+            "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+            "license": "MIT"
+        },
         "node_modules/graphemer": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -2867,6 +2900,12 @@
             "engines": {
                 "node": "*"
             }
+        },
+        "node_modules/performance-now": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+            "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+            "license": "MIT"
         },
         "node_modules/picocolors": {
             "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
         "serialize-javascript": "7.0.4"
     },
     "dependencies": {
+        "@microsoft/powerquery-formatter": "0.3.20",
+        "@microsoft/powerquery-parser": "0.18.5",
         "vscode-languageserver-textdocument": "1.0.12",
         "vscode-languageserver-types": "3.17.5"
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.11.10",
+    "version": "0.12.0",
     "author": "Microsoft",
     "license": "MIT",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -60,8 +60,6 @@
         "serialize-javascript": "7.0.4"
     },
     "dependencies": {
-        "@microsoft/powerquery-formatter": "0.3.20",
-        "@microsoft/powerquery-parser": "0.18.5",
         "vscode-languageserver-textdocument": "1.0.12",
         "vscode-languageserver-types": "3.17.5"
     }

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteItem/autocompleteItemUtils.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteItem/autocompleteItemUtils.ts
@@ -90,10 +90,7 @@ export function fromScopeItem(
 export function createSnippetItems(): ReadonlyArray<AutocompleteItem> {
     return [
         createSnippetItem("let...in", "let\n\t${1:name} = ${2:value}\nin\n\t${0:result}"),
-        createSnippetItem(
-            "if...then...else",
-            "if ${1:condition} then ${2:trueValue} else ${3:falseValue}",
-        ),
+        createSnippetItem("if...then...else", "if ${1:condition} then ${2:trueValue} else ${3:falseValue}"),
         createSnippetItem("try...otherwise", "try ${1:expression} otherwise ${2:default}"),
         createSnippetItem("each", "each ${0:expression}"),
     ];

--- a/src/powerquery-language-services/inspection/autocomplete/autocompleteItem/autocompleteItemUtils.ts
+++ b/src/powerquery-language-services/inspection/autocomplete/autocompleteItem/autocompleteItemUtils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { CompletionItemKind, TextEdit } from "vscode-languageserver-types";
+import { CompletionItemKind, InsertTextFormat, MarkupKind, TextEdit } from "vscode-languageserver-types";
 import { Keyword, Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 import { Assert } from "@microsoft/powerquery-parser";
 import { XorNodeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
@@ -18,6 +18,7 @@ export function fromKeywordKind(label: Keyword.KeywordKind, other?: string): Aut
         jaroWinklerScore,
         kind: CompletionItemKind.Keyword,
         label,
+        commitCharacters: [" "],
         powerQueryType: Type.NotApplicableInstance,
     };
 }
@@ -29,10 +30,14 @@ export function fromLibraryDefinition(
 ): Inspection.AutocompleteItem {
     const jaroWinklerScore: number = other !== undefined ? calculateJaroWinkler(label, other) : 1;
 
+    const isFunction: boolean = libraryDefinition.kind === Library.LibraryDefinitionKind.Function;
+
     return {
         jaroWinklerScore,
         kind: libraryDefinition.completionItemKind,
         label,
+        documentation: { kind: MarkupKind.PlainText, value: libraryDefinition.description },
+        commitCharacters: isFunction ? ["("] : undefined,
         powerQueryType: libraryDefinition.asPowerQueryType,
     };
 }
@@ -76,8 +81,32 @@ export function fromScopeItem(
         jaroWinklerScore: context?.text ? calculateJaroWinkler(label, context.text) : 1,
         kind: CompletionItemKind.Variable,
         label,
+        commitCharacters: [".", "["],
         powerQueryType,
         textEdit: context.range ? TextEdit.replace(context.range, label) : undefined,
+    };
+}
+
+export function createSnippetItems(): ReadonlyArray<AutocompleteItem> {
+    return [
+        createSnippetItem("let...in", "let\n\t${1:name} = ${2:value}\nin\n\t${0:result}"),
+        createSnippetItem(
+            "if...then...else",
+            "if ${1:condition} then ${2:trueValue} else ${3:falseValue}",
+        ),
+        createSnippetItem("try...otherwise", "try ${1:expression} otherwise ${2:default}"),
+        createSnippetItem("each", "each ${0:expression}"),
+    ];
+}
+
+function createSnippetItem(label: string, insertText: string): AutocompleteItem {
+    return {
+        jaroWinklerScore: 1,
+        kind: CompletionItemKind.Snippet,
+        label,
+        insertText,
+        insertTextFormat: InsertTextFormat.Snippet,
+        powerQueryType: Type.NotApplicableInstance,
     };
 }
 

--- a/src/powerquery-language-services/library/libraryDefinitionUtils.ts
+++ b/src/powerquery-language-services/library/libraryDefinitionUtils.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { CompletionItemKind, MarkupKind, ParameterInformation, SignatureInformation } from "vscode-languageserver-types";
+import {
+    CompletionItemKind,
+    MarkupKind,
+    ParameterInformation,
+    SignatureInformation,
+} from "vscode-languageserver-types";
 import { Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 
 import { ExternalTypeRequestKind, TExternalTypeRequest, TExternalTypeResolverFn } from "../externalType/externalType";

--- a/src/powerquery-language-services/library/libraryDefinitionUtils.ts
+++ b/src/powerquery-language-services/library/libraryDefinitionUtils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { CompletionItemKind, ParameterInformation, SignatureInformation } from "vscode-languageserver-types";
+import { CompletionItemKind, MarkupKind, ParameterInformation, SignatureInformation } from "vscode-languageserver-types";
 import { Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 
 import { ExternalTypeRequestKind, TExternalTypeRequest, TExternalTypeResolverFn } from "../externalType/externalType";
@@ -154,6 +154,8 @@ export function signatureInformation(libraryFunctionSignature: LibraryFunction):
 export function parameterInformation(libraryParameter: LibraryParameter): ParameterInformation {
     return {
         label: libraryParameter.label,
-        documentation: undefined,
+        documentation: libraryParameter.documentation
+            ? { kind: MarkupKind.Markdown, value: libraryParameter.documentation }
+            : undefined,
     };
 }

--- a/src/powerquery-language-services/library/librarySymbolUtils.ts
+++ b/src/powerquery-language-services/library/librarySymbolUtils.ts
@@ -244,9 +244,41 @@ function librarySymbolFunctionParameterToLibraryParameter(
         isNullable: primitiveType.isNullable,
         isOptional: false,
         label: parameter.name,
-        documentation: parameter.description ?? undefined,
+        documentation: buildParameterDocumentation(parameter),
         typeKind: primitiveType.kind,
     };
+}
+
+function buildParameterDocumentation(parameter: LibrarySymbolFunctionParameter): string | undefined {
+    const parts: string[] = [];
+
+    if (parameter.caption) {
+        parts.push(`**${parameter.caption}**`);
+    }
+
+    if (parameter.description) {
+        parts.push(parameter.description);
+    }
+
+    if (parameter.defaultValue !== null && parameter.defaultValue !== undefined) {
+        parts.push(`Default: \`${parameter.defaultValue}\``);
+    }
+
+    if (parameter.allowedValues && parameter.allowedValues.length > 0) {
+        parts.push(`Allowed values: ${parameter.allowedValues.map((v: string | number) => `\`${v}\``).join(", ")}`);
+    }
+
+    if (parameter.sampleValues && parameter.sampleValues.length > 0) {
+        parts.push(`Sample values: ${parameter.sampleValues.map((v: string | number) => `\`${v}\``).join(", ")}`);
+    }
+
+    // Only include type info when there's other documentation content,
+    // since the type is already visible in the signature label.
+    if (parts.length > 0 && parameter.type) {
+        parts.push(`Type: \`${parameter.type}\``);
+    }
+
+    return parts.length > 0 ? parts.join("\n\n") : undefined;
 }
 
 function numberToCompletionItemKind(variant: number): CompletionItemKind | undefined {

--- a/src/powerquery-language-services/library/librarySymbolUtils.ts
+++ b/src/powerquery-language-services/library/librarySymbolUtils.ts
@@ -9,6 +9,8 @@ import { ExternalType, ExternalTypeUtils } from "../externalType";
 import { Library, LibraryDefinitionUtils } from "../library";
 import { LibrarySymbol, LibrarySymbolFunctionParameter } from "./librarySymbol";
 import { CompletionItemKind } from "../commonTypes";
+import { Localization } from "../localization/localization";
+import { DefaultTemplates } from "../localization/templates";
 
 // Created when non-zero conversion errors occur.
 export interface IncompleteLibrary {
@@ -261,21 +263,21 @@ function buildParameterDocumentation(parameter: LibrarySymbolFunctionParameter):
     }
 
     if (parameter.defaultValue !== null && parameter.defaultValue !== undefined) {
-        parts.push(`Default: \`${parameter.defaultValue}\``);
+        parts.push(Localization.parameterDocumentation_default(DefaultTemplates, String(parameter.defaultValue)));
     }
 
     if (parameter.allowedValues && parameter.allowedValues.length > 0) {
-        parts.push(`Allowed values: ${parameter.allowedValues.map((v: string | number) => `\`${v}\``).join(", ")}`);
+        parts.push(Localization.parameterDocumentation_allowedValues(DefaultTemplates, parameter.allowedValues.map((v: string | number) => `\`${v}\``).join(", ")));
     }
 
     if (parameter.sampleValues && parameter.sampleValues.length > 0) {
-        parts.push(`Sample values: ${parameter.sampleValues.map((v: string | number) => `\`${v}\``).join(", ")}`);
+        parts.push(Localization.parameterDocumentation_sampleValues(DefaultTemplates, parameter.sampleValues.map((v: string | number) => `\`${v}\``).join(", ")));
     }
 
     // Only include type info when there's other documentation content,
     // since the type is already visible in the signature label.
     if (parts.length > 0 && parameter.type) {
-        parts.push(`Type: \`${parameter.type}\``);
+        parts.push(Localization.parameterDocumentation_type(DefaultTemplates, parameter.type));
     }
 
     return parts.length > 0 ? parts.join("\n\n") : undefined;

--- a/src/powerquery-language-services/library/librarySymbolUtils.ts
+++ b/src/powerquery-language-services/library/librarySymbolUtils.ts
@@ -10,7 +10,7 @@ import { Library, LibraryDefinitionUtils } from "../library";
 import { LibrarySymbol, LibrarySymbolFunctionParameter } from "./librarySymbol";
 import { CompletionItemKind } from "../commonTypes";
 import { Localization } from "../localization/localization";
-import { DefaultTemplates } from "../localization/templates";
+import { DefaultTemplates, ILocalizationTemplates } from "../localization/templates";
 
 // Created when non-zero conversion errors occur.
 export interface IncompleteLibrary {
@@ -49,11 +49,12 @@ export function createLibrary(
     librarySymbols: ReadonlyArray<LibrarySymbol>,
     dynamicLibraryDefinitions: () => ReadonlyMap<string, Library.TLibraryDefinition>,
     externalTypeResolverFn: ExternalType.TExternalTypeResolverFn | undefined,
+    templates: ILocalizationTemplates = DefaultTemplates,
 ): Result<Library.ILibrary, IncompleteLibrary> {
     const libraryDefinitionsResult: Result<
         ReadonlyMap<string, Library.TLibraryDefinition>,
         IncompleteLibraryDefinitions
-    > = createLibraryDefinitions(librarySymbols);
+    > = createLibraryDefinitions(librarySymbols, templates);
 
     let staticLibraryDefinitions: ReadonlyMap<string, Library.TLibraryDefinition>;
     let failedLibrarySymbolConversions: ReadonlyArray<FailedLibrarySymbolConversion>;
@@ -93,6 +94,7 @@ export function createLibrary(
 
 export function createLibraryDefinition(
     librarySymbol: LibrarySymbol,
+    templates: ILocalizationTemplates = DefaultTemplates,
 ): Result<Library.TLibraryDefinition, FailedLibrarySymbolConversion> {
     const primitiveType: Type.TPrimitiveType | undefined = stringToPrimitiveType(librarySymbol.type);
 
@@ -133,7 +135,7 @@ export function createLibraryDefinition(
 
         for (const [parameter, index] of ArrayUtils.enumerate(librarySymbol.functionParameters)) {
             const libraryParameter: Library.LibraryParameter | undefined =
-                librarySymbolFunctionParameterToLibraryParameter(parameter);
+                librarySymbolFunctionParameterToLibraryParameter(parameter, templates);
 
             if (libraryParameter === undefined) {
                 return failedParameterConversionError(librarySymbol, index);
@@ -163,13 +165,14 @@ export function createLibraryDefinition(
 
 export function createLibraryDefinitions(
     librarySymbols: ReadonlyArray<LibrarySymbol>,
+    templates: ILocalizationTemplates = DefaultTemplates,
 ): Result<ReadonlyMap<string, Library.TLibraryDefinition>, IncompleteLibraryDefinitions> {
     const libraryDefinitions: Map<string, Library.TLibraryDefinition> = new Map<string, Library.TLibraryDefinition>();
     const failedLibrarySymbolConversions: FailedLibrarySymbolConversion[] = [];
 
     for (const librarySymbol of librarySymbols) {
         const libraryDefinitionResult: Result<Library.TLibraryDefinition, FailedLibrarySymbolConversion> =
-            createLibraryDefinition(librarySymbol);
+            createLibraryDefinition(librarySymbol, templates);
 
         if (ResultUtils.isOk(libraryDefinitionResult)) {
             libraryDefinitions.set(librarySymbol.name, libraryDefinitionResult.value);
@@ -235,6 +238,7 @@ function librarySymbolFunctionParamatersToDefinedFunction(
 
 function librarySymbolFunctionParameterToLibraryParameter(
     parameter: LibrarySymbolFunctionParameter,
+    templates: ILocalizationTemplates,
 ): Library.LibraryParameter | undefined {
     const primitiveType: Type.TPrimitiveType | undefined = stringToPrimitiveType(parameter.type);
 
@@ -246,12 +250,12 @@ function librarySymbolFunctionParameterToLibraryParameter(
         isNullable: primitiveType.isNullable,
         isOptional: false,
         label: parameter.name,
-        documentation: buildParameterDocumentation(parameter),
+        documentation: buildParameterDocumentation(parameter, templates),
         typeKind: primitiveType.kind,
     };
 }
 
-function buildParameterDocumentation(parameter: LibrarySymbolFunctionParameter): string | undefined {
+function buildParameterDocumentation(parameter: LibrarySymbolFunctionParameter, templates: ILocalizationTemplates): string | undefined {
     const parts: string[] = [];
 
     if (parameter.caption) {
@@ -263,21 +267,21 @@ function buildParameterDocumentation(parameter: LibrarySymbolFunctionParameter):
     }
 
     if (parameter.defaultValue !== null && parameter.defaultValue !== undefined) {
-        parts.push(Localization.parameterDocumentation_default(DefaultTemplates, String(parameter.defaultValue)));
+        parts.push(Localization.parameterDocumentation_default(templates, String(parameter.defaultValue)));
     }
 
     if (parameter.allowedValues && parameter.allowedValues.length > 0) {
-        parts.push(Localization.parameterDocumentation_allowedValues(DefaultTemplates, parameter.allowedValues.map((v: string | number) => `\`${v}\``).join(", ")));
+        parts.push(Localization.parameterDocumentation_allowedValues(templates, parameter.allowedValues.map((v: string | number) => `\`${v}\``).join(", ")));
     }
 
     if (parameter.sampleValues && parameter.sampleValues.length > 0) {
-        parts.push(Localization.parameterDocumentation_sampleValues(DefaultTemplates, parameter.sampleValues.map((v: string | number) => `\`${v}\``).join(", ")));
+        parts.push(Localization.parameterDocumentation_sampleValues(templates, parameter.sampleValues.map((v: string | number) => `\`${v}\``).join(", ")));
     }
 
     // Only include type info when there's other documentation content,
     // since the type is already visible in the signature label.
     if (parts.length > 0 && parameter.type) {
-        parts.push(Localization.parameterDocumentation_type(DefaultTemplates, parameter.type));
+        parts.push(Localization.parameterDocumentation_type(templates, parameter.type));
     }
 
     return parts.length > 0 ? parts.join("\n\n") : undefined;

--- a/src/powerquery-language-services/library/librarySymbolUtils.ts
+++ b/src/powerquery-language-services/library/librarySymbolUtils.ts
@@ -5,12 +5,12 @@ import { ArrayUtils, ErrorResult, Result, ResultUtils } from "@microsoft/powerqu
 import { Constant, ConstantUtils, Type, TypeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 import { NoOpTraceManagerInstance } from "@microsoft/powerquery-parser/lib/powerquery-parser/common/trace";
 
+import { DefaultTemplates, ILocalizationTemplates } from "../localization/templates";
 import { ExternalType, ExternalTypeUtils } from "../externalType";
 import { Library, LibraryDefinitionUtils } from "../library";
 import { LibrarySymbol, LibrarySymbolFunctionParameter } from "./librarySymbol";
 import { CompletionItemKind } from "../commonTypes";
 import { Localization } from "../localization/localization";
-import { DefaultTemplates, ILocalizationTemplates } from "../localization/templates";
 
 // Created when non-zero conversion errors occur.
 export interface IncompleteLibrary {
@@ -255,7 +255,10 @@ function librarySymbolFunctionParameterToLibraryParameter(
     };
 }
 
-function buildParameterDocumentation(parameter: LibrarySymbolFunctionParameter, templates: ILocalizationTemplates): string | undefined {
+function buildParameterDocumentation(
+    parameter: LibrarySymbolFunctionParameter,
+    templates: ILocalizationTemplates,
+): string | undefined {
     const parts: string[] = [];
 
     if (parameter.caption) {
@@ -271,11 +274,21 @@ function buildParameterDocumentation(parameter: LibrarySymbolFunctionParameter, 
     }
 
     if (parameter.allowedValues && parameter.allowedValues.length > 0) {
-        parts.push(Localization.parameterDocumentation_allowedValues(templates, parameter.allowedValues.map((v: string | number) => `\`${v}\``).join(", ")));
+        parts.push(
+            Localization.parameterDocumentation_allowedValues(
+                templates,
+                parameter.allowedValues.map((v: string | number) => `\`${v}\``).join(", "),
+            ),
+        );
     }
 
     if (parameter.sampleValues && parameter.sampleValues.length > 0) {
-        parts.push(Localization.parameterDocumentation_sampleValues(templates, parameter.sampleValues.map((v: string | number) => `\`${v}\``).join(", ")));
+        parts.push(
+            Localization.parameterDocumentation_sampleValues(
+                templates,
+                parameter.sampleValues.map((v: string | number) => `\`${v}\``).join(", "),
+            ),
+        );
     }
 
     // Only include type info when there's other documentation content,

--- a/src/powerquery-language-services/library/libraryUtils.ts
+++ b/src/powerquery-language-services/library/libraryUtils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { ParameterInformation, SignatureInformation } from "vscode-languageserver-types";
+import { MarkupKind, ParameterInformation, SignatureInformation } from "vscode-languageserver-types";
 import { Assert } from "@microsoft/powerquery-parser";
 import { IdentifierExpressionUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 
@@ -34,7 +34,9 @@ export function signatureInformation(libraryFunctionSignature: LibraryFunction):
 export function parameterInformation(libraryParameter: LibraryParameter): ParameterInformation {
     return {
         label: libraryParameter.label,
-        documentation: undefined,
+        documentation: libraryParameter.documentation
+            ? { kind: MarkupKind.Markdown, value: libraryParameter.documentation }
+            : undefined,
     };
 }
 

--- a/src/powerquery-language-services/localization/localization.ts
+++ b/src/powerquery-language-services/localization/localization.ts
@@ -33,8 +33,11 @@ interface ILocalization {
     ) => string;
 
     parameterDocumentation_default: (templates: ILocalizationTemplates, value: string) => string;
+
     parameterDocumentation_allowedValues: (templates: ILocalizationTemplates, values: string) => string;
+
     parameterDocumentation_sampleValues: (templates: ILocalizationTemplates, values: string) => string;
+
     parameterDocumentation_type: (templates: ILocalizationTemplates, type: string) => string;
 }
 
@@ -132,26 +135,14 @@ export const Localization: ILocalization = {
     },
 
     parameterDocumentation_default: (templates: ILocalizationTemplates, value: string) =>
-        StringUtils.assertGetFormatted(
-            templates.parameterDocumentation_default,
-            new Map([["value", value]]),
-        ),
+        StringUtils.assertGetFormatted(templates.parameterDocumentation_default, new Map([["value", value]])),
 
     parameterDocumentation_allowedValues: (templates: ILocalizationTemplates, values: string) =>
-        StringUtils.assertGetFormatted(
-            templates.parameterDocumentation_allowedValues,
-            new Map([["values", values]]),
-        ),
+        StringUtils.assertGetFormatted(templates.parameterDocumentation_allowedValues, new Map([["values", values]])),
 
     parameterDocumentation_sampleValues: (templates: ILocalizationTemplates, values: string) =>
-        StringUtils.assertGetFormatted(
-            templates.parameterDocumentation_sampleValues,
-            new Map([["values", values]]),
-        ),
+        StringUtils.assertGetFormatted(templates.parameterDocumentation_sampleValues, new Map([["values", values]])),
 
     parameterDocumentation_type: (templates: ILocalizationTemplates, type: string) =>
-        StringUtils.assertGetFormatted(
-            templates.parameterDocumentation_type,
-            new Map([["type", type]]),
-        ),
+        StringUtils.assertGetFormatted(templates.parameterDocumentation_type, new Map([["type", type]])),
 };

--- a/src/powerquery-language-services/localization/localization.ts
+++ b/src/powerquery-language-services/localization/localization.ts
@@ -31,6 +31,11 @@ interface ILocalization {
         identifier: string,
         suggestion: string | undefined,
     ) => string;
+
+    parameterDocumentation_default: (templates: ILocalizationTemplates, value: string) => string;
+    parameterDocumentation_allowedValues: (templates: ILocalizationTemplates, values: string) => string;
+    parameterDocumentation_sampleValues: (templates: ILocalizationTemplates, values: string) => string;
+    parameterDocumentation_type: (templates: ILocalizationTemplates, type: string) => string;
 }
 
 export const Localization: ILocalization = {
@@ -125,4 +130,28 @@ export const Localization: ILocalization = {
             );
         }
     },
+
+    parameterDocumentation_default: (templates: ILocalizationTemplates, value: string) =>
+        StringUtils.assertGetFormatted(
+            templates.parameterDocumentation_default,
+            new Map([["value", value]]),
+        ),
+
+    parameterDocumentation_allowedValues: (templates: ILocalizationTemplates, values: string) =>
+        StringUtils.assertGetFormatted(
+            templates.parameterDocumentation_allowedValues,
+            new Map([["values", values]]),
+        ),
+
+    parameterDocumentation_sampleValues: (templates: ILocalizationTemplates, values: string) =>
+        StringUtils.assertGetFormatted(
+            templates.parameterDocumentation_sampleValues,
+            new Map([["values", values]]),
+        ),
+
+    parameterDocumentation_type: (templates: ILocalizationTemplates, type: string) =>
+        StringUtils.assertGetFormatted(
+            templates.parameterDocumentation_type,
+            new Map([["type", type]]),
+        ),
 };

--- a/src/powerquery-language-services/localization/templates.ts
+++ b/src/powerquery-language-services/localization/templates.ts
@@ -142,6 +142,10 @@ export interface ILocalizationTemplates {
     readonly error_validation_invokeExpression_numArgs: string;
     readonly error_validation_unknownIdentifier_noSuggestion: string;
     readonly error_validation_unknownIdentifier_suggestion: string;
+    readonly parameterDocumentation_default: string;
+    readonly parameterDocumentation_allowedValues: string;
+    readonly parameterDocumentation_sampleValues: string;
+    readonly parameterDocumentation_type: string;
 }
 
 export const DefaultTemplates: ILocalizationTemplates = en_US;

--- a/src/powerquery-language-services/localization/templates/templates.bg-BG.json
+++ b/src/powerquery-language-services/localization/templates/templates.bg-BG.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "\"{funcName}\" очакваше аргументът за \"{argName}\" да е \"{expected}\", но вместо това получи \"{actual}\".",
   "error_validation_invokeExpression_typeMismatch_unnamed": "Очакваше аргументът за \"{argName}\" да е \"{expected}\", но вместо това получи \"{actual}\".",
   "error_validation_unknownIdentifier_noSuggestion": "Cannot find the name '{identifier}'.",
-  "error_validation_unknownIdentifier_suggestion": "Не можем да намерим името '{identifier}', да не би да имахте предвид '{suggestion}'?"
+  "error_validation_unknownIdentifier_suggestion": "Не можем да намерим името '{identifier}', да не би да имахте предвид '{suggestion}'?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.ca-ES.json
+++ b/src/powerquery-language-services/localization/templates/templates.ca-ES.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "\"{funcName}\" esperava que l'argument \"{argName}\" fos \"{expected}\", però va ser \"{actual}\".",
   "error_validation_invokeExpression_typeMismatch_unnamed": "S’esperava que l’argument per a \"{argName}\" fos \"{expected}\", però va ser \"{actual}\".",
   "error_validation_unknownIdentifier_noSuggestion": "Cannot find the name '{identifier}'.",
-  "error_validation_unknownIdentifier_suggestion": "No es troba el nom ”{identifier}”, volíeu dir ”{suggestion}”?"
+  "error_validation_unknownIdentifier_suggestion": "No es troba el nom ”{identifier}”, volíeu dir ”{suggestion}”?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.cs-CZ.json
+++ b/src/powerquery-language-services/localization/templates/templates.cs-CZ.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "Funkce {funcName} očekávala, že argument pro {argName} bude {expected}, ale místo něj obdržela argument {actual}.",
   "error_validation_invokeExpression_typeMismatch_unnamed": "Očekávalo se, že argument pro {argName} bude {expected}, ale místo něj byl obdržen argument {actual}.",
   "error_validation_unknownIdentifier_noSuggestion": "Nelze najít název {identifier}.",
-  "error_validation_unknownIdentifier_suggestion": "Nepovedlo se najít název {identifier}, měli jste na mysli {suggestion}?"
+  "error_validation_unknownIdentifier_suggestion": "Nepovedlo se najít název {identifier}, měli jste na mysli {suggestion}?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.da-DK.json
+++ b/src/powerquery-language-services/localization/templates/templates.da-DK.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "'{funcName} forventede, at argumentet for '{argName} ville være '{expected}', men modtog '{actual}' i stedet for.",
   "error_validation_invokeExpression_typeMismatch_unnamed": "Forventede, at argumentet for '{argName} ville være '{expected}', men modtog '{actual}' i stedet for.",
   "error_validation_unknownIdentifier_noSuggestion": "Cannot find the name '{identifier}'.",
-  "error_validation_unknownIdentifier_suggestion": "Navnet '{identifier}' blev ikke fundet. Mente du '{suggestion}'?"
+  "error_validation_unknownIdentifier_suggestion": "Navnet '{identifier}' blev ikke fundet. Mente du '{suggestion}'?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.de-DE.json
+++ b/src/powerquery-language-services/localization/templates/templates.de-DE.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "„{funcName}“ hat erwartet, dass das Argument für „{argName}“ „{expected}“ sein würde, hat aber stattdessen „{actual}“ erhalten.",
   "error_validation_invokeExpression_typeMismatch_unnamed": "Es wurde erwartet, dass das Argument für „{argName}“ „{expected}“ sein würde, aber stattdessen wurde „{actual}“ erhalten.",
   "error_validation_unknownIdentifier_noSuggestion": "Cannot find the name '{identifier}'.",
-  "error_validation_unknownIdentifier_suggestion": "Der Name „{identifier}“ kann nicht gefunden werden. Meinten Sie „{suggestion}“?"
+  "error_validation_unknownIdentifier_suggestion": "Der Name „{identifier}“ kann nicht gefunden werden. Meinten Sie „{suggestion}“?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.el-GR.json
+++ b/src/powerquery-language-services/localization/templates/templates.el-GR.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "{funcName} ανέμενε το όρισμα για {argName} να είναι {expected}, αλλά έλαβε το {actual} αντ' αυτού.",
   "error_validation_invokeExpression_typeMismatch_unnamed": "Αναμενόταν το όρισμα για {argName} να είναι {expected}, αλλά έλαβε το {actual} αντ ' αυτού.",
   "error_validation_unknownIdentifier_noSuggestion": "Cannot find the name '{identifier}'.",
-  "error_validation_unknownIdentifier_suggestion": "Δεν είναι δυνατή η εύρεση του ονόματος '{identifier}', μήπως εννοείτε '{suggestion}';"
+  "error_validation_unknownIdentifier_suggestion": "Δεν είναι δυνατή η εύρεση του ονόματος '{identifier}', μήπως εννοείτε '{suggestion}';",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.es-ES.json
+++ b/src/powerquery-language-services/localization/templates/templates.es-ES.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "\"{funcName} esperaba que el argumento \"{argName}\" fuera \"{expected}\", pero en su lugar obtuvo \"{actual}\".",
   "error_validation_invokeExpression_typeMismatch_unnamed": "Se esperaba que el argumento de \"{argName}\" fuera \"{expected}\", pero en su lugar se obtuvo \"{actual}\".",
   "error_validation_unknownIdentifier_noSuggestion": "Cannot find the name '{identifier}'.",
-  "error_validation_unknownIdentifier_suggestion": "No se encuentra el nombre \"{identifier}\". ¿Quería decir \"{suggestion}\"?"
+  "error_validation_unknownIdentifier_suggestion": "No se encuentra el nombre \"{identifier}\". ¿Quería decir \"{suggestion}\"?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.et-EE.json
+++ b/src/powerquery-language-services/localization/templates/templates.et-EE.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "'{funcName}' eeldas, et argument '{argName}' jaoks on '{expected}', kuid sai selle asemel '{actual}'.",
   "error_validation_invokeExpression_typeMismatch_unnamed": "Eeldati, et argumendi „{argName}“ väärtus on „{expected}“, kuid selle asemel oli väärtus „{actual}“.",
   "error_validation_unknownIdentifier_noSuggestion": "Cannot find the name '{identifier}'.",
-  "error_validation_unknownIdentifier_suggestion": "Nime „{identifier}“ ei leitud. Kas pidasite silmas nime „{suggestion}“?"
+  "error_validation_unknownIdentifier_suggestion": "Nime „{identifier}“ ei leitud. Kas pidasite silmas nime „{suggestion}“?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.eu-ES.json
+++ b/src/powerquery-language-services/localization/templates/templates.eu-ES.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "“{funcName}” elementuak espero zuen “{expected}” izango zela “{argName}” elementuaren argumentua, baina “{actual}” da.",
   "error_validation_invokeExpression_typeMismatch_unnamed": "Espero zen “{expected}” izango zela “{argName}” elementuaren argumentua, baina “{actual}” da.",
   "error_validation_unknownIdentifier_noSuggestion": "Cannot find the name '{identifier}'.",
-  "error_validation_unknownIdentifier_suggestion": "Ez da aurkitu '{identifier}' izena; '{suggestion}' esan nahi zenuen?"
+  "error_validation_unknownIdentifier_suggestion": "Ez da aurkitu '{identifier}' izena; '{suggestion}' esan nahi zenuen?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.fi-FI.json
+++ b/src/powerquery-language-services/localization/templates/templates.fi-FI.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "{funcName} odotti, että {argName}-argumentiksi tulee {expected}, mutta se sai sen sijaan argumentin {actual}.",
   "error_validation_invokeExpression_typeMismatch_unnamed": "Odotettiin, että {argName}-argumentiksi tulee {expected}, mutta se sai sen sijaan {actual}.",
   "error_validation_unknownIdentifier_noSuggestion": "Nimeä {identifier} ei löydy.",
-  "error_validation_unknownIdentifier_suggestion": "Nimeä {identifier} ei löydy, tarkoititko {suggestion}?"
+  "error_validation_unknownIdentifier_suggestion": "Nimeä {identifier} ei löydy, tarkoititko {suggestion}?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.fr-FR.json
+++ b/src/powerquery-language-services/localization/templates/templates.fr-FR.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "'{funcName}' s'attendait à ce que l'argument pour '{argName}' soit '{expected}', mais a obtenu '{actual}' à la place.",
   "error_validation_invokeExpression_typeMismatch_unnamed": "Désolé... L’argument du paramètre '{argName}' devait être '{expected}', mais nous avons obtenu '{actual}' à la place.",
   "error_validation_unknownIdentifier_noSuggestion": "Cannot find the name '{identifier}'.",
-  "error_validation_unknownIdentifier_suggestion": "Impossible de trouver le nom '{identifier}'. Vouliez-vous dire '{suggestion}' ?"
+  "error_validation_unknownIdentifier_suggestion": "Impossible de trouver le nom '{identifier}'. Vouliez-vous dire '{suggestion}' ?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.gl-ES.json
+++ b/src/powerquery-language-services/localization/templates/templates.gl-ES.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "“{funcName}” esperaba que o argumento para “{argName}” fose “{expected}”, mais recibiu “{actual}”.",
   "error_validation_invokeExpression_typeMismatch_unnamed": "Esperábase que o argumento para “{argName}” fose “{expected}”, mais recibiu “{actual}”.",
   "error_validation_unknownIdentifier_noSuggestion": "Cannot find the name '{identifier}'.",
-  "error_validation_unknownIdentifier_suggestion": "Non se pode atopar o nome '{identificador}', querías dicir '{suxestión}'?"
+  "error_validation_unknownIdentifier_suggestion": "Non se pode atopar o nome '{identificador}', querías dicir '{suxestión}'?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.hi-IN.json
+++ b/src/powerquery-language-services/localization/templates/templates.hi-IN.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "'{funcName}' ने '{argName}' के लिए '{expected}' तर्क की अपेक्षा की थी, लेकिन उसकी बजाय '{actual}' मिला.",
   "error_validation_invokeExpression_typeMismatch_unnamed": "{argName} के लिए {expected} तर्क की अपेक्षा थी, लेकिन उसके बजाय {actual} मिला.",
   "error_validation_unknownIdentifier_noSuggestion": "Cannot find the name '{identifier}'.",
-  "error_validation_unknownIdentifier_suggestion": "'{identifier}' नाम नहीं मिला, क्या आपका मतलब '{suggestion}' था?"
+  "error_validation_unknownIdentifier_suggestion": "'{identifier}' नाम नहीं मिला, क्या आपका मतलब '{suggestion}' था?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.hr-HR.json
+++ b/src/powerquery-language-services/localization/templates/templates.hr-HR.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "'{funcName}' je očekivao da će argument za '{argName}' biti '{expected}', ali je umjesto toga dobio '{actual}'.",
   "error_validation_invokeExpression_typeMismatch_unnamed": "Očekivao da će argument za '{argName}' biti '{expected}', ali je umjesto dobio '{actual}'.",
   "error_validation_unknownIdentifier_noSuggestion": "Cannot find the name '{identifier}'.",
-  "error_validation_unknownIdentifier_suggestion": "Nije moguće pronaći naziv '{identifier}', jeste li mislili '{suggestion}'?"
+  "error_validation_unknownIdentifier_suggestion": "Nije moguće pronaći naziv '{identifier}', jeste li mislili '{suggestion}'?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.hu-HU.json
+++ b/src/powerquery-language-services/localization/templates/templates.hu-HU.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "A(z) {funcName} a(z) {expected} argumentumot várta ehhez: {argName}, de helyette {actual} argumentumot kapott.",
   "error_validation_invokeExpression_typeMismatch_unnamed": "A rendszer várta ehhez: {argName} az argumentumot, így: {expected}, de ehelyett ezt: {actual} kapta.",
   "error_validation_unknownIdentifier_noSuggestion": "Cannot find the name '{identifier}'.",
-  "error_validation_unknownIdentifier_suggestion": "A(z) „{identifier}“ név nem található. Erre gondolt: „{suggestion}“?"
+  "error_validation_unknownIdentifier_suggestion": "A(z) „{identifier}“ név nem található. Erre gondolt: „{suggestion}“?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.id-ID.json
+++ b/src/powerquery-language-services/localization/templates/templates.id-ID.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "'{funcName}' mengharapkan argumen untuk '{argName}' adalah '{expected}', namun mendapatkan '{actual}' sebagai gantinya.",
   "error_validation_invokeExpression_typeMismatch_unnamed": "Argumen yang diharapkan untuk '{argName}' adalah '{expected}', namun yang didapatkan adalah '{actual}'.",
   "error_validation_unknownIdentifier_noSuggestion": "Cannot find the name '{identifier}'.",
-  "error_validation_unknownIdentifier_suggestion": "Tidak dapat menemukan nama '{identifier}', apakah maksud Anda '{suggestion}'?"
+  "error_validation_unknownIdentifier_suggestion": "Tidak dapat menemukan nama '{identifier}', apakah maksud Anda '{suggestion}'?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.it-IT.json
+++ b/src/powerquery-language-services/localization/templates/templates.it-IT.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "' {funcName} prevedeva che l'argomento per ' {argName}' fosse ' {expected}', ma è stato ottenuto ' {actual}'.",
   "error_validation_invokeExpression_typeMismatch_unnamed": "L'argomento per ' {argName}' prevedeva che fosse ' {expected}', ma è stato ottenuto ' {actual}'.",
   "error_validation_unknownIdentifier_noSuggestion": "Impossibile trovare il nome '{identifier}'.",
-  "error_validation_unknownIdentifier_suggestion": "Il nome '{identifier}' non è stato trovato. Si intendeva '{suggestion}'?"
+  "error_validation_unknownIdentifier_suggestion": "Il nome '{identifier}' non è stato trovato. Si intendeva '{suggestion}'?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.ja-JP.json
+++ b/src/powerquery-language-services/localization/templates/templates.ja-JP.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "'{funcName} は '{argName}' の引数が '{expected}' であることを期待していましたが、代わりに '{actual}' を取得しました。",
   "error_validation_invokeExpression_typeMismatch_unnamed": "'{argName}' の引数が '{expected}' であることを期待していましたが、代わりに '{actual}' を取得しました。",
   "error_validation_unknownIdentifier_noSuggestion": "Cannot find the name '{identifier}'.",
-  "error_validation_unknownIdentifier_suggestion": "名前 '{identifier}' が見つかりません。'{suggestion}' のことですか?"
+  "error_validation_unknownIdentifier_suggestion": "名前 '{identifier}' が見つかりません。'{suggestion}' のことですか?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.json
+++ b/src/powerquery-language-services/localization/templates/templates.json
@@ -24,5 +24,14 @@
     "_error_validation_unknownIdentifier_noSuggestion.comment": "An error when an unknown variable is referenced. Expected to be user facing.",
 
     "error_validation_unknownIdentifier_suggestion": "Cannot find the name '{identifier}', did you mean '{suggestion}'?",
-    "_error_validation_unknownIdentifier_suggestion.comment": "An error when an unknown variable is referenced, but a similarly named variable is in scope. Expected to be user facing."
+    "_error_validation_unknownIdentifier_suggestion.comment": "An error when an unknown variable is referenced, but a similarly named variable is in scope. Expected to be user facing.",
+
+    "parameterDocumentation_default": "Default: `{value}`",
+    "_parameterDocumentation_default.comment": "Label shown in parameter documentation indicating the default value. The {value} placeholder is the actual default. Expected to be user facing.",
+    "parameterDocumentation_allowedValues": "Allowed values: {values}",
+    "_parameterDocumentation_allowedValues.comment": "Label shown in parameter documentation listing the allowed values. The {values} placeholder is a comma-separated list. Expected to be user facing.",
+    "parameterDocumentation_sampleValues": "Sample values: {values}",
+    "_parameterDocumentation_sampleValues.comment": "Label shown in parameter documentation listing sample values. The {values} placeholder is a comma-separated list. Expected to be user facing.",
+    "parameterDocumentation_type": "Type: `{type}`",
+    "_parameterDocumentation_type.comment": "Label shown in parameter documentation indicating the type. The {type} placeholder is the type name. Expected to be user facing."
 }

--- a/src/powerquery-language-services/localization/templates/templates.kk-KZ.json
+++ b/src/powerquery-language-services/localization/templates/templates.kk-KZ.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "\"{funcName}\" функциясы үшін \"{argName}\" аргументінің мәні \"{expected}\" болып күтілген, бірақ \"{actual}\" мәні болып шыққан.",
   "error_validation_invokeExpression_typeMismatch_unnamed": "'{argName}' параметрінің аргументі '{expected}' болып күтілген, бірақ аргументі '{actual}' болып шыққан.",
   "error_validation_unknownIdentifier_noSuggestion": "«{identifier}» деген атауды табу мүмкін емес.",
-  "error_validation_unknownIdentifier_suggestion": "\"{identifier}\" атауын табу мүмкін емес. Сіз \"{suggestion}\" деп енгізгіңіз келді ме?"
+  "error_validation_unknownIdentifier_suggestion": "\"{identifier}\" атауын табу мүмкін емес. Сіз \"{suggestion}\" деп енгізгіңіз келді ме?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.ko-KR.json
+++ b/src/powerquery-language-services/localization/templates/templates.ko-KR.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "'{funcName}'에서는 '{argName}'에 대한 인수를 '{expected}'(으)로 예상했지만 대신 '{actual}'을(를) 받았습니다.",
   "error_validation_invokeExpression_typeMismatch_unnamed": "'{argName}'에 대한 인수가 '{expected}'일 것으로 예상되었지만 대신 '{actual}'이(가) 수신되었습니다.",
   "error_validation_unknownIdentifier_noSuggestion": "Cannot find the name '{identifier}'.",
-  "error_validation_unknownIdentifier_suggestion": "이름 '{identifier}'을(를) 찾을 수 없습니다. '{suggestion}'을(를) 의미했나요?"
+  "error_validation_unknownIdentifier_suggestion": "이름 '{identifier}'을(를) 찾을 수 없습니다. '{suggestion}'을(를) 의미했나요?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.lt-LT.json
+++ b/src/powerquery-language-services/localization/templates/templates.lt-LT.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "„{funcName}“ numatomas „{argName}“ argumentas turėtų būti „{expected}“, tačiau gautas „{actual}“.",
   "error_validation_invokeExpression_typeMismatch_unnamed": "Tikėtasi, kad argumentas, skirtas „{argName}“, bus „{expected}“, tačiau gautas „{actual}“.",
   "error_validation_unknownIdentifier_noSuggestion": "Nepavyksta rasti pavadinimo „{identifier}“.",
-  "error_validation_unknownIdentifier_suggestion": "Nepavyko rasti pavadinimo „{identifier}“. Ar turėjote omenyje „{suggestion}“?"
+  "error_validation_unknownIdentifier_suggestion": "Nepavyko rasti pavadinimo „{identifier}“. Ar turėjote omenyje „{suggestion}“?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.lv-LV.json
+++ b/src/powerquery-language-services/localization/templates/templates.lv-LV.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "Funkcijā {funcName} bija paredzēts, ka būs arguments {argName} ar vērtību {expected}, bet tā vietā bija {actual}.",
   "error_validation_invokeExpression_typeMismatch_unnamed": "Bija paredzēts, ka būs arguments {argName} ar vērtību {expected}, bet tā vietā bija {actual}.",
   "error_validation_unknownIdentifier_noSuggestion": "Cannot find the name '{identifier}'.",
-  "error_validation_unknownIdentifier_suggestion": "Nevar atrast nosaukumu \"{identifier}\". Vai domājāt \"{suggestion}\"?"
+  "error_validation_unknownIdentifier_suggestion": "Nevar atrast nosaukumu \"{identifier}\". Vai domājāt \"{suggestion}\"?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.ms-MY.json
+++ b/src/powerquery-language-services/localization/templates/templates.ms-MY.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "'{funcName}' menjangkakan argumen untuk '{argName}' ialah '{expected}', tetapi sebaliknya mendapat '{actual}'.",
   "error_validation_invokeExpression_typeMismatch_unnamed": "Menjangkakan argumen untuk '{argName}' ialah '{expected}', tetapi sebaliknya mendapat '{actual}'.",
   "error_validation_unknownIdentifier_noSuggestion": "Tidak menemui nama '{identifier}'.",
-  "error_validation_unknownIdentifier_suggestion": "Tidak menemui nama '{identifier}', adakah anda maksudkan '{suggestion}'?"
+  "error_validation_unknownIdentifier_suggestion": "Tidak menemui nama '{identifier}', adakah anda maksudkan '{suggestion}'?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.nb-NO.json
+++ b/src/powerquery-language-services/localization/templates/templates.nb-NO.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "{funcName} forventet at argumentet for {argName} var {expected}, men fikk {actual} i stedet.",
   "error_validation_invokeExpression_typeMismatch_unnamed": "Forventet at argumentet {argName} skulle være {expected}, men fikk {actual} i stedet.",
   "error_validation_unknownIdentifier_noSuggestion": "Finner ikke navnet {identifier}.",
-  "error_validation_unknownIdentifier_suggestion": "Finner ikke navnet '{identifier}'. Mente du '{suggestion}'?"
+  "error_validation_unknownIdentifier_suggestion": "Finner ikke navnet '{identifier}'. Mente du '{suggestion}'?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.nl-NL.json
+++ b/src/powerquery-language-services/localization/templates/templates.nl-NL.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "'{funcName} verwachtte dat het argument voor '{argName}' '{expected}' zou zijn, maar kreeg in plaats daarvan '{actual}'.",
   "error_validation_invokeExpression_typeMismatch_unnamed": "Verwachtte dat het argument voor '{argName}' '{expected}' zou zijn, maar kreeg in plaats daarvan '{actual}'.",
   "error_validation_unknownIdentifier_noSuggestion": "Cannot find the name '{identifier}'.",
-  "error_validation_unknownIdentifier_suggestion": "Kan de naam {identifier} niet vinden. Bedoelt u {suggestion}?"
+  "error_validation_unknownIdentifier_suggestion": "Kan de naam {identifier} niet vinden. Bedoelt u {suggestion}?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.pl-PL.json
+++ b/src/powerquery-language-services/localization/templates/templates.pl-PL.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "Element „{funcName}” oczekiwał, że argument „{argName}” będzie miał wartość „{expected}”, ale zamiast tego uzyskano wartość „{actual}”.",
   "error_validation_invokeExpression_typeMismatch_unnamed": "Oczekiwano argumentu „{argName}” na „{expected}”, ale zamiast tego otrzymano „{actual}”.",
   "error_validation_unknownIdentifier_noSuggestion": "Cannot find the name '{identifier}'.",
-  "error_validation_unknownIdentifier_suggestion": "Nie można odnaleźć nazwy „{identifier}“. Czy chodziło Ci o „{suggestion}“?"
+  "error_validation_unknownIdentifier_suggestion": "Nie można odnaleźć nazwy „{identifier}“. Czy chodziło Ci o „{suggestion}“?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.pt-BR.json
+++ b/src/powerquery-language-services/localization/templates/templates.pt-BR.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "'{funcName}' esperava que o argumento para '{argName}' fosse '{expected}', mas obteve '{actual}' em vez disso.",
   "error_validation_invokeExpression_typeMismatch_unnamed": "Esperava que o argumento para '{argName}' fosse '{expected}', mas, em vez disso, obteve '{actual}'.",
   "error_validation_unknownIdentifier_noSuggestion": "Cannot find the name '{identifier}'.",
-  "error_validation_unknownIdentifier_suggestion": "Não é possível localizar o nome '{identifier}', você quis dizer '{suggestion}'?"
+  "error_validation_unknownIdentifier_suggestion": "Não é possível localizar o nome '{identifier}', você quis dizer '{suggestion}'?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.pt-PT.json
+++ b/src/powerquery-language-services/localization/templates/templates.pt-PT.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "Esperava-se que o argumento de \"{funcName}\" \"{argName}\" fosse \"{expected}\", mas foi \"{actual}\".",
   "error_validation_invokeExpression_typeMismatch_unnamed": "Esperava que o argumento para '{argName}' fosse '{expectativo}', mas em vez disso obteve '{actual}'.",
   "error_validation_unknownIdentifier_noSuggestion": "Cannot find the name '{identifier}'.",
-  "error_validation_unknownIdentifier_suggestion": "Não é possível encontrar o nome \"{identifier}\", queria dizer \"{suggestion}\"?"
+  "error_validation_unknownIdentifier_suggestion": "Não é possível encontrar o nome \"{identifier}\", queria dizer \"{suggestion}\"?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.ro-RO.json
+++ b/src/powerquery-language-services/localization/templates/templates.ro-RO.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "„{funcName}” se aștepta ca argumentul pentru „{argName}” să fie „{expected}”, dar a primit în schimb „{actual}”.",
   "error_validation_invokeExpression_typeMismatch_unnamed": "Se aștepta ca argumentul pentru „{argName}” să fie „{expected}”, dar s-a primit în schimb „{actual}”.",
   "error_validation_unknownIdentifier_noSuggestion": "Cannot find the name '{identifier}'.",
-  "error_validation_unknownIdentifier_suggestion": "Nu se poate găsi numele „{identifier}”, ați vrut să vă referiți la „{suggestion}”?"
+  "error_validation_unknownIdentifier_suggestion": "Nu se poate găsi numele „{identifier}”, ați vrut să vă referiți la „{suggestion}”?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.ru-RU.json
+++ b/src/powerquery-language-services/localization/templates/templates.ru-RU.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "Для функции \"{funcName}' ожидалось значение \"{expected}\" аргумента \"{argName}\", но было получено значение \"{actual}\".",
   "error_validation_invokeExpression_typeMismatch_unnamed": "Ожидалось, что аргументом для \"{argName}\" будет \"{expected}\", однако вместо этого получен аргумент \"{actual}\".",
   "error_validation_unknownIdentifier_noSuggestion": "Cannot find the name '{identifier}'.",
-  "error_validation_unknownIdentifier_suggestion": "Не удается найти имя \"{identifier}\". Вы имели в виду \"{suggestion}\"?"
+  "error_validation_unknownIdentifier_suggestion": "Не удается найти имя \"{identifier}\". Вы имели в виду \"{suggestion}\"?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.sk-SK.json
+++ b/src/powerquery-language-services/localization/templates/templates.sk-SK.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "Funkcia '{funcName}' očakávala, že argument '{argName}' bude '{expected}', ale namiesto toho sa vrátila hodnota '{actual}'.",
   "error_validation_invokeExpression_typeMismatch_unnamed": "Očakávalo sa, že argument '{argName}' bude '{expected}', ale namiesto toho sa vrátila hodnota '{actual}'.",
   "error_validation_unknownIdentifier_noSuggestion": "Nepodarilo sa nájsť názov {identifier}.",
-  "error_validation_unknownIdentifier_suggestion": "Nepodarilo sa nájsť názov {identifier}, mali ste na mysli {suggestion}?"
+  "error_validation_unknownIdentifier_suggestion": "Nepodarilo sa nájsť názov {identifier}, mali ste na mysli {suggestion}?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.sl-SI.json
+++ b/src/powerquery-language-services/localization/templates/templates.sl-SI.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "Za funkcijo »{funcName}« je bil za argument »{argName}« pričakovan parameter »{expected}«, vendar je bil namesto tega uporabljen parameter »{actual}«.",
   "error_validation_invokeExpression_typeMismatch_unnamed": "Za argument »{argName}« je bil pričakovan parameter »{expected}«, vendar je bil namesto tega uporabljen parameter »{actual}«.",
   "error_validation_unknownIdentifier_noSuggestion": "Imena '{identifier}' ni mogoče najti.",
-  "error_validation_unknownIdentifier_suggestion": "Imena '{identifier}' ni mogoče najti. Ali ste mislili '{suggestion}'?"
+  "error_validation_unknownIdentifier_suggestion": "Imena '{identifier}' ni mogoče najti. Ali ste mislili '{suggestion}'?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.sr-Cyrl-RS.json
+++ b/src/powerquery-language-services/localization/templates/templates.sr-Cyrl-RS.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "Функција '{funcName}' очекује аргумент за '{argName}' који треба да буде '{expected}', али је уместо дога добијен '{actual}'.",
   "error_validation_invokeExpression_typeMismatch_unnamed": "Очекивани аргумент за '{argName}' који треба да буде '{expected}', али је уместо тога добијен '{actual}'.",
   "error_validation_unknownIdentifier_noSuggestion": "Cannot find the name '{identifier}'.",
-  "error_validation_unknownIdentifier_suggestion": "Није могуће пронаћи име '{identifier}', да ли сте мислили на '{suggestion}'?"
+  "error_validation_unknownIdentifier_suggestion": "Није могуће пронаћи име '{identifier}', да ли сте мислили на '{suggestion}'?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.sr-Latn-RS.json
+++ b/src/powerquery-language-services/localization/templates/templates.sr-Latn-RS.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "Funkcija '{funcName}' očekuje argument za '{argName}' koji treba da bude '{expected}', ali je umesto doga dobijen '{actual}'.",
   "error_validation_invokeExpression_typeMismatch_unnamed": "Očekivani argument za '{argName}' koji treba da bude '{expected}', ali je umesto toga dobijen '{actual}'.",
   "error_validation_unknownIdentifier_noSuggestion": "Nije moguće pronaći ime „{identifier}“.",
-  "error_validation_unknownIdentifier_suggestion": "Nije moguće pronaći ime „{identifier}“, da li ste mislili na „{suggestion}“?"
+  "error_validation_unknownIdentifier_suggestion": "Nije moguće pronaći ime „{identifier}“, da li ste mislili na „{suggestion}“?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.sv-SE.json
+++ b/src/powerquery-language-services/localization/templates/templates.sv-SE.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "{funcName} förväntade att argumentet för {argName} ska vara {expected}, men ha {actual} i stället.",
   "error_validation_invokeExpression_typeMismatch_unnamed": "Förväntade att argumentet för {argName} ska vara {expected}, men ha {actual} i stället.",
   "error_validation_unknownIdentifier_noSuggestion": "Cannot find the name '{identifier}'.",
-  "error_validation_unknownIdentifier_suggestion": "Det gick inte att hitta namnet {identifier}, menar du {suggestion}?"
+  "error_validation_unknownIdentifier_suggestion": "Det gick inte att hitta namnet {identifier}, menar du {suggestion}?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.th-TH.json
+++ b/src/powerquery-language-services/localization/templates/templates.th-TH.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "'{funcName}' ต้องการอาร์กิวเมนต์สําหรับ '{argName}' เป็น '{expected}' แต่ได้รับ '{actual}' แทน",
   "error_validation_invokeExpression_typeMismatch_unnamed": "ต้องการอาร์กิวเมนต์สำหรับ '{argName}‘ เป็น '{expected}' แต่ได้ '{actual}' แทน",
   "error_validation_unknownIdentifier_noSuggestion": "Cannot find the name '{identifier}'.",
-  "error_validation_unknownIdentifier_suggestion": "ไม่พบชื่อ '{identifier}' คุณหมายถึง '{suggestion}' ใช่หรือไม่"
+  "error_validation_unknownIdentifier_suggestion": "ไม่พบชื่อ '{identifier}' คุณหมายถึง '{suggestion}' ใช่หรือไม่",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.tr-TR.json
+++ b/src/powerquery-language-services/localization/templates/templates.tr-TR.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "'{funcName}, '{argName}' bağımsız değişkeninin '{expected}' olmasını bekliyordu, ancak bunun yerine '{actual}' alındı.",
   "error_validation_invokeExpression_typeMismatch_unnamed": "'{argName}' bağımsız değişkeninin' {expected}' olması bekleniyordu, ancak bunun yerine '{actual}' alındı.",
   "error_validation_unknownIdentifier_noSuggestion": "'{identifier}' adı bulunamıyor.",
-  "error_validation_unknownIdentifier_suggestion": "'{identifier}' adı bulunamıyor. Şunu mu demek istediniz: '{suggestion}'?"
+  "error_validation_unknownIdentifier_suggestion": "'{identifier}' adı bulunamıyor. Şunu mu demek istediniz: '{suggestion}'?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.uk-UA.json
+++ b/src/powerquery-language-services/localization/templates/templates.uk-UA.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "Функція «{funcName}» очікувала, що аргумент для «{argName}» матиме значення «{expected}», але натомість він має значення «{actual}».",
   "error_validation_invokeExpression_typeMismatch_unnamed": "Очікувалося, що аргумент для \"{argName}\" матиме значення \"{expected}\", але натомість він має значення \"{actual}\".",
   "error_validation_unknownIdentifier_noSuggestion": "Cannot find the name '{identifier}'.",
-  "error_validation_unknownIdentifier_suggestion": "Не вдалося знайти ім’я '{identifier}'. Можливо, ви мали на увазі '{suggestion}'?"
+  "error_validation_unknownIdentifier_suggestion": "Не вдалося знайти ім’я '{identifier}'. Можливо, ви мали на увазі '{suggestion}'?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.vi-VN.json
+++ b/src/powerquery-language-services/localization/templates/templates.vi-VN.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "“{funcName}” dự kiến đối số cho “{argName}” sẽ là “{expected}” nhưng thay vào đó lại là “{actual}”.",
   "error_validation_invokeExpression_typeMismatch_unnamed": "Dự kiến tham đối cho '{argName}' sẽ là '{expected}' nhưng thay vào đó lại là '{actual}'.",
   "error_validation_unknownIdentifier_noSuggestion": "Cannot find the name '{identifier}'.",
-  "error_validation_unknownIdentifier_suggestion": "Không thể tìm thấy tên '{identifier}', ý bạn là '{suggestion}' phải không?"
+  "error_validation_unknownIdentifier_suggestion": "Không thể tìm thấy tên '{identifier}', ý bạn là '{suggestion}' phải không?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.zh-CN.json
+++ b/src/powerquery-language-services/localization/templates/templates.zh-CN.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "“{funcName}” 需要 “{argName}” 的参数为 “{expected}”，但实际获得的却是 “{actual}”。",
   "error_validation_invokeExpression_typeMismatch_unnamed": "\"{argName}\" 的参数应为 \"{expected}\"，但实际获得的却是 \"{actual}\"。",
   "error_validation_unknownIdentifier_noSuggestion": "找不到名称“{identifier}”。",
-  "error_validation_unknownIdentifier_suggestion": "找不到名称“{identifier}”，你是否指的是“{suggestion}”?"
+  "error_validation_unknownIdentifier_suggestion": "找不到名称“{identifier}”，你是否指的是“{suggestion}”?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/localization/templates/templates.zh-TW.json
+++ b/src/powerquery-language-services/localization/templates/templates.zh-TW.json
@@ -8,5 +8,9 @@
   "error_validation_invokeExpression_typeMismatch_named": "'{funcName} 預期 '{argName}' 的引數為 '{expected}'，但卻得到 '{actual}'。",
   "error_validation_invokeExpression_typeMismatch_unnamed": "預期 '{argName}' 的引數為 '{expected}'，但卻得到 '{actual}'。",
   "error_validation_unknownIdentifier_noSuggestion": "Cannot find the name '{identifier}'.",
-  "error_validation_unknownIdentifier_suggestion": "找不到名稱 '{identifier}'，您指的是 '{suggestion}' 嗎?"
+  "error_validation_unknownIdentifier_suggestion": "找不到名稱 '{identifier}'，您指的是 '{suggestion}' 嗎?",
+  "parameterDocumentation_default": "Default: `{value}`",
+  "parameterDocumentation_allowedValues": "Allowed values: {values}",
+  "parameterDocumentation_sampleValues": "Sample values: {values}",
+  "parameterDocumentation_type": "Type: `{type}`"
 }

--- a/src/powerquery-language-services/providers/languageCompletionItemProvider.ts
+++ b/src/powerquery-language-services/providers/languageCompletionItemProvider.ts
@@ -6,6 +6,7 @@ import { KeywordKind } from "@microsoft/powerquery-parser/lib/powerquery-parser/
 import { Trace } from "@microsoft/powerquery-parser/lib/powerquery-parser/common/trace";
 
 import { AutocompleteItemProviderContext, IAutocompleteItemProvider } from "./commonTypes";
+import { AutocompleteItemUtils } from "../inspection/autocomplete/autocompleteItem";
 import { Inspection } from "..";
 import { ProviderTraceConstant } from "../trace";
 
@@ -25,6 +26,14 @@ export class LanguageAutocompleteItemProvider implements IAutocompleteItemProvid
         KeywordKind.HashTable,
         KeywordKind.HashTime,
     ];
+
+    // Keywords that have corresponding snippet completions
+    private static readonly SnippetKeywords: ReadonlySet<string> = new Set([
+        KeywordKind.Let,
+        KeywordKind.If,
+        KeywordKind.Try,
+        KeywordKind.Each,
+    ]);
 
     protected readonly locale: string;
 
@@ -47,8 +56,14 @@ export class LanguageAutocompleteItemProvider implements IAutocompleteItemProvid
 
             const autocomplete: Inspection.Autocomplete = context.autocomplete;
 
+            const keywords: ReadonlyArray<Inspection.AutocompleteItem> = this.getKeywords(
+                autocomplete.triedKeyword,
+                context.cancellationToken,
+            );
+
             const autocompleteItems: Inspection.AutocompleteItem[] = [
-                ...this.getKeywords(autocomplete.triedKeyword, context.cancellationToken),
+                ...keywords,
+                ...this.getSnippets(keywords),
                 ...this.getLanguageConstants(autocomplete.triedLanguageConstant, context.cancellationToken),
                 ...this.getPrimitiveTypes(autocomplete.triedPrimitiveType, context.cancellationToken),
             ];
@@ -73,6 +88,17 @@ export class LanguageAutocompleteItemProvider implements IAutocompleteItemProvid
             (autocompleteItem: Inspection.AutocompleteItem) =>
                 LanguageAutocompleteItemProvider.ExcludedKeywords.includes(autocompleteItem.label) === false,
         );
+    }
+
+    // Include snippet completions when relevant keywords (let, if, try, each) are in the keyword results.
+    private getSnippets(
+        keywords: ReadonlyArray<Inspection.AutocompleteItem>,
+    ): ReadonlyArray<Inspection.AutocompleteItem> {
+        const hasSnippetKeyword: boolean = keywords.some((item: Inspection.AutocompleteItem) =>
+            LanguageAutocompleteItemProvider.SnippetKeywords.has(item.label),
+        );
+
+        return hasSnippetKeyword ? AutocompleteItemUtils.createSnippetItems() : [];
     }
 
     private getLanguageConstants(

--- a/src/test/analysis.test.ts
+++ b/src/test/analysis.test.ts
@@ -10,6 +10,7 @@ import {
     Result,
     ResultUtils,
 } from "@microsoft/powerquery-parser";
+import { CompletionItemKind } from "vscode-languageserver-types";
 import { expect } from "chai";
 
 import type {
@@ -41,7 +42,9 @@ describe(`Analysis`, () => {
 
             const autocompleteItem: AutocompleteItem = Assert.asDefined(
                 autocompleteItems.find(
-                    (item: AutocompleteItem) => item.label === TestConstants.TestLibraryName.SquareIfNumber,
+                    (item: AutocompleteItem) =>
+                        item.label === TestConstants.TestLibraryName.SquareIfNumber &&
+                        item.kind === CompletionItemKind.Variable,
                 ),
             );
 

--- a/src/test/inspection/autocomplete/autocompleteItem.test.ts
+++ b/src/test/inspection/autocomplete/autocompleteItem.test.ts
@@ -2,13 +2,13 @@
 // Licensed under the MIT license.
 
 import "mocha";
-import { expect } from "chai";
 import { CompletionItemKind, InsertTextFormat, MarkupKind } from "vscode-languageserver-types";
 import { Keyword, Type, TypeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { expect } from "chai";
 
-import { AutocompleteItemUtils } from "../../../powerquery-language-services/inspection/autocomplete/autocompleteItem";
-import { AutocompleteItem } from "../../../powerquery-language-services/inspection/autocomplete/autocompleteItem/autocompleteItem";
 import { Library, LibraryDefinitionUtils } from "../../../powerquery-language-services";
+import { AutocompleteItem } from "../../../powerquery-language-services/inspection/autocomplete/autocompleteItem/autocompleteItem";
+import { AutocompleteItemUtils } from "../../../powerquery-language-services/inspection/autocomplete/autocompleteItem";
 
 describe("AutocompleteItemUtils", () => {
     describe("createSnippetItems", () => {
@@ -41,9 +41,7 @@ describe("AutocompleteItemUtils", () => {
             expect(ifSnippet).to.not.equal(undefined);
             expect(ifSnippet!.kind).to.equal(CompletionItemKind.Snippet);
             expect(ifSnippet!.insertTextFormat).to.equal(InsertTextFormat.Snippet);
-            expect(ifSnippet!.insertText).to.equal(
-                "if ${1:condition} then ${2:trueValue} else ${3:falseValue}",
-            );
+            expect(ifSnippet!.insertText).to.equal("if ${1:condition} then ${2:trueValue} else ${3:falseValue}");
         });
 
         it("try...otherwise snippet has correct properties", () => {
@@ -129,19 +127,13 @@ describe("AutocompleteItemUtils", () => {
 
         describe("commitCharacters", () => {
             it("function definition has commitCharacters ['(']", () => {
-                const item: AutocompleteItem = AutocompleteItemUtils.fromLibraryDefinition(
-                    "TestFunc",
-                    functionDef,
-                );
+                const item: AutocompleteItem = AutocompleteItemUtils.fromLibraryDefinition("TestFunc", functionDef);
 
                 expect(item.commitCharacters).to.deep.equal(["("]);
             });
 
             it("constant definition has commitCharacters undefined", () => {
-                const item: AutocompleteItem = AutocompleteItemUtils.fromLibraryDefinition(
-                    "TestConst",
-                    constantDef,
-                );
+                const item: AutocompleteItem = AutocompleteItemUtils.fromLibraryDefinition("TestConst", constantDef);
 
                 expect(item.commitCharacters).to.equal(undefined);
             });
@@ -149,10 +141,7 @@ describe("AutocompleteItemUtils", () => {
 
         describe("documentation", () => {
             it("function definition has PlainText documentation with description", () => {
-                const item: AutocompleteItem = AutocompleteItemUtils.fromLibraryDefinition(
-                    "TestFunc",
-                    functionDef,
-                );
+                const item: AutocompleteItem = AutocompleteItemUtils.fromLibraryDefinition("TestFunc", functionDef);
 
                 expect(item.documentation).to.deep.equal({
                     kind: MarkupKind.PlainText,
@@ -161,10 +150,7 @@ describe("AutocompleteItemUtils", () => {
             });
 
             it("constant definition has PlainText documentation with description", () => {
-                const item: AutocompleteItem = AutocompleteItemUtils.fromLibraryDefinition(
-                    "TestConst",
-                    constantDef,
-                );
+                const item: AutocompleteItem = AutocompleteItemUtils.fromLibraryDefinition("TestConst", constantDef);
 
                 expect(item.documentation).to.deep.equal({
                     kind: MarkupKind.PlainText,
@@ -175,10 +161,7 @@ describe("AutocompleteItemUtils", () => {
 
         describe("jaroWinklerScore", () => {
             it("has jaroWinklerScore of 1 when no other text", () => {
-                const item: AutocompleteItem = AutocompleteItemUtils.fromLibraryDefinition(
-                    "TestFunc",
-                    functionDef,
-                );
+                const item: AutocompleteItem = AutocompleteItemUtils.fromLibraryDefinition("TestFunc", functionDef);
 
                 expect(item.jaroWinklerScore).to.equal(1);
             });
@@ -186,10 +169,7 @@ describe("AutocompleteItemUtils", () => {
 
         describe("kind", () => {
             it("uses completionItemKind from library definition", () => {
-                const funcItem: AutocompleteItem = AutocompleteItemUtils.fromLibraryDefinition(
-                    "TestFunc",
-                    functionDef,
-                );
+                const funcItem: AutocompleteItem = AutocompleteItemUtils.fromLibraryDefinition("TestFunc", functionDef);
 
                 expect(funcItem.kind).to.equal(CompletionItemKind.Function);
 
@@ -204,10 +184,7 @@ describe("AutocompleteItemUtils", () => {
 
         describe("powerQueryType", () => {
             it("uses asPowerQueryType from library definition", () => {
-                const item: AutocompleteItem = AutocompleteItemUtils.fromLibraryDefinition(
-                    "TestConst",
-                    constantDef,
-                );
+                const item: AutocompleteItem = AutocompleteItemUtils.fromLibraryDefinition("TestConst", constantDef);
 
                 expect(item.powerQueryType).to.equal(Type.NumberInstance);
             });

--- a/src/test/inspection/autocomplete/autocompleteItem.test.ts
+++ b/src/test/inspection/autocomplete/autocompleteItem.test.ts
@@ -1,0 +1,216 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import "mocha";
+import { expect } from "chai";
+import { CompletionItemKind, InsertTextFormat, MarkupKind } from "vscode-languageserver-types";
+import { Keyword, Type, TypeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+
+import { AutocompleteItemUtils } from "../../../powerquery-language-services/inspection/autocomplete/autocompleteItem";
+import { AutocompleteItem } from "../../../powerquery-language-services/inspection/autocomplete/autocompleteItem/autocompleteItem";
+import { Library, LibraryDefinitionUtils } from "../../../powerquery-language-services";
+
+describe("AutocompleteItemUtils", () => {
+    describe("createSnippetItems", () => {
+        let snippetItems: ReadonlyArray<AutocompleteItem>;
+
+        before(() => {
+            snippetItems = AutocompleteItemUtils.createSnippetItems();
+        });
+
+        it("returns exactly 4 items", () => {
+            expect(snippetItems).to.have.lengthOf(4);
+        });
+
+        it("let...in snippet has correct properties", () => {
+            const letSnippet: AutocompleteItem | undefined = snippetItems.find(
+                (item: AutocompleteItem) => item.label === "let...in",
+            );
+
+            expect(letSnippet).to.not.equal(undefined);
+            expect(letSnippet!.kind).to.equal(CompletionItemKind.Snippet);
+            expect(letSnippet!.insertTextFormat).to.equal(InsertTextFormat.Snippet);
+            expect(letSnippet!.insertText).to.equal("let\n\t${1:name} = ${2:value}\nin\n\t${0:result}");
+        });
+
+        it("if...then...else snippet has correct properties", () => {
+            const ifSnippet: AutocompleteItem | undefined = snippetItems.find(
+                (item: AutocompleteItem) => item.label === "if...then...else",
+            );
+
+            expect(ifSnippet).to.not.equal(undefined);
+            expect(ifSnippet!.kind).to.equal(CompletionItemKind.Snippet);
+            expect(ifSnippet!.insertTextFormat).to.equal(InsertTextFormat.Snippet);
+            expect(ifSnippet!.insertText).to.equal(
+                "if ${1:condition} then ${2:trueValue} else ${3:falseValue}",
+            );
+        });
+
+        it("try...otherwise snippet has correct properties", () => {
+            const trySnippet: AutocompleteItem | undefined = snippetItems.find(
+                (item: AutocompleteItem) => item.label === "try...otherwise",
+            );
+
+            expect(trySnippet).to.not.equal(undefined);
+            expect(trySnippet!.kind).to.equal(CompletionItemKind.Snippet);
+            expect(trySnippet!.insertTextFormat).to.equal(InsertTextFormat.Snippet);
+            expect(trySnippet!.insertText).to.equal("try ${1:expression} otherwise ${2:default}");
+        });
+
+        it("each snippet has correct properties", () => {
+            const eachSnippet: AutocompleteItem | undefined = snippetItems.find(
+                (item: AutocompleteItem) => item.label === "each",
+            );
+
+            expect(eachSnippet).to.not.equal(undefined);
+            expect(eachSnippet!.kind).to.equal(CompletionItemKind.Snippet);
+            expect(eachSnippet!.insertTextFormat).to.equal(InsertTextFormat.Snippet);
+            expect(eachSnippet!.insertText).to.equal("each ${0:expression}");
+        });
+
+        it("all snippets have jaroWinklerScore of 1", () => {
+            for (const snippet of snippetItems) {
+                expect(snippet.jaroWinklerScore).to.equal(1, `expected jaroWinklerScore of 1 for "${snippet.label}"`);
+            }
+        });
+
+        it("all snippets have powerQueryType of NotApplicableInstance", () => {
+            for (const snippet of snippetItems) {
+                expect(snippet.powerQueryType).to.equal(
+                    Type.NotApplicableInstance,
+                    `expected NotApplicableInstance for "${snippet.label}"`,
+                );
+            }
+        });
+    });
+
+    describe("fromKeywordKind", () => {
+        it("creates keyword item with commitCharacters [' ']", () => {
+            const item: AutocompleteItem = AutocompleteItemUtils.fromKeywordKind(Keyword.KeywordKind.Let);
+            expect(item.commitCharacters).to.deep.equal([" "]);
+        });
+
+        it("creates keyword item with kind Keyword", () => {
+            const item: AutocompleteItem = AutocompleteItemUtils.fromKeywordKind(Keyword.KeywordKind.If);
+            expect(item.kind).to.equal(CompletionItemKind.Keyword);
+        });
+
+        it("has jaroWinklerScore of 1 when no other text", () => {
+            const item: AutocompleteItem = AutocompleteItemUtils.fromKeywordKind(Keyword.KeywordKind.Then);
+            expect(item.jaroWinklerScore).to.equal(1);
+        });
+
+        it("has label matching the keyword kind", () => {
+            const item: AutocompleteItem = AutocompleteItemUtils.fromKeywordKind(Keyword.KeywordKind.Let);
+            expect(item.label).to.equal("let");
+        });
+
+        it("has powerQueryType of NotApplicableInstance", () => {
+            const item: AutocompleteItem = AutocompleteItemUtils.fromKeywordKind(Keyword.KeywordKind.Let);
+            expect(item.powerQueryType).to.equal(Type.NotApplicableInstance);
+        });
+    });
+
+    describe("fromLibraryDefinition", () => {
+        const functionDef: Library.LibraryFunction = LibraryDefinitionUtils.functionDefinition(
+            "TestFunc",
+            "Test function description",
+            TypeUtils.definedFunction(false, [], Type.AnyInstance),
+            CompletionItemKind.Function,
+            [],
+        );
+
+        const constantDef: Library.LibraryConstant = LibraryDefinitionUtils.constantDefinition(
+            "TestConst",
+            "Test constant description",
+            Type.NumberInstance,
+            CompletionItemKind.Constant,
+        );
+
+        describe("commitCharacters", () => {
+            it("function definition has commitCharacters ['(']", () => {
+                const item: AutocompleteItem = AutocompleteItemUtils.fromLibraryDefinition(
+                    "TestFunc",
+                    functionDef,
+                );
+
+                expect(item.commitCharacters).to.deep.equal(["("]);
+            });
+
+            it("constant definition has commitCharacters undefined", () => {
+                const item: AutocompleteItem = AutocompleteItemUtils.fromLibraryDefinition(
+                    "TestConst",
+                    constantDef,
+                );
+
+                expect(item.commitCharacters).to.equal(undefined);
+            });
+        });
+
+        describe("documentation", () => {
+            it("function definition has PlainText documentation with description", () => {
+                const item: AutocompleteItem = AutocompleteItemUtils.fromLibraryDefinition(
+                    "TestFunc",
+                    functionDef,
+                );
+
+                expect(item.documentation).to.deep.equal({
+                    kind: MarkupKind.PlainText,
+                    value: "Test function description",
+                });
+            });
+
+            it("constant definition has PlainText documentation with description", () => {
+                const item: AutocompleteItem = AutocompleteItemUtils.fromLibraryDefinition(
+                    "TestConst",
+                    constantDef,
+                );
+
+                expect(item.documentation).to.deep.equal({
+                    kind: MarkupKind.PlainText,
+                    value: "Test constant description",
+                });
+            });
+        });
+
+        describe("jaroWinklerScore", () => {
+            it("has jaroWinklerScore of 1 when no other text", () => {
+                const item: AutocompleteItem = AutocompleteItemUtils.fromLibraryDefinition(
+                    "TestFunc",
+                    functionDef,
+                );
+
+                expect(item.jaroWinklerScore).to.equal(1);
+            });
+        });
+
+        describe("kind", () => {
+            it("uses completionItemKind from library definition", () => {
+                const funcItem: AutocompleteItem = AutocompleteItemUtils.fromLibraryDefinition(
+                    "TestFunc",
+                    functionDef,
+                );
+
+                expect(funcItem.kind).to.equal(CompletionItemKind.Function);
+
+                const constItem: AutocompleteItem = AutocompleteItemUtils.fromLibraryDefinition(
+                    "TestConst",
+                    constantDef,
+                );
+
+                expect(constItem.kind).to.equal(CompletionItemKind.Constant);
+            });
+        });
+
+        describe("powerQueryType", () => {
+            it("uses asPowerQueryType from library definition", () => {
+                const item: AutocompleteItem = AutocompleteItemUtils.fromLibraryDefinition(
+                    "TestConst",
+                    constantDef,
+                );
+
+                expect(item.powerQueryType).to.equal(Type.NumberInstance);
+            });
+        });
+    });
+});

--- a/src/test/library/buildParameterDocumentation.test.ts
+++ b/src/test/library/buildParameterDocumentation.test.ts
@@ -1,0 +1,175 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import "mocha";
+import { expect } from "chai";
+import { ResultUtils } from "@microsoft/powerquery-parser";
+import { CompletionItemKind } from "vscode-languageserver-types";
+
+import { Library, LibrarySymbolUtils } from "../../powerquery-language-services";
+import { LibrarySymbol, LibrarySymbolFunctionParameter } from "../../powerquery-language-services/library/librarySymbol";
+
+function createLibrarySymbolWithParameter(paramOverrides: Partial<LibrarySymbolFunctionParameter>): LibrarySymbol {
+    return {
+        name: "TestFunction",
+        documentation: { description: "test function", longDescription: null },
+        completionItemKind: CompletionItemKind.Function,
+        isDataSource: false,
+        type: "any",
+        functionParameters: [
+            {
+                name: "param1",
+                type: "text",
+                isRequired: true,
+                isNullable: false,
+                caption: undefined,
+                description: undefined,
+                sampleValues: undefined,
+                allowedValues: undefined,
+                defaultValue: undefined,
+                fields: undefined,
+                enumNames: undefined,
+                enumCaptions: undefined,
+                ...paramOverrides,
+            },
+        ],
+    };
+}
+
+function getParameterDocumentation(librarySymbol: LibrarySymbol): string | undefined {
+    const result = LibrarySymbolUtils.createLibraryDefinition(librarySymbol);
+    ResultUtils.assertIsOk(result);
+    const funcDef: Library.LibraryFunction = result.value as Library.LibraryFunction;
+
+    return funcDef.parameters[0].documentation;
+}
+
+describe("buildParameterDocumentation", () => {
+    it("parameter with only description", () => {
+        const documentation: string | undefined = getParameterDocumentation(
+            createLibrarySymbolWithParameter({
+                description: "A text parameter",
+            }),
+        );
+
+        expect(documentation).to.equal("A text parameter\n\nType: `text`");
+    });
+
+    it("parameter with caption and description", () => {
+        const documentation: string | undefined = getParameterDocumentation(
+            createLibrarySymbolWithParameter({
+                caption: "Column Name",
+                description: "Pick a column",
+            }),
+        );
+
+        expect(documentation).to.equal("**Column Name**\n\nPick a column\n\nType: `text`");
+    });
+
+    it("parameter with all fields", () => {
+        const documentation: string | undefined = getParameterDocumentation(
+            createLibrarySymbolWithParameter({
+                caption: "Caption",
+                description: "description text",
+                defaultValue: "hello",
+                allowedValues: ["a", "b"],
+                sampleValues: ["x", "y"],
+            }),
+        );
+
+        expect(documentation).to.equal(
+            "**Caption**\n\ndescription text\n\nDefault: `hello`\n\nAllowed values: `a`, `b`\n\nSample values: `x`, `y`\n\nType: `text`",
+        );
+    });
+
+    it("parameter with no documentation fields returns undefined", () => {
+        const documentation: string | undefined = getParameterDocumentation(
+            createLibrarySymbolWithParameter({
+                caption: undefined,
+                description: undefined,
+                defaultValue: undefined,
+                allowedValues: undefined,
+                sampleValues: undefined,
+            }),
+        );
+
+        expect(documentation).to.equal(undefined);
+    });
+
+    it("parameter with type only returns undefined", () => {
+        // type exists but no other content so parts.length is 0 before type check
+        const documentation: string | undefined = getParameterDocumentation(
+            createLibrarySymbolWithParameter({
+                type: "text",
+                caption: undefined,
+                description: undefined,
+                defaultValue: undefined,
+                allowedValues: undefined,
+                sampleValues: undefined,
+            }),
+        );
+
+        expect(documentation).to.equal(undefined);
+    });
+
+    it("parameter with description and type includes both", () => {
+        const documentation: string | undefined = getParameterDocumentation(
+            createLibrarySymbolWithParameter({
+                description: "some description",
+                type: "number",
+            }),
+        );
+
+        expect(documentation).to.equal("some description\n\nType: `number`");
+    });
+
+    it("parameter with defaultValue", () => {
+        const documentation: string | undefined = getParameterDocumentation(
+            createLibrarySymbolWithParameter({
+                defaultValue: "myDefault",
+            }),
+        );
+
+        expect(documentation).to.contain("Default: `myDefault`");
+    });
+
+    it("parameter with allowedValues", () => {
+        const documentation: string | undefined = getParameterDocumentation(
+            createLibrarySymbolWithParameter({
+                allowedValues: ["v1", "v2"],
+            }),
+        );
+
+        expect(documentation).to.contain("Allowed values: `v1`, `v2`");
+    });
+
+    it("parameter with sampleValues", () => {
+        const documentation: string | undefined = getParameterDocumentation(
+            createLibrarySymbolWithParameter({
+                sampleValues: ["v1", "v2"],
+            }),
+        );
+
+        expect(documentation).to.contain("Sample values: `v1`, `v2`");
+    });
+
+    it("parameter with numeric defaultValue", () => {
+        const documentation: string | undefined = getParameterDocumentation(
+            createLibrarySymbolWithParameter({
+                defaultValue: 42,
+            }),
+        );
+
+        expect(documentation).to.contain("Default: `42`");
+    });
+
+    it("parameter with numeric allowedValues", () => {
+        const documentation: string | undefined = getParameterDocumentation(
+            createLibrarySymbolWithParameter({
+                allowedValues: [1, 2, 3],
+            }),
+        );
+
+        expect(documentation).to.contain("Allowed values: `1`, `2`, `3`");
+    });
+});

--- a/src/test/library/buildParameterDocumentation.test.ts
+++ b/src/test/library/buildParameterDocumentation.test.ts
@@ -2,12 +2,15 @@
 // Licensed under the MIT license.
 
 import "mocha";
-import { expect } from "chai";
-import { ResultUtils } from "@microsoft/powerquery-parser";
+import { Result, ResultUtils } from "@microsoft/powerquery-parser";
 import { CompletionItemKind } from "vscode-languageserver-types";
+import { expect } from "chai";
 
 import { Library, LibrarySymbolUtils } from "../../powerquery-language-services";
-import { LibrarySymbol, LibrarySymbolFunctionParameter } from "../../powerquery-language-services/library/librarySymbol";
+import {
+    LibrarySymbol,
+    LibrarySymbolFunctionParameter,
+} from "../../powerquery-language-services/library/librarySymbol";
 
 function createLibrarySymbolWithParameter(paramOverrides: Partial<LibrarySymbolFunctionParameter>): LibrarySymbol {
     return {
@@ -37,7 +40,9 @@ function createLibrarySymbolWithParameter(paramOverrides: Partial<LibrarySymbolF
 }
 
 function getParameterDocumentation(librarySymbol: LibrarySymbol): string | undefined {
-    const result = LibrarySymbolUtils.createLibraryDefinition(librarySymbol);
+    const result: Result<Library.TLibraryDefinition, LibrarySymbolUtils.FailedLibrarySymbolConversion> =
+        LibrarySymbolUtils.createLibraryDefinition(librarySymbol);
+
     ResultUtils.assertIsOk(result);
     const funcDef: Library.LibraryFunction = result.value as Library.LibraryFunction;
 

--- a/src/test/providers/simpleLibraryProvider.test.ts
+++ b/src/test/providers/simpleLibraryProvider.test.ts
@@ -116,7 +116,10 @@ describe(`SimpleLibraryProvider`, () => {
             label: "Test.SquareIfNumber",
             parameters: [
                 {
-                    documentation: undefined,
+                    documentation: {
+                        kind: "markdown",
+                        value: "If the argument is a number then multiply it by itself, otherwise return argument as-is.",
+                    },
                     label: "x",
                 },
             ],


### PR DESCRIPTION
Summary

  Improves Intellisense completion items with documentation, snippets, and commit characters.

  Changes

  1. Library parameter documentation in signature help ParameterInformation.documentation was hardcoded to undefined
  despite rich data being available. Now renders markdown from caption, description, defaultValue, allowedValues,
  sampleValues, and type.

  2. Documentation on library completion items Library function/constant completions now include the description as
  PlainText documentation, visible in the autocomplete popup.

  3. Snippet completions Four snippet templates with tab stops: let...in, if...then...else, try...otherwise, each.
  They appear contextually when the corresponding keyword is valid.

  4. Commit characters Auto-accepts completions on: ( for functions, . and [ for variables, space for keywords.

  5. Version bump Bumped to 0.12.0 (semver minor — new features, no breaking changes).