### PR TITLE
Infer schemas for #table expressions

### DIFF
--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeHashTableInvokeExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeHashTableInvokeExpression.ts
@@ -2,37 +2,18 @@
 // Licensed under the MIT license.
 
 import * as PQP from "@microsoft/powerquery-parser";
-import { Ast, Keyword, TextUtils, Type, TypeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
-import {
-    NodeIdMapIterator,
-    NodeIdMapUtils,
-    TXorNode,
-    XorNode,
-    XorNodeUtils,
-} from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
+import { Ast, TextUtils, Type, TypeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { NodeIdMapIterator, TXorNode, XorNodeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
 import { InspectTypeState } from "./inspectTypeState";
 import { inspectXor } from "./common";
 import { TypeStrategy } from "../../../inspectionSettings";
 
-export async function tryInspectTypeHashTableInvokeExpression(
+export async function inspectTypeHashTableInvokeExpression(
     state: InspectTypeState,
     xorNode: TXorNode,
     correlationId: number | undefined,
-): Promise<Type.TPowerQueryType | undefined> {
-    const identifier: XorNode<Ast.IdentifierExpression> | undefined = NodeIdMapUtils.invokeExpressionIdentifier(
-        state.nodeIdMapCollection,
-        xorNode.node.id,
-    );
-
-    if (
-        identifier === undefined ||
-        XorNodeUtils.isContext(identifier) ||
-        identifier.node.identifier.literal !== Keyword.KeywordKind.HashTable
-    ) {
-        return undefined;
-    }
-
+): Promise<Type.TPowerQueryType> {
     if (state.typeStrategy === TypeStrategy.Primitive) {
         return Type.TableInstance;
     }

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeHashTableInvokeExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeHashTableInvokeExpression.ts
@@ -46,6 +46,7 @@ function definedTableFromColumnsType(columnsType: Type.TPowerQueryType): Type.Ta
             return Type.TableInstance;
         }
 
+        // Convert the quoted M text literal to its unescaped column name.
         const fieldName: string = TextUtils.unescape(element.literal.slice(1, -1));
 
         if (fields.has(fieldName)) {

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeHashTableInvokeExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeHashTableInvokeExpression.ts
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as PQP from "@microsoft/powerquery-parser";
+import { Ast, Keyword, TextUtils, Type, TypeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import {
+    NodeIdMapIterator,
+    NodeIdMapUtils,
+    TXorNode,
+    XorNode,
+    XorNodeUtils,
+} from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
+
+import { InspectTypeState } from "./inspectTypeState";
+import { inspectXor } from "./common";
+import { TypeStrategy } from "../../../inspectionSettings";
+
+export async function tryInspectTypeHashTableInvokeExpression(
+    state: InspectTypeState,
+    xorNode: TXorNode,
+    correlationId: number | undefined,
+): Promise<Type.TPowerQueryType | undefined> {
+    const identifier: XorNode<Ast.IdentifierExpression> | undefined = NodeIdMapUtils.invokeExpressionIdentifier(
+        state.nodeIdMapCollection,
+        xorNode.node.id,
+    );
+
+    if (
+        identifier === undefined ||
+        XorNodeUtils.isContext(identifier) ||
+        identifier.node.identifier.literal !== Keyword.KeywordKind.HashTable
+    ) {
+        return undefined;
+    }
+
+    if (state.typeStrategy === TypeStrategy.Primitive) {
+        return Type.TableInstance;
+    }
+
+    const [columns]: ReadonlyArray<TXorNode> = NodeIdMapIterator.iterInvokeExpression(
+        state.nodeIdMapCollection,
+        XorNodeUtils.assertAsNodeKind<Ast.InvokeExpression>(xorNode, Ast.NodeKind.InvokeExpression),
+    );
+
+    if (columns === undefined) {
+        return Type.TableInstance;
+    }
+
+    return definedTableFromColumnsType(await inspectXor(state, columns, correlationId));
+}
+
+function definedTableFromColumnsType(columnsType: Type.TPowerQueryType): Type.Table | Type.DefinedTable {
+    if (columnsType.extendedKind === Type.ExtendedTypeKind.TableType) {
+        return TypeUtils.definedTable(false, new PQP.OrderedMap(columnsType.fields), columnsType.isOpen);
+    }
+
+    if (columnsType.extendedKind !== Type.ExtendedTypeKind.DefinedList) {
+        return Type.TableInstance;
+    }
+
+    const fields: Map<string, Type.TPowerQueryType> = new Map();
+
+    for (const element of columnsType.elements) {
+        if (element.extendedKind !== Type.ExtendedTypeKind.TextLiteral) {
+            return Type.TableInstance;
+        }
+
+        const fieldName: string = TextUtils.unescape(element.literal.slice(1, -1));
+
+        if (fields.has(fieldName)) {
+            return Type.TableInstance;
+        }
+
+        fields.set(fieldName, Type.AnyInstance);
+    }
+
+    return TypeUtils.definedTable(false, new PQP.OrderedMap(fields), false);
+}

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIdentifierExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIdentifierExpression.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Ast, Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { Ast, Keyword, Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 import { Trace, TraceConstant } from "@microsoft/powerquery-parser/lib/powerquery-parser/common/trace";
 import { TXorNode, XorNodeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
@@ -35,7 +35,11 @@ export async function inspectTypeIdentifierExpression(
             trace.id,
         );
 
-        result = dereferencedType ?? Type.UnknownInstance;
+        result =
+            dereferencedType?.kind === Type.TypeKind.Unknown &&
+            xorNode.node.identifier.literal === Keyword.KeywordKind.HashTable
+                ? Type.FunctionInstance
+                : (dereferencedType ?? Type.UnknownInstance);
     }
 
     trace.exit({ [TraceConstant.Result]: TraceUtils.typeDetails(result) });

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIdentifierExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIdentifierExpression.ts
@@ -30,16 +30,18 @@ export async function inspectTypeIdentifierExpression(
     if (XorNodeUtils.isContext(xorNode)) {
         result = Type.UnknownInstance;
     } else {
-        const dereferencedType: Type.TPowerQueryType | undefined = await dereferencedIdentifierType(
+        let dereferencedType: Type.TPowerQueryType | undefined = await dereferencedIdentifierType(
             state,
             xorNode,
             trace.id,
         );
 
-        result =
-            dereferencedType?.kind === Type.TypeKind.Unknown
-                ? (intrinsicIdentifierType(xorNode.node.identifier.literal) ?? Type.UnknownInstance)
-                : (dereferencedType ?? Type.UnknownInstance);
+        // If the dereferenced type is unknown, we will attempt to see if the identifier is an intrinsic function.
+        if (dereferencedType?.kind === Type.TypeKind.Unknown) {
+            dereferencedType = intrinsicIdentifierType(xorNode.node.identifier.literal);
+        }
+
+        result = dereferencedType ?? Type.UnknownInstance;
     }
 
     trace.exit({ [TraceConstant.Result]: TraceUtils.typeDetails(result) });

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIdentifierExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIdentifierExpression.ts
@@ -1,13 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Ast, Keyword, Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { Ast, Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 import { Trace, TraceConstant } from "@microsoft/powerquery-parser/lib/powerquery-parser/common/trace";
 import { TXorNode, XorNodeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
 
 import { InspectionTraceConstant, TraceUtils } from "../../..";
 import { dereferencedIdentifierType } from "./common";
 import { InspectTypeState } from "./inspectTypeState";
+import { intrinsicIdentifierType } from "./inspectTypeIntrinsic";
 
 export async function inspectTypeIdentifierExpression(
     state: InspectTypeState,
@@ -36,9 +37,8 @@ export async function inspectTypeIdentifierExpression(
         );
 
         result =
-            dereferencedType?.kind === Type.TypeKind.Unknown &&
-            xorNode.node.identifier.literal === Keyword.KeywordKind.HashTable
-                ? Type.FunctionInstance
+            dereferencedType?.kind === Type.TypeKind.Unknown
+                ? (intrinsicIdentifierType(xorNode.node.identifier.literal) ?? Type.UnknownInstance)
                 : (dereferencedType ?? Type.UnknownInstance);
     }
 

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIntrinsic.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIntrinsic.ts
@@ -1,7 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Keyword, Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { Ast, Keyword, Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import {
+    NodeIdMapUtils,
+    TXorNode,
+    XorNode,
+    XorNodeUtils,
+} from "@microsoft/powerquery-parser/lib/powerquery-parser/parser";
+
+import { inspectTypeHashTableInvokeExpression } from "./inspectTypeHashTableInvokeExpression";
+import { InspectTypeState } from "./inspectTypeState";
 
 const FunctionIntrinsicIdentifiers: ReadonlySet<string> = new Set([
     Keyword.KeywordKind.HashBinary,
@@ -15,4 +24,27 @@ const FunctionIntrinsicIdentifiers: ReadonlySet<string> = new Set([
 
 export function intrinsicIdentifierType(identifierLiteral: string): Type.TPowerQueryType | undefined {
     return FunctionIntrinsicIdentifiers.has(identifierLiteral) ? Type.FunctionInstance : undefined;
+}
+
+export async function tryInspectTypeIntrinsicInvokeExpression(
+    state: InspectTypeState,
+    xorNode: TXorNode,
+    correlationId: number | undefined,
+): Promise<Type.TPowerQueryType | undefined> {
+    const identifier: XorNode<Ast.IdentifierExpression> | undefined = NodeIdMapUtils.invokeExpressionIdentifier(
+        state.nodeIdMapCollection,
+        xorNode.node.id,
+    );
+
+    if (identifier === undefined || XorNodeUtils.isContext(identifier)) {
+        return undefined;
+    }
+
+    switch (identifier.node.identifier.literal) {
+        case Keyword.KeywordKind.HashTable:
+            return await inspectTypeHashTableInvokeExpression(state, xorNode, correlationId);
+
+        default:
+            return undefined;
+    }
 }

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIntrinsic.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeIntrinsic.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { Keyword, Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+
+const FunctionIntrinsicIdentifiers: ReadonlySet<string> = new Set([
+    Keyword.KeywordKind.HashBinary,
+    Keyword.KeywordKind.HashDate,
+    Keyword.KeywordKind.HashDateTime,
+    Keyword.KeywordKind.HashDateTimeZone,
+    Keyword.KeywordKind.HashDuration,
+    Keyword.KeywordKind.HashTable,
+    Keyword.KeywordKind.HashTime,
+]);
+
+export function intrinsicIdentifierType(identifierLiteral: string): Type.TPowerQueryType | undefined {
+    return FunctionIntrinsicIdentifiers.has(identifierLiteral) ? Type.FunctionInstance : undefined;
+}

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeInvokeExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeInvokeExpression.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import * as PQP from "@microsoft/powerquery-parser";
-import { Assert, OrderedMap, ResultUtils } from "@microsoft/powerquery-parser";
+import { Assert, ResultUtils } from "@microsoft/powerquery-parser";
 import { Ast, Keyword, TextUtils, Type, TypeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 import {
     NodeIdMapIterator,
@@ -123,38 +123,31 @@ async function inspectIntrinsicInvokeExpression(
 }
 
 function definedTableFromColumnsType(columnsType: Type.TPowerQueryType): Type.Table | Type.DefinedTable {
-    // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
-    switch (columnsType.extendedKind) {
-        case Type.ExtendedTypeKind.TableType:
-            return TypeUtils.definedTable(
-                false,
-                new OrderedMap<string, Type.TPowerQueryType>(columnsType.fields),
-                columnsType.isOpen,
-            );
+    if (columnsType.extendedKind === Type.ExtendedTypeKind.TableType) {
+        return TypeUtils.definedTable(false, new PQP.OrderedMap(columnsType.fields), columnsType.isOpen);
+    }
 
-        case Type.ExtendedTypeKind.DefinedList: {
-            const fields: Map<string, Type.TPowerQueryType> = new Map();
+    if (columnsType.extendedKind !== Type.ExtendedTypeKind.DefinedList) {
+        return Type.TableInstance;
+    }
 
-            for (const element of columnsType.elements) {
-                if (element.extendedKind !== Type.ExtendedTypeKind.TextLiteral) {
-                    return Type.TableInstance;
-                }
+    const fields: Map<string, Type.TPowerQueryType> = new Map();
 
-                const fieldName: string = TextUtils.unescape(element.literal.slice(1, -1));
-
-                if (fields.has(fieldName)) {
-                    return Type.TableInstance;
-                }
-
-                fields.set(fieldName, Type.AnyInstance);
-            }
-
-            return TypeUtils.definedTable(false, new OrderedMap(fields), false);
+    for (const element of columnsType.elements) {
+        if (element.extendedKind !== Type.ExtendedTypeKind.TextLiteral) {
+            return Type.TableInstance;
         }
 
-        default:
+        const fieldName: string = TextUtils.unescape(element.literal.slice(1, -1));
+
+        if (fields.has(fieldName)) {
             return Type.TableInstance;
+        }
+
+        fields.set(fieldName, Type.AnyInstance);
     }
+
+    return TypeUtils.definedTable(false, new PQP.OrderedMap(fields), false);
 }
 
 async function externalInvokeRequest(

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeInvokeExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeInvokeExpression.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 
 import * as PQP from "@microsoft/powerquery-parser";
-import { Assert, ResultUtils } from "@microsoft/powerquery-parser";
-import { Ast, Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { Assert, OrderedMap, ResultUtils } from "@microsoft/powerquery-parser";
+import { Ast, Keyword, TextUtils, Type, TypeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 import {
     NodeIdMapIterator,
     NodeIdMapUtils,
@@ -19,6 +19,7 @@ import { InspectionTraceConstant, TraceUtils } from "../../..";
 import { InspectTypeState, InspectTypeStateUtils } from "./inspectTypeState";
 import { inspectXor } from "./common";
 import { tryBuildDereferencedIdentifierPath } from "../../dereferencedIdentifier/dereferencedIdentifierUtils";
+import { TypeStrategy } from "../../../inspectionSettings";
 
 export async function inspectTypeInvokeExpression(
     state: InspectTypeState,
@@ -34,6 +35,18 @@ export async function inspectTypeInvokeExpression(
 
     state.cancellationToken?.throwIfCancelled();
     XorNodeUtils.assertIsNodeKind<Ast.InvokeExpression>(xorNode, Ast.NodeKind.InvokeExpression);
+
+    const intrinsicType: Type.TPowerQueryType | undefined = await inspectIntrinsicInvokeExpression(
+        state,
+        xorNode,
+        trace.id,
+    );
+
+    if (intrinsicType !== undefined) {
+        trace.exit({ [TraceConstant.Result]: TraceUtils.typeDetails(intrinsicType) });
+
+        return intrinsicType;
+    }
 
     const request: ExternalType.ExternalInvocationTypeRequest | undefined = await externalInvokeRequest(
         state,
@@ -73,6 +86,75 @@ export async function inspectTypeInvokeExpression(
     trace.exit({ [TraceConstant.Result]: TraceUtils.typeDetails(result) });
 
     return result;
+}
+
+async function inspectIntrinsicInvokeExpression(
+    state: InspectTypeState,
+    xorNode: TXorNode,
+    correlationId: number | undefined,
+): Promise<Type.TPowerQueryType | undefined> {
+    const identifier: XorNode<Ast.IdentifierExpression> | undefined = NodeIdMapUtils.invokeExpressionIdentifier(
+        state.nodeIdMapCollection,
+        xorNode.node.id,
+    );
+
+    if (
+        identifier === undefined ||
+        XorNodeUtils.isContext(identifier) ||
+        identifier.node.identifier.literal !== Keyword.KeywordKind.HashTable
+    ) {
+        return undefined;
+    }
+
+    if (state.typeStrategy === TypeStrategy.Primitive) {
+        return Type.TableInstance;
+    }
+
+    const [columns]: ReadonlyArray<TXorNode> = NodeIdMapIterator.iterInvokeExpression(
+        state.nodeIdMapCollection,
+        XorNodeUtils.assertAsNodeKind<Ast.InvokeExpression>(xorNode, Ast.NodeKind.InvokeExpression),
+    );
+
+    if (columns === undefined) {
+        return Type.TableInstance;
+    }
+
+    return definedTableFromColumnsType(await inspectXor(state, columns, correlationId));
+}
+
+function definedTableFromColumnsType(columnsType: Type.TPowerQueryType): Type.Table | Type.DefinedTable {
+    // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
+    switch (columnsType.extendedKind) {
+        case Type.ExtendedTypeKind.TableType:
+            return TypeUtils.definedTable(
+                false,
+                new OrderedMap<string, Type.TPowerQueryType>(columnsType.fields),
+                columnsType.isOpen,
+            );
+
+        case Type.ExtendedTypeKind.DefinedList: {
+            const fields: Map<string, Type.TPowerQueryType> = new Map();
+
+            for (const element of columnsType.elements) {
+                if (element.extendedKind !== Type.ExtendedTypeKind.TextLiteral) {
+                    return Type.TableInstance;
+                }
+
+                const fieldName: string = TextUtils.unescape(element.literal.slice(1, -1));
+
+                if (fields.has(fieldName)) {
+                    return Type.TableInstance;
+                }
+
+                fields.set(fieldName, Type.AnyInstance);
+            }
+
+            return TypeUtils.definedTable(false, new OrderedMap(fields), false);
+        }
+
+        default:
+            return Type.TableInstance;
+    }
 }
 
 async function externalInvokeRequest(

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeInvokeExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeInvokeExpression.ts
@@ -19,7 +19,7 @@ import { InspectionTraceConstant, TraceUtils } from "../../..";
 import { InspectTypeState, InspectTypeStateUtils } from "./inspectTypeState";
 import { inspectXor } from "./common";
 import { tryBuildDereferencedIdentifierPath } from "../../dereferencedIdentifier/dereferencedIdentifierUtils";
-import { tryInspectTypeHashTableInvokeExpression } from "./inspectTypeHashTableInvokeExpression";
+import { tryInspectTypeIntrinsicInvokeExpression } from "./inspectTypeIntrinsic";
 
 export async function inspectTypeInvokeExpression(
     state: InspectTypeState,
@@ -36,16 +36,16 @@ export async function inspectTypeInvokeExpression(
     state.cancellationToken?.throwIfCancelled();
     XorNodeUtils.assertIsNodeKind<Ast.InvokeExpression>(xorNode, Ast.NodeKind.InvokeExpression);
 
-    const hashTableType: Type.TPowerQueryType | undefined = await tryInspectTypeHashTableInvokeExpression(
+    const intrinsicType: Type.TPowerQueryType | undefined = await tryInspectTypeIntrinsicInvokeExpression(
         state,
         xorNode,
         trace.id,
     );
 
-    if (hashTableType !== undefined) {
-        trace.exit({ [TraceConstant.Result]: TraceUtils.typeDetails(hashTableType) });
+    if (intrinsicType !== undefined) {
+        trace.exit({ [TraceConstant.Result]: TraceUtils.typeDetails(intrinsicType) });
 
-        return hashTableType;
+        return intrinsicType;
     }
 
     const request: ExternalType.ExternalInvocationTypeRequest | undefined = await externalInvokeRequest(

--- a/src/powerquery-language-services/inspection/type/inspectType/inspectTypeInvokeExpression.ts
+++ b/src/powerquery-language-services/inspection/type/inspectType/inspectTypeInvokeExpression.ts
@@ -3,7 +3,7 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 import { Assert, ResultUtils } from "@microsoft/powerquery-parser";
-import { Ast, Keyword, TextUtils, Type, TypeUtils } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
+import { Ast, Type } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 import {
     NodeIdMapIterator,
     NodeIdMapUtils,
@@ -19,7 +19,7 @@ import { InspectionTraceConstant, TraceUtils } from "../../..";
 import { InspectTypeState, InspectTypeStateUtils } from "./inspectTypeState";
 import { inspectXor } from "./common";
 import { tryBuildDereferencedIdentifierPath } from "../../dereferencedIdentifier/dereferencedIdentifierUtils";
-import { TypeStrategy } from "../../../inspectionSettings";
+import { tryInspectTypeHashTableInvokeExpression } from "./inspectTypeHashTableInvokeExpression";
 
 export async function inspectTypeInvokeExpression(
     state: InspectTypeState,
@@ -36,16 +36,16 @@ export async function inspectTypeInvokeExpression(
     state.cancellationToken?.throwIfCancelled();
     XorNodeUtils.assertIsNodeKind<Ast.InvokeExpression>(xorNode, Ast.NodeKind.InvokeExpression);
 
-    const intrinsicType: Type.TPowerQueryType | undefined = await inspectIntrinsicInvokeExpression(
+    const hashTableType: Type.TPowerQueryType | undefined = await tryInspectTypeHashTableInvokeExpression(
         state,
         xorNode,
         trace.id,
     );
 
-    if (intrinsicType !== undefined) {
-        trace.exit({ [TraceConstant.Result]: TraceUtils.typeDetails(intrinsicType) });
+    if (hashTableType !== undefined) {
+        trace.exit({ [TraceConstant.Result]: TraceUtils.typeDetails(hashTableType) });
 
-        return intrinsicType;
+        return hashTableType;
     }
 
     const request: ExternalType.ExternalInvocationTypeRequest | undefined = await externalInvokeRequest(
@@ -86,68 +86,6 @@ export async function inspectTypeInvokeExpression(
     trace.exit({ [TraceConstant.Result]: TraceUtils.typeDetails(result) });
 
     return result;
-}
-
-async function inspectIntrinsicInvokeExpression(
-    state: InspectTypeState,
-    xorNode: TXorNode,
-    correlationId: number | undefined,
-): Promise<Type.TPowerQueryType | undefined> {
-    const identifier: XorNode<Ast.IdentifierExpression> | undefined = NodeIdMapUtils.invokeExpressionIdentifier(
-        state.nodeIdMapCollection,
-        xorNode.node.id,
-    );
-
-    if (
-        identifier === undefined ||
-        XorNodeUtils.isContext(identifier) ||
-        identifier.node.identifier.literal !== Keyword.KeywordKind.HashTable
-    ) {
-        return undefined;
-    }
-
-    if (state.typeStrategy === TypeStrategy.Primitive) {
-        return Type.TableInstance;
-    }
-
-    const [columns]: ReadonlyArray<TXorNode> = NodeIdMapIterator.iterInvokeExpression(
-        state.nodeIdMapCollection,
-        XorNodeUtils.assertAsNodeKind<Ast.InvokeExpression>(xorNode, Ast.NodeKind.InvokeExpression),
-    );
-
-    if (columns === undefined) {
-        return Type.TableInstance;
-    }
-
-    return definedTableFromColumnsType(await inspectXor(state, columns, correlationId));
-}
-
-function definedTableFromColumnsType(columnsType: Type.TPowerQueryType): Type.Table | Type.DefinedTable {
-    if (columnsType.extendedKind === Type.ExtendedTypeKind.TableType) {
-        return TypeUtils.definedTable(false, new PQP.OrderedMap(columnsType.fields), columnsType.isOpen);
-    }
-
-    if (columnsType.extendedKind !== Type.ExtendedTypeKind.DefinedList) {
-        return Type.TableInstance;
-    }
-
-    const fields: Map<string, Type.TPowerQueryType> = new Map();
-
-    for (const element of columnsType.elements) {
-        if (element.extendedKind !== Type.ExtendedTypeKind.TextLiteral) {
-            return Type.TableInstance;
-        }
-
-        const fieldName: string = TextUtils.unescape(element.literal.slice(1, -1));
-
-        if (fields.has(fieldName)) {
-            return Type.TableInstance;
-        }
-
-        fields.set(fieldName, Type.AnyInstance);
-    }
-
-    return TypeUtils.definedTable(false, new PQP.OrderedMap(fields), false);
 }
 
 async function externalInvokeRequest(

--- a/src/test/inspection/autocomplete/autocompleteFieldAccess.test.ts
+++ b/src/test/inspection/autocomplete/autocompleteFieldAccess.test.ts
@@ -350,6 +350,15 @@ describe(`Inspection - Autocomplete - FieldAccess`, () => {
                     },
                 }));
 
+            it(`let Source = #table({"Name", "Score"}, {}) in Source[|`, async () =>
+                await expectFieldAccessSuggestions({
+                    textWithPipe: `let Source = #table({"Name", "Score"}, {}) in Source[|`,
+                    expected: {
+                        labels: [`Name`, `Score`],
+                        isTextEdit: false,
+                    },
+                }));
+
             it(`[car = 1, cat = 2][ |`, async () =>
                 await expectFieldAccessSuggestions({
                     textWithPipe: `[car = 1, cat = 2][ |`,

--- a/src/test/inspection/type.test.ts
+++ b/src/test/inspection/type.test.ts
@@ -231,6 +231,26 @@ describe(`Inspection - Type`, () => {
                 }));
         });
 
+        describe(`intrinsic identifiers`, () => {
+            const functionIntrinsics: ReadonlyArray<string> = [
+                `#binary`,
+                `#date`,
+                `#datetime`,
+                `#datetimezone`,
+                `#duration`,
+                `#table`,
+                `#time`,
+            ];
+
+            for (const intrinsic of functionIntrinsics) {
+                it(`${intrinsic} is a function`, async () =>
+                    await assertEqualRootType({
+                        text: intrinsic,
+                        expected: Type.FunctionInstance,
+                    }));
+            }
+        });
+
         describe(`#table`, () => {
             function definedTable(fields: ReadonlyArray<[string, Type.TPowerQueryType]>): Type.DefinedTable {
                 return TypeUtils.definedTable(false, new PQP.OrderedMap(fields), false);

--- a/src/test/inspection/type.test.ts
+++ b/src/test/inspection/type.test.ts
@@ -231,6 +231,63 @@ describe(`Inspection - Type`, () => {
                 }));
         });
 
+        describe(`#table`, () => {
+            it(`recognizes the intrinsic without library metadata`, async () =>
+                await assertEqualRootType({
+                    text: `#table`,
+                    expected: Type.FunctionInstance,
+                }));
+
+            it(`infers columns from a literal list`, async () =>
+                await assertEqualRootType({
+                    text: `let Source = #table({"Name", "Score"}, {}) in Source`,
+                    expected: TypeUtils.definedTable(
+                        false,
+                        new PQP.OrderedMap<string, Type.TPowerQueryType>([
+                            [`Name`, Type.AnyInstance],
+                            [`Score`, Type.AnyInstance],
+                        ]),
+                        false,
+                    ),
+                }));
+
+            it(`preserves an explicit table type`, async () =>
+                await assertEqualRootType({
+                    text: `#table(type table [Name = text, Score = number], {})`,
+                    expected: TypeUtils.definedTable(
+                        false,
+                        new PQP.OrderedMap<string, Type.TPowerQueryType>([
+                            [`Name`, Type.TextInstance],
+                            [`Score`, Type.NumberInstance],
+                        ]),
+                        false,
+                    ),
+                }));
+
+            it(`unescapes literal column names`, async () =>
+                await assertEqualRootType({
+                    text: `#table({"Display ""Name"""}, {})`,
+                    expected: TypeUtils.definedTable(
+                        false,
+                        new PQP.OrderedMap<string, Type.TPowerQueryType>([[`Display "Name"`, Type.AnyInstance]]),
+                        false,
+                    ),
+                }));
+
+            it(`falls back to table for an unknown schema`, async () =>
+                await assertEqualRootType({
+                    text: `let columns = {} as list in #table(columns, {})`,
+                    expected: Type.TableInstance,
+                }));
+
+            it(`uses the primitive table type with the primitive strategy`, async () =>
+                await assertEqualRootType({
+                    text: `#table({"Name"}, {})`,
+                    expected: Type.TableInstance,
+                    settings: PrimitiveInspectionSettings,
+                }));
+        });
+
         describe(`${Ast.NodeKind.ErrorHandlingExpression}`, () => {
             it(`try 1`, async () =>
                 await assertEqualRootType({

--- a/src/test/inspection/type.test.ts
+++ b/src/test/inspection/type.test.ts
@@ -232,46 +232,32 @@ describe(`Inspection - Type`, () => {
         });
 
         describe(`#table`, () => {
-            it(`recognizes the intrinsic without library metadata`, async () =>
-                await assertEqualRootType({
-                    text: `#table`,
-                    expected: Type.FunctionInstance,
-                }));
+            function definedTable(fields: ReadonlyArray<[string, Type.TPowerQueryType]>): Type.DefinedTable {
+                return TypeUtils.definedTable(false, new PQP.OrderedMap(fields), false);
+            }
 
             it(`infers columns from a literal list`, async () =>
                 await assertEqualRootType({
                     text: `let Source = #table({"Name", "Score"}, {}) in Source`,
-                    expected: TypeUtils.definedTable(
-                        false,
-                        new PQP.OrderedMap<string, Type.TPowerQueryType>([
-                            [`Name`, Type.AnyInstance],
-                            [`Score`, Type.AnyInstance],
-                        ]),
-                        false,
-                    ),
+                    expected: definedTable([
+                        [`Name`, Type.AnyInstance],
+                        [`Score`, Type.AnyInstance],
+                    ]),
                 }));
 
             it(`preserves an explicit table type`, async () =>
                 await assertEqualRootType({
                     text: `#table(type table [Name = text, Score = number], {})`,
-                    expected: TypeUtils.definedTable(
-                        false,
-                        new PQP.OrderedMap<string, Type.TPowerQueryType>([
-                            [`Name`, Type.TextInstance],
-                            [`Score`, Type.NumberInstance],
-                        ]),
-                        false,
-                    ),
+                    expected: definedTable([
+                        [`Name`, Type.TextInstance],
+                        [`Score`, Type.NumberInstance],
+                    ]),
                 }));
 
             it(`unescapes literal column names`, async () =>
                 await assertEqualRootType({
                     text: `#table({"Display ""Name"""}, {})`,
-                    expected: TypeUtils.definedTable(
-                        false,
-                        new PQP.OrderedMap<string, Type.TPowerQueryType>([[`Display "Name"`, Type.AnyInstance]]),
-                        false,
-                    ),
+                    expected: definedTable([[`Display "Name"`, Type.AnyInstance]]),
                 }));
 
             it(`falls back to table for an unknown schema`, async () =>

--- a/src/test/inspection/type.test.ts
+++ b/src/test/inspection/type.test.ts
@@ -280,6 +280,30 @@ describe(`Inspection - Type`, () => {
                     expected: definedTable([[`Display "Name"`, Type.AnyInstance]]),
                 }));
 
+            it(`infers a column name from a quoted identifier`, async () =>
+                await assertEqualRootType({
+                    text: `let key = "foobar", tbl = #table({#"key"}, {}) in tbl`,
+                    expected: definedTable([[`foobar`, Type.AnyInstance]]),
+                }));
+
+            it(`infers a column name from an identifier that requires quotes`, async () =>
+                await assertEqualRootType({
+                    text: `let #"column name" = "foobar", tbl = #table({#"column name"}, {}) in tbl`,
+                    expected: definedTable([[`foobar`, Type.AnyInstance]]),
+                }));
+
+            it(`falls back to table for duplicate column names`, async () =>
+                await assertEqualRootType({
+                    text: `#table({"Name", "Name"}, {})`,
+                    expected: Type.TableInstance,
+                }));
+
+            it(`falls back to table for a non-text column name`, async () =>
+                await assertEqualRootType({
+                    text: `#table({"Name", 1}, {})`,
+                    expected: Type.TableInstance,
+                }));
+
             it(`falls back to table for an unknown schema`, async () =>
                 await assertEqualRootType({
                     text: `let columns = {} as list in #table(columns, {})`,


### PR DESCRIPTION
## Summary
- recognize `#table` intrinsically without requiring library metadata
- infer a `DefinedTable` schema from literal column-name lists
- preserve explicit `type table [...]` schemas
- enable field autocomplete from the inferred schema

## Stack
1. This PR: column/schema introspection
2. #286: exact row introspection

The row follow-up also depends on microsoft/powerquery-parser#411.

## Validation
- `npm run build`
- `npm run lint`
- `npm test -- --grep "#table"` (7 passing)
- full suite (737 passing)