### PR TITLE
Cache knownIdentifiers per scope in validateUnknownIdentifiers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.14.0",
+    "version": "0.14.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/powerquery-language-services",
-            "version": "0.14.0",
+            "version": "0.14.1",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/powerquery-formatter": "0.3.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-language-services",
-    "version": "0.14.0",
+    "version": "0.14.1",
     "author": "Microsoft",
     "license": "MIT",
     "scripts": {

--- a/src/powerquery-language-services/validate/validateUnknownIdentifiers.ts
+++ b/src/powerquery-language-services/validate/validateUnknownIdentifiers.ts
@@ -129,6 +129,14 @@ function findUnknownIdentifiers(
 
     const unknownIdentifiers: UnknownIdentifier[] = [];
 
+    // Compute library keys once for the entire validation run instead of per-unknown-identifier.
+    const libraryKeys: ReadonlyArray<string> = LibraryUtils.getDefinitionKeys(validationSettings.library);
+
+    // Cache the combined known-identifier list per NodeScope instance.
+    // Multiple identifiers in the same scope (e.g. bindings in a let) share the same list,
+    // avoiding repeated array allocation and spreading.
+    const knownIdentifiersByScope: Map<Inspection.NodeScope, ReadonlyArray<string>> = new Map();
+
     for (const identifierWithNodeScope of identifiersWithNodeScope) {
         if (ResultUtils.isError(identifierWithNodeScope.triedNodeScope)) {
             continue;
@@ -146,10 +154,12 @@ function findUnknownIdentifiers(
                 identifierLiteral: literal,
             })
         ) {
-            const knownIdentifiers: ReadonlyArray<string> = [
-                ...nodeScope.scopeItemByKey.keys(),
-                ...LibraryUtils.getDefinitionKeys(validationSettings.library),
-            ];
+            let knownIdentifiers: ReadonlyArray<string> | undefined = knownIdentifiersByScope.get(nodeScope);
+
+            if (knownIdentifiers === undefined) {
+                knownIdentifiers = [...nodeScope.scopeItemByKey.keys(), ...libraryKeys];
+                knownIdentifiersByScope.set(nodeScope, knownIdentifiers);
+            }
 
             const [jaroWinklerScore, suggestion]: [number, string] = calculateJaroWinklers(literal, knownIdentifiers);
 


### PR DESCRIPTION
Hoist library key computation out of the per-identifier loop and cache the combined known-identifier list per NodeScope instance. Avoids repeated array allocation and spreading when multiple unknown identifiers share the same scope.